### PR TITLE
Added minimal extensions directory structure with wscript adaptions.

### DIFF
--- a/extensions/include/extensions.h
+++ b/extensions/include/extensions.h
@@ -1,0 +1,42 @@
+/*
+    File: extensions.h
+*/
+
+/*
+Copyright (c) 2018, Christian E. Schafmeister
+
+CLASP is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+See directory 'clasp/licenses' for full details.
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+*/
+/* -^- */
+
+
+#ifndef CLASP_EXTENSIONS_H //[
+#define CLASP_EXTENSIONS_H
+
+/* THIS FILE IS EMPTY ON PURPOSE AS LONG AS NO EXTENSIONS ARE IMPLELEMTED */
+/* ANY EXTENSION MUST PLACE A TOPLEVEL INCLUDE FILE HERE FOR GC INCLUSION */
+/* THE SEARCH PATH PREPRENDED TO THE INCLUDE PATH IS "extensions/include" */
+/* e.g.:                                                                  */
+/* #include <dummy/dummy.h>                                               */
+/* THE CORRESPONDING FILE IS TO BE FOUND AT:                              */
+/* clasp/extensions/include/dummy.h                                       */
+/* IT IS EXPECTED THAT THIS FILE ONLY CONTAINS INCLUDE DIRECTIVES TO      */
+/* INCLUDE THE ACTUAL, EXTENSION-SPECIFIC INCLUDE FILES.                  */
+
+#endif //]

--- a/extensions/include/wscript
+++ b/extensions/include/wscript
@@ -1,0 +1,22 @@
+import os
+
+def subdirectories():
+    dir = os.listdir("./extensions/include")
+    subdirs = []
+    for x in dir:
+        if os.path.isdir("./extensions/include/%s"%x):
+            subdirs.append(x)
+    return subdirs
+
+def build_extension(ctx):
+    ctx.recurse(" ".join(subdirectories()))
+
+def grovel(ctx):
+    ctx.recurse(" ".join(subdirectories()))
+
+def configure(ctx):
+    ctx.recurse(" ".join(subdirectories()))
+
+def build(ctx):
+    ctx.recurse(" ".join(subdirectories()))
+

--- a/include/clasp/extensions
+++ b/include/clasp/extensions
@@ -1,0 +1,1 @@
+../../extensions/include

--- a/src/gctools/gc_interface.cc
+++ b/src/gctools/gc_interface.cc
@@ -165,9 +165,12 @@ typedef bool _Bool;
 
 #ifdef BUILD_EXTENSION
 #define GC_INTERFACE_INCLUDES
-#include <project_headers.h>
+// #include <project_headers.h>  // frgo, 2018-04-01: Where is project_headers supposed to be found? What if multiple extensions have to be built in one build?
+// Other way of doing this: Include file extensions.h - see there for more info 
+#include <clasp/extensions/extensions.h>
 #undef GC_INTERFACE_INCLUDES
 #endif
+
 
 #define NAMESPACE_gctools
 #define NAMESPACE_core


### PR DESCRIPTION
Issue:
When adding multiple extensions then questions is how to include all those in the build process. Also, there was an include directive in src/gctools/gc_interface.cc saying "#include <project_headers.h>" - which only worked for cando and not for multiple extensions.
Solution Idea:
Have a well-defined directory structure below clasp/extensions where:
1. Each extension has its own sub-directory, e.g. "dummy"
2. Have an include directory directly below clasp/extensions with one include file: extensions.h
3. In this include file all extensions' toplevel include file are inserted manually when adding an extension, e.g. "#include <dummy/dummy.h>" for extension dummy.
4. Each extension directory has at least sub-directories "src" and "include". The wscript file in the extensions root directory has to recurse down into these directories.
5. Also, the wscript file in the extension's root directory has to load a wscript.config file in which a config flag "CLASP_EXT_ENABLE_DUMMY = 1" enables the build of that extension. This variable has to be checked in the extensions' root directory wscript file, and, if set to 0, will effect to not configure/build the extension.
All this assumes we distribute the wscript files in the extensions' dirs. @attila-lendvai Do you have another idea for this? @drmeister I'd need to have your thoughts on this as I am heading into several extensions at once ... 
Thank you all for providing feedback!
