### PR TITLE
MPS fork support

### DIFF
--- a/wscript
+++ b/wscript
@@ -533,6 +533,7 @@ def configure(cfg):
     load_local_config(cfg)
     cfg.load("why")
     cfg.check_waf_version(mini = '1.7.5')
+    cfg.env["DEST_OS"] = cfg.env["DEST_OS"] or Utils.unversioned_sys_platform()
     update_exe_search_path(cfg)
     run_llvm_config(cfg, "--version") # make sure we fail early
     check_externals_clasp_version(cfg)

--- a/wscript
+++ b/wscript
@@ -191,7 +191,7 @@ def update_dependencies(cfg):
                        "5e0add45b7c6140e4ab07a2cbfd28964e36e6e48")
     fetch_git_revision("src/mps",
                        "https://github.com/Ravenbrook/mps.git",
-                       label = "master", revision = "release-1.115.0")
+                       label = "branch/2018-06-13/fork", revision = "9fecfb27798c57acabb9eff6f3e86dcd50d5bc5e")
     fetch_git_revision("src/lisp/modules/asdf",
                        "https://gitlab.common-lisp.net/asdf/asdf.git",
                        label = "master", revision = "3.3.1.2")

--- a/wscript
+++ b/wscript
@@ -191,7 +191,7 @@ def update_dependencies(cfg):
                        "5e0add45b7c6140e4ab07a2cbfd28964e36e6e48")
     fetch_git_revision("src/mps",
                        "https://github.com/Ravenbrook/mps.git",
-                       label = "branch/2018-06-13/fork", revision = "9fecfb27798c57acabb9eff6f3e86dcd50d5bc5e")
+                       label = "master", revision = "46e0a8d77ac470282de7300f5eaf471ca2fbee05")
     fetch_git_revision("src/lisp/modules/asdf",
                        "https://gitlab.common-lisp.net/asdf/asdf.git",
                        label = "master", revision = "3.3.1.2")


### PR DESCRIPTION
We now support fork() in MPS and parallel builds are working in clasp.

Please read:

https://www.ravenbrook.com/project/mps/master/manual/html/topic/thread.html#fork-safety

for information and caveats to check if there might be further work to do clasp side for safety and robustness.

