### PR TITLE
Programmatically enable HANDLE_FORK in boehm_gc at runtime

### DIFF
--- a/src/gctools/boehmGarbageCollection.cc
+++ b/src/gctools/boehmGarbageCollection.cc
@@ -230,6 +230,7 @@ void* boehm_create_shadow_table(size_t nargs)
 namespace gctools {
 __attribute__((noinline))
 int initializeBoehm(MainFunctionType startupFn, int argc, char *argv[], bool mpiEnabled, int mpiRank, int mpiSize) {
+  GC_set_handle_fork(1);
   GC_INIT();
   GC_allow_register_threads();
   GC_set_java_finalization(1);


### PR DESCRIPTION
This should remove the requirement of having to rebuild the Boehm garbage collector with HANDLE_FORK.

Most builds of the garbage collector have HANDLE_FORK support compiled in, just disabled at runtime. This behavior will change in version 7.7.0 of the garbage collector, but we can programmatically enable it by calling GC_set_handle_fork() before GC_INIT().
If a version of the garbage collector does not have it compiled in, and the platform supports threading, the garbage collector will simply abort (see the logic at https://github.com/ivmai/bdwgc/blob/cb1194d/misc.c#L214).