### PR TITLE
Fix float reader ofr short-float & long-float

### DIFF
--- a/src/core/lispReader.cc
+++ b/src/core/lispReader.cc
@@ -856,13 +856,26 @@ T_sp interpret_token_or_throw_reader_error(T_sp sin, Token &token, bool only_dot
         char *lastValid = NULL;
         if (cl::_sym_STARreadDefaultFloatFormatSTAR->symbolValue() == cl::_sym_single_float) {
           string numstr = tokenStr(sin,token, start - token.data())->get_std_string();
+          // don't understand this, clasp_make_single_float takes a float , not a double
+          // shouldn't that be float f = strtof(......
           double d = ::strtod(numstr.c_str(), &lastValid);
           return clasp_make_single_float(d);
         } else if (cl::_sym_STARreadDefaultFloatFormatSTAR->symbolValue() == cl::_sym_DoubleFloat_O) {
           string numstr = tokenStr(sin,token, start - token.data())->get_std_string();
           double d = ::strtod(numstr.c_str(), &lastValid);
           return DoubleFloat_O::create(d);
-        } else {
+        }
+        else if (cl::_sym_STARreadDefaultFloatFormatSTAR->symbolValue() == cl::_sym_ShortFloat_O) {
+          string numstr = tokenStr(sin,token, start - token.data())->get_std_string();
+          float f = ::strtof(numstr.c_str(), &lastValid);
+          return clasp_make_single_float(f); //ShortFloat_O::create(f) crashes
+        }
+        else if (cl::_sym_STARreadDefaultFloatFormatSTAR->symbolValue() == cl::_sym_LongFloat_O) {
+          string numstr = tokenStr(sin,token, start - token.data())->get_std_string();
+          LongFloat l = ::strtod(numstr.c_str(), &lastValid);
+          return LongFloat_O::create(l);
+        }
+        else {
           SIMPLE_ERROR(BF("Handle *read-default-float-format* of %s") % _rep_(cl::_sym_STARreadDefaultFloatFormatSTAR->symbolValue()));
         }
       }

--- a/src/core/lispReader.cc
+++ b/src/core/lispReader.cc
@@ -856,10 +856,8 @@ T_sp interpret_token_or_throw_reader_error(T_sp sin, Token &token, bool only_dot
         char *lastValid = NULL;
         if (cl::_sym_STARreadDefaultFloatFormatSTAR->symbolValue() == cl::_sym_single_float) {
           string numstr = tokenStr(sin,token, start - token.data())->get_std_string();
-          // don't understand this, clasp_make_single_float takes a float , not a double
-          // shouldn't that be float f = strtof(......
-          double d = ::strtod(numstr.c_str(), &lastValid);
-          return clasp_make_single_float(d);
+          float f = ::strtof(numstr.c_str(), &lastValid);
+          return clasp_make_single_float(f);
         } else if (cl::_sym_STARreadDefaultFloatFormatSTAR->symbolValue() == cl::_sym_DoubleFloat_O) {
           string numstr = tokenStr(sin,token, start - token.data())->get_std_string();
           double d = ::strtod(numstr.c_str(), &lastValid);


### PR DESCRIPTION
Before:
````
COMMON-LISP-USER> (equalp (list 1.111 1.111 1.111d0 1.111d0)
              (let ((result nil))
                (dolist (type (list 'short-float 'single-float 'double-float 'long-float) (reverse result))
                  (let ((*read-default-float-format* type))
                    (push (read-from-string "1.111") result)))))

Condition of type: SIMPLE-PROGRAM-ERROR
Handle *read-default-float-format* of SHORT-FLOAT

Available restarts:
(use :r1 to invoke restart 1)

1. (RESTART-TOPLEVEL) Go back to Top-Level REPL.
````

After
````
COMMON-LISP-USER> (equalp (list 1.111 1.111 1.111d0 1.111d0)
              (let ((result nil))
                (dolist (type (list 'short-float 'single-float 'double-float 'long-float) (reverse result))
                  (let ((*read-default-float-format* type))
                    (push (read-from-string "1.111") result)))))

T
````