### PR TITLE
Add the link path for the externals-clasp libraries to the built Clasp executables.

### DIFF
--- a/src/main/Jamfile.jam
+++ b/src/main/Jamfile.jam
@@ -140,5 +140,8 @@ install bundle : clasp
 #			<dll-path>$(APPLIB)
 		   	# <variant>debug:<dll-path>$(APPRES-EXTERNALS-DEBUG-LIB) #Uncomment to get the debug version of llvm
 #                         <dll-path>$(APPRES-EXTERNALS-RELEASE-LIB)
+# Add the link path for the externals-clasp libraries to the executable(s)
+                        <dll-path>$(APPRES-EXTERNALS-RELEASE-LIB)
+                        <dll-path>$(APPRES-EXTERNALS-COMMON-LIB)
                         ;
 


### PR DESCRIPTION
Only tested on Ubuntu 14.04 / Linux

But without adding the link path:
mband@<host>:~$ ldd ~/local/clasp/bin/clasp_boehm_o 
    linux-vdso.so.1 =>  (0x00007fff29ffe000)
    libgmpxx.so.4 => not found
    libgmp.so.10 => /usr/lib/x86_64-linux-gnu/libgmp.so.10 (0x00007feca52ca000)
    libncurses.so.5 => /lib/x86_64-linux-gnu/libncurses.so.5 (0x00007feca50a6000)
    libtinfo.so.5 => /lib/x86_64-linux-gnu/libtinfo.so.5 (0x00007feca4e7d000)
    libreadline.so.6 => /lib/x86_64-linux-gnu/libreadline.so.6 (0x00007feca4c37000)
    libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007feca4a1d000)
    libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1 (0x00007feca47f3000)
    librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007feca45eb000)
    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007feca43cc000)
    libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007feca41c8000)
    libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007feca3ec4000)
    libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007feca3bbd000)
    libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007feca39a7000)
    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007feca35e1000)
    /lib64/ld-linux-x86-64.so.2 (0x00007feca556f000)

And with this patch:
mband@<host>:~$ ldd ~/local/clasp/bin/clasp_boehm_o 
    linux-vdso.so.1 =>  (0x00007fff1b1e9000)
    libgmpxx.so.4 => /home/mband/local/externals-clasp/common/lib/libgmpxx.so.4 (0x00007fcdabede000)
    libgmp.so.10 => /home/mband/local/externals-clasp/common/lib/libgmp.so.10 (0x00007fcdabc67000)
    libncurses.so.5 => /lib/x86_64-linux-gnu/libncurses.so.5 (0x00007fcdaba15000)
    libtinfo.so.5 => /lib/x86_64-linux-gnu/libtinfo.so.5 (0x00007fcdab7ec000)
    libreadline.so.6 => /home/mband/local/externals-clasp/common/lib/libreadline.so.6 (0x00007fcdab5a8000)
    libz.so.1 => /home/mband/local/externals-clasp/common/lib/libz.so.1 (0x00007fcdab38e000)
    libexpat.so.1 => /home/mband/local/externals-clasp/common/lib/libexpat.so.1 (0x00007fcdab164000)
    librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007fcdaaf5b000)
    libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007fcdaad3d000)
    libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007fcdaab39000)
    libstdc++.so.6 => /usr/lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007fcdaa834000)
    libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007fcdaa52e000)
    libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007fcdaa318000)
    libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007fcda9f51000)
    /lib64/ld-linux-x86-64.so.2 (0x00007fcdac0e6000)
