### PR TITLE
rewamp regression tests, add new tests, expected failures

### DIFF
--- a/src/lisp/regression-tests/cons01.lisp
+++ b/src/lisp/regression-tests/cons01.lisp
@@ -1,0 +1,58 @@
+(in-package #:clasp-tests)
+
+(test adjoin-1 (equalp (list 3 1 2)(let ()(adjoin 1 (list 3 1 2)))))
+(test adjoin-2 (equalp (list 5 3 1 2)(let ()(adjoin 5 (list 3 1 2)))))
+(test adjoin-2 (equalp '((1 3) (2 4))
+                       (let ()
+                         (adjoin (list 1 2) (list (list 1 3)(list 2 4)) :key #'first))))
+(test pushnew-1
+      (equalp (list 3 1 2)
+              (let ((x (list 3 1 2)))
+                (pushnew 1 x)
+                x)))
+(test pushnew-2
+      (equalp (list 5 3 1 2)
+              (let ((x (list 3 1 2)))
+                (pushnew 5 x)
+                x)))
+
+(test pushnew-3
+      (equalp '((1 3) (2 4))
+              (let ((x (list (list 1 3)(list 2 4))))
+                (pushnew (list 1 2) x :key #'first)
+                x)))
+
+;;; whether z and y have their values seems to depend on the order key and test are executed
+;;; I consider this undefined behaviour, see two-arg-test-parse-args, third return value
+(test ansi-PUSHNEW.14
+      (equalp
+       '((A B C)
+         (A B C)
+         3
+         1
+         3
+         2)
+      (multiple-value-bind
+            (a b c d e f)
+          (LET ((I 0)
+                X
+                Y
+                Z
+                (D '(B C)))
+            (VALUES
+             (PUSHNEW
+              (PROGN (SETF X (INCF I)) 'A)
+              D
+              :TEST
+               (PROGN (SETF Z (INCF I)) #'EQL)
+              :KEY
+              (PROGN (SETF Y (INCF I)) #'IDENTITY))
+             D
+             I
+             X
+             Y
+             Z))
+        (list a b c d e f))))
+
+
+

--- a/src/lisp/regression-tests/framework.lisp
+++ b/src/lisp/regression-tests/framework.lisp
@@ -1,11 +1,41 @@
 (defpackage #:clasp-tests
     (:use :cl :core)
-  (:export #:test))
+  (:export #:test #:test-expect-error))
 
 (in-package #:clasp-tests)
 
 (defparameter *passes* 0)
 (defparameter *fails* 0)
+(defparameter *failed-tests* nil)
+(defparameter *expected-failures* nil)
+
+(defun reset-clasp-test ()
+  (setq *passes* 0
+        *fails* 0
+        *failed-tests* nil))
+
+(defun note-test-finished ()
+  (setq *failed-tests* (nreverse *failed-tests*)))
+  
+(defun show-failed-tests ()
+  (cond (*failed-tests*
+         (format t "~%Failed tests ~a~%" *failed-tests*)
+         (show-unexpected-failures))
+        (t (format t "~%No tests failed~%"))))
+
+(defun show-unexpected-failures ()
+  (let ((unexpected-failures nil))
+    (dolist (fail *failed-tests*)
+      (unless (member fail *expected-failures*)
+        (push fail unexpected-failures)))
+    (when unexpected-failures
+      (format t "~%unexpected failures ~a~%" (nreverse unexpected-failures)))
+    (let ((unexpected-successes nil))
+      (dolist (fail *expected-failures*)
+        (unless (member fail *failed-tests*)
+          (push fail unexpected-successes)))
+      (when unexpected-successes
+        (format t "~%unexpected success ~a~%" (nreverse unexpected-successes))))))
 
 (defmacro test (name form &key description )
   `(if (ignore-errors ,form)
@@ -14,6 +44,7 @@
          (incf *passes*))
        (progn
          (incf *fails*)
+         (pushnew ',name *failed-tests*)
          (format t "Failed ~s~%" ',name)
          (when ,description (format t "~s~%" ,description)))))
 

--- a/src/lisp/regression-tests/package.lisp
+++ b/src/lisp/regression-tests/package.lisp
@@ -36,7 +36,9 @@
   (delete-package "KARSTEN")
   (test nicknames-1 (null (package-nicknames pkg))))
 
-(test nicknames-2 (packagep (make-package "KARSTEN-NEW" :nicknames (list "CARLES" "CARLITO"))))
+(test nicknames-2 (prog1
+                      (packagep (make-package "KARSTEN-NEW" :nicknames (list "CARLES" "CARLITO")))
+                    (delete-package "KARSTEN-NEW")))
 
 ;;; used to unintern the symbols in shadowing-import-from when delete-package
 (test shadowing-import-1

--- a/src/lisp/regression-tests/read01.lisp
+++ b/src/lisp/regression-tests/read01.lisp
@@ -1,0 +1,29 @@
+(in-package #:clasp-tests)
+
+(test read-1
+      (equalp (list 1.111 1.111 1.111d0 1.111d0)
+              (let ((result nil))
+                (dolist (type (list 'short-float 'single-float 'double-float 'long-float) (reverse result))
+                  (let ((*read-default-float-format* type))
+                    (push (read-from-string "1.111") result))))))
+
+(test read-2
+      (string-equal
+       "
+#.ext::single-float-positive-infinity "
+       (with-output-to-string (*standard-output*)
+         (let ((*read-default-float-format* 'single-float)
+               (*print-readably* nil))
+           (print (read-from-string (format nil "12~40,2f" most-positive-single-float)))))))
+
+#+that-does-crash-the-lisp-in-printing
+(test read-3
+      (string-equal
+       "
+#.exit::long-float-positive-infinity "
+       (with-output-to-string (*standard-output*)
+         (let ((*read-default-float-format* 'long-float)
+               (*print-readably* nil))
+           (print (read-from-string (format nil "12~308,2f" most-positive-long-float)))))))
+
+

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -1,4 +1,5 @@
 (load (compile-file "sys:regression-tests;framework.lisp"))
+(load "sys:regression-tests;set-unexpected-failures.lisp")
 
 (in-package #:clasp-tests)
        
@@ -13,6 +14,7 @@
 #+use-mps
 (progn (princ "Skipping finalizer tests on MPS - fix!") (terpri))
 (load (compile-file "sys:regression-tests;strings01.lisp"))
+(load (compile-file "sys:regression-tests;cons01.lisp"))
 (load (compile-file "sys:regression-tests;sequences01.lisp"))
 (load (compile-file "sys:regression-tests;clos.lisp"))
 (load (compile-file "sys:regression-tests;numbers.lisp"))
@@ -26,6 +28,10 @@
 (load (compile-file "sys:regression-tests;character0.lisp"))
 (load (compile-file "sys:regression-tests;hash-tables0.lisp"))
 (load (compile-file "sys:regression-tests;misc.lisp"))
+(load (compile-file "sys:regression-tests;read01.lisp"))
 
-(format t "Passes: ~a~%" *passes*)
-(format t "Fails:  ~a~%" *fails*)
+(progn
+  (note-test-finished)
+  (format t "Passes: ~a~%" *passes*)
+  (format t "Fails:  ~a~%" *fails*)
+  (show-failed-tests))

--- a/src/lisp/regression-tests/sequences01.lisp
+++ b/src/lisp/regression-tests/sequences01.lisp
@@ -5,9 +5,9 @@
 (test subseq0 (equal (subseq '(1 2 3 4 5) 0 3) (list 1 2 3)))
 
 (test last-1 (equal (list 1 2 3 4)
-             (last (list 1 2 3 4) most-positive-fixnum)))
+                    (last (list 1 2 3 4) most-positive-fixnum)))
 (test last-2  (equal (list 1 2 3 4)
-             (last (list 1 2 3 4) (1+ most-positive-fixnum))))
+                     (last (list 1 2 3 4) (1+ most-positive-fixnum))))
 (test last-3  (null (last (list 1 2 3 4) 0)))
 (TEST-EXPECT-ERROR last-4 (last (list 1 2 3 4) -1) :type type-error)
 (TEST-EXPECT-ERROR last-5 (last (list 1 2 3 4) most-negative-fixnum) :type type-error)
@@ -64,9 +64,9 @@
                  (write-sequence (vector #\1 #\2 #\3 #\4) blah :start 0 :end 2))))
 
 (test write-sequence-2
-       (string= "1223"
-                (with-output-to-string (blah)
-                  (gray:stream-write-sequence blah "1223"))))
+      (string= "1223"
+               (with-output-to-string (blah)
+                 (gray:stream-write-sequence blah "1223"))))
 
 (test read-sequence-1
       (string= "12        "
@@ -158,7 +158,7 @@
                    :type  program-error)
 
 (test fill-5 (equalp (make-array 6 :initial-element 3)
-                      (FILL (make-array 6 :initial-element 3) -5 :start 3 :end 3)))
+                     (FILL (make-array 6 :initial-element 3) -5 :start 3 :end 3)))
 
 (test fill-6
       (equalp #*01010111111111110101010101010101
@@ -166,19 +166,95 @@
                                  :initial-contents (list 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1 0 1)) 1
                                  :start 5 :end 16)))
 
+(test-expect-error fill-7
+                   (fill #*01010111111111110101010101010101 2)
+                   :type type-error)
+
+(test fill-8
+      (equalp #*1111111111
+              (fill #*0000000000 1)))
+
+(test fill-9
+      (equalp #*0000001111
+              (fill #*0000000000 1 :start 6)))
+
+(test fill-10
+      (equalp #*1111110000
+              (fill #*0000000000 1 :end 6)))
+
+(test fill-11
+      (equalp #*1111111111
+              (fill #*0000000000 1 :end 10)))
+
+(test fill-12
+      (equalp #*0000000000
+              (fill #*1111111111 0 :end 10)))
+
+
+(test fill-13
+      (equalp
+       (let ((vector (vector 0 1 2 3))
+             (results nil))
+         (dotimes (x (length vector))
+           (push (let () (find x vector)) results))
+         (dotimes (x (length vector))
+           (dotimes (y (length vector))
+             (push (let () (find x vector :end y)) results)))
+         (dotimes (x (length vector))
+           (dotimes (y (length vector))
+             (push (let ()(find x vector :start y)) results)))
+         (dotimes (x (length vector))
+           (dotimes (y (length vector))
+             (dotimes (z (length vector))
+               (when (>= z y)
+                 (push (let () (find x vector :start y :end z)) results)))))
+         results)
+       (list NIL NIL NIL NIL NIL NIL NIL NIL NIL NIL NIL 2 NIL 2 NIL NIL 2 NIL NIL NIL NIL
+             NIL NIL 1 1 NIL 1 1 NIL NIL NIL NIL NIL NIL NIL NIL 0 0 0 NIL 3 3 3 3 NIL 2 2
+             2 NIL NIL 1 1 NIL NIL NIL 0 NIL NIL NIL NIL 2 NIL NIL NIL 1 1 NIL NIL 0 0 0
+             NIL 3 2 1 0)))
+
+(test fill-13b
+      (equalp
+       (let ((vector (vector 0 1 2 3))
+             (results nil))
+         (dotimes (x (length vector))
+           (push (find x vector) results))
+         (dotimes (x (length vector))
+           (dotimes (y (length vector))
+             (push (find x vector :end y) results)))
+         (dotimes (x (length vector))
+           (dotimes (y (length vector))
+             (push (find x vector :start y) results)))
+         (dotimes (x (length vector))
+           (dotimes (y (length vector))
+             (dotimes (z (length vector))
+               (when (>= z y)
+                 (push (find x vector :start y :end z) results)))))
+         results)
+       (list NIL NIL NIL NIL NIL NIL NIL NIL NIL NIL NIL 2 NIL 2 NIL NIL 2 NIL NIL NIL NIL
+             NIL NIL 1 1 NIL 1 1 NIL NIL NIL NIL NIL NIL NIL NIL 0 0 0 NIL 3 3 3 3 NIL 2 2
+             2 NIL NIL 1 1 NIL NIL NIL 0 NIL NIL NIL NIL 2 NIL NIL NIL 1 1 NIL NIL 0 0 0
+             NIL 3 2 1 0)))
+
+(test fill-14 (null (let ()(FIND 1 #*0010010 :END 1))))
+
+(test fill-15 (null (let ()(FIND 1 (vector 0 1 2 3 4 5) :END 1))))
+
+(test fill-16  (let ()(FIND 1 (vector 0 1 2 3 4 5) :END 2)))
 
 (test search-sequence-1 (= 5  (search "5" "0123456789" :start2 2)))
 (test search-sequence-2 (= 4  (search (vector 4 5) (vector 0 1 2 3 4 5 6 7 8 9) :start2 2)))
 (test search-sequence-3 (= 4 (search (list 4 5) (list 0 1 2 3 4 5 6 7 8 9) :start2 2)))
 
 (test equalp-1
- (equalp "1234567890" (make-array 15 :element-type 'character :initial-contents "123456789012345" :fill-pointer 10)))
+      (equalp "1234567890" (make-array 15 :element-type 'character :initial-contents "123456789012345" :fill-pointer 10)))
 
 ;;; fails
 (test equalp-2
- (equalp
-  (make-array 12 :element-type 'character :initial-contents "123456789012" :fill-pointer 10)
-  (make-array 15 :element-type 'character :initial-contents "123456789012345" :fill-pointer 10)))
+      (equalp
+       (make-array 12 :element-type 'character :initial-contents "123456789012" :fill-pointer 10)
+       (make-array 15 :element-type 'character :initial-contents "123456789012345" :fill-pointer 10)))
 
 ;;; from clhs Fill-pointer in the second array seem to be respected
 (test equalp-clhs-1
@@ -210,3 +286,22 @@
       (equalp
        (MAKE-ARRAY '(4) :INITIAL-CONTENTS '(1 2 3 4) :ELEMENT-TYPE 'Integer)
        #(1 2 3 4)))
+
+(test equalp-6
+      (equalp "ab" #(#\a #\b)))
+
+(test equalp-7
+      (let ((vector (make-array 3 :fill-pointer 2 :initial-contents (list 1 2 3))))
+        (equalp vector (copy-seq vector))))
+
+(test nreverse-1
+      (let ((array (MAKE-ARRAY 10 :INITIAL-CONTENTS '(1 2 3 4 5 6 7 8 9 10) :FILL-POINTER 5)))
+        (let ((new (nreverse array)))
+          (array-has-fill-pointer-p new))))
+
+(test reverse-1
+      (equalp #(3 2 1)
+              (reverse
+               (make-array 3 :displaced-to
+                           (make-array 5 :initial-contents (list 0 1 2 3 4))
+                           :displaced-index-offset 1))))

--- a/src/lisp/regression-tests/set-unexpected-failures.lisp
+++ b/src/lisp/regression-tests/set-unexpected-failures.lisp
@@ -1,0 +1,10 @@
+(in-package #:clasp-tests)
+
+(setq *expected-failures*
+      '(ANSI-PUSHNEW.14 ;;; this is debatable, will ask jackdaniel to verify, I consider this undefined behaviour
+        EQUALP-2 EQUALP-CLHS-2 EQUALP-3 EQUALP-4 EQUALP-6 EQUALP-7
+        NREVERSE-1 REVERSE-1
+        ACCESSOR-TOO-MANY-ARGS-1
+        HELL-MDBIT-5A
+        LOAD-STREAM.1
+        ))


### PR DESCRIPTION
Tests can give now the following:
Passes: 726
Fails:  15

Failed tests (FINALIZERS-CONS FINALIZERS-CONS-REMOVE FINALIZERS-GENERAL
              FINALIZERS-GENERAL-REMOVE ANSI-PUSHNEW.14 EQUALP-2 EQUALP-CLHS-2
              EQUALP-3 EQUALP-4 EQUALP-6 EQUALP-7 NREVERSE-1 REVERSE-1
              ACCESSOR-TOO-MANY-ARGS-1 HELL-MDBIT-5A)

unexpected failures (FINALIZERS-CONS FINALIZERS-CONS-REMOVE FINALIZERS-GENERAL
                     FINALIZERS-GENERAL-REMOVE)

unexpected success (LOAD-STREAM.1)

Hopefully this coud be used in continous integration