### PR TITLE
clos: don't allow subclassing builtin classes

### DIFF
--- a/src/lisp/kernel/clos/standard.lsp
+++ b/src/lisp/kernel/clos/standard.lsp
@@ -297,9 +297,9 @@ argument was supplied for metaclass ~S." (class-of class))))))))
 	    (c2 (class-of superclass)))
 	(or (eq c1 c2)
 	    (and (eq c1 +the-standard-class+) (eq c2 +the-funcallable-standard-class+))
-	    (and (eq c2 +the-standard-class+) (eq c1 +the-funcallable-standard-class+))
-	    ))
-      (forward-referenced-class-p superclass)))
+	    (and (eq c2 +the-standard-class+) (eq c1 +the-funcallable-standard-class+))))
+      (or (forward-referenced-class-p class)
+          (forward-referenced-class-p superclass))))
 
 ;;; ----------------------------------------------------------------------
 ;;; FINALIZATION OF CLASS INHERITANCE

--- a/src/lisp/kernel/clos/streams.lsp
+++ b/src/lisp/kernel/clos/streams.lsp
@@ -234,9 +234,10 @@
 ;;; generic functions.
 ;;;
 
-(defclass fundamental-stream (standard-object stream)
-  ((open-p :initform t :accessor open-stream-p))
-  (:documentation "the base class for all CLOS streams"))
+(let ((clos::*clos-booted* 'clos:map-dependents))
+  (defclass fundamental-stream (standard-object stream)
+    ((open-p :initform t :accessor open-stream-p))
+    (:documentation "the base class for all CLOS streams")))
 
 (defclass fundamental-input-stream (fundamental-stream) nil)
 
@@ -711,5 +712,4 @@
     (si::package-lock "COMMON-LISP" x)
     nil))
 
-(setf *clos-booted* t)
-
+(setf clos::*clos-booted* t)


### PR DESCRIPTION
This issue was discussed at some point in the past. See
https://gitlab.com/embeddable-common-lisp/ecl/issues/426 for some logs.