### PR TITLE
Feature print float infinity

### DIFF
--- a/src/core/float_to_string.cc
+++ b/src/core/float_to_string.cc
@@ -56,8 +56,11 @@ insert_char(StrNs_sp buffer, cl_index where, gc::Fixnum c) {
 
 static T_sp
 push_base_string(T_sp buffer, StrNs_sp s) {
-    ASSERT(s->arrayHasFillPointerP());
-    buffer = _clasp_ensure_buffer(buffer, s->fillPointer());
+    //There is no reason why s should have a mandatory fill-pointer
+    if (s->arrayHasFillPointerP())
+       buffer = _clasp_ensure_buffer(buffer, s->fillPointer());
+    else
+       buffer = _clasp_ensure_buffer(buffer, s->length());
     StrNs_sp sbuffer = gc::As<StrNs_sp>(buffer);
     for ( size_t i(0),iEnd(s->length()); i<iEnd; ++i ) {
 	sbuffer->vectorPush(s->rowMajorAref(i));

--- a/src/lisp/kernel/clos/print.lsp
+++ b/src/lisp/kernel/clos/print.lsp
@@ -227,21 +227,21 @@ printer and we should rather use MAKE-LOAD-FORM."
   (when (and *print-readably* (null *read-eval*))
     (error 'print-not-readable :object x))
   (let* ((negative-infinities '((single-float .
-                                 "#.ext::single-float-negative-infinity")
+                                 "#.core::single-float-negative-infinity")
                                 (double-float .
-                                 "#.ext::double-float-negative-infinity")
+                                 "#.core::double-float-negative-infinity")
                                 (long-float .
-                                 "#.ext::long-float-negative-infinity")
+                                 "#.core::long-float-negative-infinity")
                                 (short-float .
-                                 "#.ext::short-float-negative-infinity")))
+                                 "#.core::short-float-negative-infinity")))
          (positive-infinities '((single-float .
-                                 "#.ext::single-float-positive-infinity")
+                                 "#.core::single-float-positive-infinity")
                                 (double-float .
-                                 "#.ext::double-float-positive-infinity")
+                                 "#.core::double-float-positive-infinity")
                                 (long-float .
-                                 "#.ext::long-float-positive-infinity")
+                                 "#.core::long-float-positive-infinity")
                                 (short-float .
-                                 "#.ext::short-float-positive-infinity")))
+                                 "#.core::short-float-positive-infinity")))
          (record (assoc (type-of x)
                         (if (plusp x) positive-infinities negative-infinities))))
     (unless record

--- a/src/lisp/kernel/clos/print.lsp
+++ b/src/lisp/kernel/clos/print.lsp
@@ -227,21 +227,21 @@ printer and we should rather use MAKE-LOAD-FORM."
   (when (and *print-readably* (null *read-eval*))
     (error 'print-not-readable :object x))
   (let* ((negative-infinities '((single-float .
-                                 "#.core::single-float-negative-infinity")
+                                 "#.ext::single-float-negative-infinity")
                                 (double-float .
-                                 "#.core::double-float-negative-infinity")
+                                 "#.ext::double-float-negative-infinity")
                                 (long-float .
-                                 "#.core::long-float-negative-infinity")
+                                 "#.ext::long-float-negative-infinity")
                                 (short-float .
-                                 "#.core::short-float-negative-infinity")))
+                                 "#.ext::short-float-negative-infinity")))
          (positive-infinities '((single-float .
-                                 "#.core::single-float-positive-infinity")
+                                 "#.ext::single-float-positive-infinity")
                                 (double-float .
-                                 "#.core::double-float-positive-infinity")
+                                 "#.ext::double-float-positive-infinity")
                                 (long-float .
-                                 "#.core::long-float-positive-infinity")
+                                 "#.ext::long-float-positive-infinity")
                                 (short-float .
-                                 "#.core::short-float-positive-infinity")))
+                                 "#.ext::short-float-positive-infinity")))
          (record (assoc (type-of x)
                         (if (plusp x) positive-infinities negative-infinities))))
     (unless record

--- a/src/lisp/kernel/lsp/numlib.lsp
+++ b/src/lisp/kernel/lsp/numlib.lsp
@@ -66,24 +66,22 @@
 	(not (= (float 1 E) (- (float 1 E) E)))")
     ))
 
