### PR TITLE
Fix obvious disassemble bugs, add regression tests

### DIFF
--- a/src/lisp/kernel/cmp/disassemble.lsp
+++ b/src/lisp/kernel/cmp/disassemble.lsp
@@ -27,14 +27,17 @@
 ;;
 (in-package :cmp)
 
+(defun safe-llvm-get-name (what)
+  (llvm-sys:get-name what))
+
 (defun disassemble-assembly-for-llvm-functions (llvm-function-list)
   "Given a list of llvm::Functions that were JITted - generate disassembly for them.
 Return T if disassembly was achieved - otherwise NIL"
   (bformat t "There are %d associated functions - disassembling them.%N" (length llvm-function-list))
   (let ((success nil))
     (dolist (llvm-func llvm-function-list)
-      (bformat t "%N%s-----%N" (llvm-sys:get-name llvm-func))
-      (let* ((llvm-function-name (bformat nil "_%s" (llvm-sys:get-name llvm-func)))
+      (bformat t "%N%s-----%N" (safe-llvm-get-name llvm-func))
+      (let* ((llvm-function-name (bformat nil "_%s" (safe-llvm-get-name llvm-func)))
              (symbol-info (gethash llvm-function-name *jit-saved-symbol-info*)))
         (if symbol-info
             (let ((bytes (first symbol-info))
@@ -54,7 +57,10 @@ Return T if disassembly was achieved - otherwise NIL"
      (unless (disassemble-assembly-for-llvm-functions (llvm-sys:module-get-function-list module-or-func))
        (error "Cannot disassemble module ~s" module-or-func)))
     ((functionp module-or-func)
-     (let ((success (disassemble-assembly-for-llvm-functions (list module-or-func))))
+     ;;; What is the type for a jitted function? For sure not CORE:CLOSURE-WITH-SLOTS, so test that 
+     (let ((success (unless (or (typep module-or-func 'CORE:CLOSURE-WITH-SLOTS)
+				(typep module-or-func 'STANDARD-GENERIC-FUNCTION))       
+		      (disassemble-assembly-for-llvm-functions (list module-or-func)))))
        (if success
            t
            (progn
@@ -79,7 +85,7 @@ Return T if disassembly was achieved - otherwise NIL"
   (check-type type (member :ir :asm))
   (multiple-value-bind (func-or-lambda name)
       (cond
-        ((null desig) (error "No function provided"))
+        ((null desig) (error 'type-error :datum desig :expected-type '(or symbol function (CONS (EQL SETF) (CONS SYMBOL NULL)))))
         ((symbolp desig) (if (fboundp desig)
                              (values (fdefinition desig) desig)
                              (error "No function bound to ~A" desig)))
@@ -95,13 +101,13 @@ Return T if disassembly was achieved - otherwise NIL"
                  (cond
                    ((eq type :ir) (llvm-sys:dump-module module))
                    ((eq type :asm) (warn "Handle disassemble of lambda-form to assembly"))
-                   (t (error "Illegal type ~a - only :ir and :asm allowed" type )))
+                   (t (error 'type-error :datum type :expected-type '(or :ir :asm))))
                  (error "Could not recover jitted module -> ~a" module))))
          (return-from disassemble nil))
          ;; treat setf functions
          ((and (consp desig) (eq (car desig) 'setf)(fdefinition desig))
          (values (fdefinition desig) desig))
-        (t (error "Unknown argument ~a passed to disassemble" desig)))
+        (t (error 'type-error :datum desig :expected-type '(or symbol function (CONS (EQL SETF) (CONS SYMBOL NULL))))))
     (setq name (if name name 'lambda))
     (bformat t "Disassembling function: %s%N" (repr func-or-lambda))
     (cond
@@ -115,9 +121,11 @@ Return T if disassembly was achieved - otherwise NIL"
                   (bformat t "Done%N"))
                 (error "LLVM-IR is not saved for functions - use :type :asm to disassemble to native code")))
            ((interpreted-function-p fn)
-            (format t "This is a interpreted function - compile it first~%"))
+            (format t "This is a interpreted function - compile it first~%")
+	        (error 'type-error :datum fn :expected-type '(or symbol function (CONS (EQL SETF) (CONS SYMBOL NULL)))))
            ((eq type :asm)
+	        ;;; How is it possible to come to this branch
             (llvm-sys:disassemble-instructions (get-builtin-target-triple-and-data-layout) (core:function-pointer fn) :start-instruction-index start-instruction-index :num-instructions num-instructions))
-           (t (error "Unknown target for disassemble: ~a" fn)))))
-      (t (error "Cannot disassemble"))))
+           (t (error 'type-error :datum fn :expected-type '(or symbol function (CONS (EQL SETF) (CONS SYMBOL NULL))))))))
+      (t (error 'type-error :datum func-or-lambda :expected-type '(or symbol function (CONS (EQL SETF) (CONS SYMBOL NULL)))))))
   nil)

--- a/src/lisp/regression-tests/misc.lisp
+++ b/src/lisp/regression-tests/misc.lisp
@@ -14,29 +14,72 @@
 ;;; Failed, see void intrinsic_error, now throws ERROR_UNDEFINED_FUNCTION
 (test cell-1
       (multiple-value-bind
-          (key error)
-        (handler-case
-            (eval '(im-am-not-defined))
-          (undefined-function (e) (values :undefined-functions-error e))
-          (program-error (p) (values :program-error p)))
+            (key error)
+          (handler-case
+              (eval '(im-am-not-defined))
+            (undefined-function (e) (values :undefined-functions-error e))
+            (program-error (p) (values :program-error p)))
         (eql :undefined-functions-error key)))
 
 (test cell-2
       (multiple-value-bind
-          (key error)
-        (handler-case
-            (eval 'im-am-not-bound)
-          (unbound-variable (e) (values :unbound-variable-error e))
-          (program-error (p) (values :program-error p)))
-        (eql  :unbound-variable-error key)))
+            (key error)
+          (handler-case
+              (eval 'im-am-not-bound)
+            (unbound-variable (e) (values :unbound-variable-error e))
+            (program-error (p) (values :program-error p)))
+        (eql :unbound-variable-error key)))
 
 (defclass foo ()((bar :accessor %bar)))
 
 (test cell-3
       (multiple-value-bind
-          (key error)
-        (handler-case
-            (%bar (make-instance 'foo))
-          (unbound-slot (e) (values :unbound-slot-error e))
-          (error (p) (values :error p)))
+            (key error)
+          (handler-case
+              (%bar (make-instance 'foo))
+            (unbound-slot (e) (values :unbound-slot-error e))
+            (error (p) (values :error p)))
         (eql :unbound-slot-error key)))
+
+(test disassemble-2 (progn
+                      (disassemble 'car)
+                      t))
+(test disassemble-3 (progn
+                      (disassemble #'car)
+                      t))
+(test disassemble-4 (progn
+                      (disassemble '(lambda(a) a))
+                      t))
+(test disassemble-5 (progn
+                      (disassemble '(lambda()) :type :ir)
+                      t))
+
+(defun %foo% (n)(* n n))
+
+(test disassemble-6 (progn
+                      (disassemble '%foo%)
+                      t))
+
+(test disassemble-7 (progn
+                      (disassemble (compile nil '(lambda(n) n)))
+                      t))
+
+(defgeneric disassemble-example-fn2 (x y z))
+(test disassemble-8 (progn
+                      (disassemble 'disassemble-example-fn2)
+                      t))
+
+(defgeneric disassemble-example-fn3 (x y z))
+(defmethod disassemble-example-fn3 ((x t)(y t)(z t)) (list x y z))
+
+(test disassemble-9 (progn
+                      (disassemble ' disassemble-example-fn3)
+                      t))
+
+(test load-stream.1
+      (with-input-from-string (s "(defun foo())")
+        (load s)))
+
+(test load-stream.2
+      (with-input-from-string (s "(defun foo())")
+        (load s :print t :verbose t)))


### PR DESCRIPTION
See test disassemble-2 until disassemble-9 for what it fixes
Ansi-tests are now happy
I see that - as before - by default only 16 bytes are disassembled, don't know how to fix that