-#+ieee-floating-point
+;;; This needs to be loaded, used in ext::float-infinity-string 
 (locally (declare (notinline -))
-  (let ((bits (si::trap-fpe 'last nil)))
-    (unwind-protect
-         (progn
-           (let ((a (/ (coerce 1 'short-float) (coerce 0.0 'short-float))))
-             (defconstant short-float-positive-infinity a)
-             (defconstant short-float-negative-infinity (- a)))
-           (let ((a (/ (coerce 1 'single-float) (coerce 0.0 'single-float))))
-             (defconstant single-float-positive-infinity a)
-             (defconstant single-float-negative-infinity (- a)))
-           (let ((a (/ (coerce 1 'double-float) (coerce 0.0 'double-float))))
-             (defconstant double-float-positive-infinity a)
-             (defconstant double-float-negative-infinity (- a)))
-           (let ((a (/ (coerce 1 'long-float) (coerce 0.0 'long-float))))
-             (defconstant long-float-positive-infinity a)
-             (defconstant long-float-negative-infinity (- a))))
-      (si::trap-fpe bits t))))
+  (unwind-protect
+       (progn
+         (let ((a (/ (coerce 1 'short-float) (coerce 0.0 'short-float))))
+           (defconstant short-float-positive-infinity a)
+           (defconstant short-float-negative-infinity (- a)))
+         (let ((a (/ (coerce 1 'single-float) (coerce 0.0 'single-float))))
+           (defconstant single-float-positive-infinity a)
+           (defconstant single-float-negative-infinity (- a)))
+         (let ((a (/ (coerce 1 'double-float) (coerce 0.0 'double-float))))
+           (defconstant double-float-positive-infinity a)
+           (defconstant double-float-negative-infinity (- a)))
+         (let ((a (/ (coerce 1 'long-float) (coerce 0.0 'long-float))))
+           (defconstant long-float-positive-infinity a)
+           (defconstant long-float-negative-infinity (- a))))))
 
 (defun isqrt (i)
   "Args: (integer)

--- a/src/lisp/kernel/lsp/numlib.lsp
+++ b/src/lisp/kernel/lsp/numlib.lsp
@@ -68,20 +68,19 @@
 
 ;;; This needs to be loaded, used in ext::float-infinity-string 
 (locally (declare (notinline -))
-  (unwind-protect
-       (progn
-         (let ((a (/ (coerce 1 'short-float) (coerce 0.0 'short-float))))
-           (defconstant short-float-positive-infinity a)
-           (defconstant short-float-negative-infinity (- a)))
-         (let ((a (/ (coerce 1 'single-float) (coerce 0.0 'single-float))))
-           (defconstant single-float-positive-infinity a)
-           (defconstant single-float-negative-infinity (- a)))
-         (let ((a (/ (coerce 1 'double-float) (coerce 0.0 'double-float))))
-           (defconstant double-float-positive-infinity a)
-           (defconstant double-float-negative-infinity (- a)))
-         (let ((a (/ (coerce 1 'long-float) (coerce 0.0 'long-float))))
-           (defconstant long-float-positive-infinity a)
-           (defconstant long-float-negative-infinity (- a))))))
+  (progn
+    (let ((a (/ (coerce 1 'short-float) (coerce 0.0 'short-float))))
+      (defconstant ext::short-float-positive-infinity a)
+      (defconstant ext::short-float-negative-infinity (- a)))
+    (let ((a (/ (coerce 1 'single-float) (coerce 0.0 'single-float))))
+      (defconstant ext::single-float-positive-infinity a)
+      (defconstant ext::single-float-negative-infinity (- a)))
+    (let ((a (/ (coerce 1 'double-float) (coerce 0.0 'double-float))))
+      (defconstant ext::double-float-positive-infinity a)
+      (defconstant ext::double-float-negative-infinity (- a)))
+    (let ((a (/ (coerce 1 'long-float) (coerce 0.0 'long-float))))
+      (defconstant ext::long-float-positive-infinity a)
+      (defconstant ext::long-float-negative-infinity (- a)))))
 
 (defun isqrt (i)
   "Args: (integer)


### PR DESCRIPTION
Fixes
````
COMMON-LISP-USER> (let ((*read-default-float-format*  'single-float)
      (*print-readably* nil))
  (read-from-string (format nil "12~40,2f" most-positive-single-float)))

#.core::single-float-positive-infinity
````