### PR TITLE
Fix :start of with-input-.., other stream fixes

### DIFF
--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -170,7 +170,7 @@ T_sp clasp_make_file_stream_from_fd(T_sp fname, int fd, enum StreamMode smm, gct
 T_sp cl__make_synonym_stream(T_sp sym);
 T_sp cl__make_two_way_stream(T_sp in, T_sp out);
 
-T_sp cl__make_string_input_stream(String_sp strng, Fixnum_sp istart, T_sp iend);
+T_sp cl__make_string_input_stream(String_sp strng, cl_index istart, T_sp iend);
 T_sp clasp_make_string_output_stream(cl_index line_length = 128, bool extended = false);
  T_sp cl__make_string_output_stream(Symbol_sp elementType);
 T_sp cl__get_output_stream_string(T_sp strm);

--- a/src/core/foundation.cc
+++ b/src/core/foundation.cc
@@ -836,7 +836,7 @@ List_sp lisp_parse_arguments(const string &packageName, const string &args) {
   Package_sp pkg = gc::As<Package_sp>(_lisp->findPackage(packageName, true));
   ChangePackage changePackage(pkg);
   SimpleBaseString_sp ss = SimpleBaseString_O::make(args);
-  Stream_sp str = cl__make_string_input_stream(ss, make_fixnum(0), _Nil<T_O>());
+  Stream_sp str = cl__make_string_input_stream(ss, 0, _Nil<T_O>());
 #if 0  
   Reader_sp reader = Reader_O::create(str);
   T_sp osscons = reader->primitive_read(true, _Nil<T_O>(), false);
@@ -853,7 +853,7 @@ List_sp lisp_parse_declares(const string &packageName, const string &declarestri
   Package_sp pkg = gc::As<Package_sp>(_lisp->findPackage(packageName, true));
   ChangePackage changePackage(pkg);
   SimpleBaseString_sp ss = SimpleBaseString_O::make(declarestring);
-  Stream_sp str = cl__make_string_input_stream(ss, make_fixnum(0), _Nil<T_O>());
+  Stream_sp str = cl__make_string_input_stream(ss, 0, _Nil<T_O>());
 #if 0
   Reader_sp reader = Reader_O::create(str);
   List_sp sscons = reader->primitive_read(true, _Nil<T_O>(), false);

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -1862,7 +1862,7 @@ T_sp clasp_make_string_input_stream(T_sp strng, cl_index istart, cl_index iend) 
 CL_LAMBDA(strng &optional (istart 0) iend);
 CL_DECLARE();
 CL_DOCSTRING("make_string_input_stream");
-CL_DEFUN T_sp cl__make_string_input_stream(String_sp strng, Fixnum_sp istart, T_sp iend) {
+CL_DEFUN T_sp cl__make_string_input_stream(String_sp strng, cl_index istart, T_sp iend) {
   ASSERT(cl__stringp(strng));
   size_t_pair p = sequenceStartEnd(cl::_sym_make_string_input_stream,
                                    strng->length(), istart, iend);
@@ -2186,6 +2186,20 @@ CL_DECLARE();
 CL_DOCSTRING("makeBroadcastStream");
 CL_DEFUN T_sp cl__make_broadcast_stream(List_sp ap) {
   T_sp x, streams;
+  // we need to verify that ap are all streams
+  // currently (make-broadcast-stream 1 2 3) works fine
+  if (!ap.nilp()) {
+    T_sp acons = oCar(ap);
+      Stream_sp aStream =acons.asOrNull<Stream_O>();
+    if (!aStream)
+      TYPE_ERROR(acons, cl::_sym_Stream_O);
+    for (auto cur : (List_sp)oCdr(ap)) {
+      T_sp acons1 = oCar(ap);
+      Stream_sp aStream1 =acons1.asOrNull<Stream_O>();
+      if (!aStream1)
+        TYPE_ERROR(acons1, cl::_sym_Stream_O);
+    }
+  }
   streams = ap;
   x = BroadcastStream_O::create();
   StreamFormat(x) = kw::_sym_default;
@@ -2514,7 +2528,7 @@ CL_DEFUN T_sp cl__make_concatenated_stream(List_sp ap) {
   }
   StreamMode(x) = clasp_smm_concatenated;
   StreamOps(x) = duplicate_dispatch_table(concatenated_ops);
-  // used to be nreverse, but this gives wrong results, since it han reads first from the last stream past
+  // used to be nreverse, but this gives wrong results, since it than reads first from the last stream passed
   // stick with the original list
   ConcatenatedStreamList(x) = streams;
   return x;
@@ -3208,7 +3222,8 @@ set_stream_elt_type(T_sp tstream, gctools::Fixnum byte_size, int flags,
   case CLASP_STREAM_BINARY:
     // e.g. (T size) is not a valid type, use (UnsignedByte size)
     // This is better than (T Size), but not necesarily the right type
-    FileStreamEltType(stream) = Cons_O::createList(cl::_sym_UnsignedByte, make_fixnum(byte_size));
+    // Probably the value of the vriable t was meant, use it now!
+    FileStreamEltType(stream) = Cons_O::createList(t, make_fixnum(byte_size));
     StreamFormat(stream) = t;
     StreamOps(stream).read_char = not_character_read_char;
     StreamOps(stream).write_char = not_character_write_char;
@@ -5867,7 +5882,10 @@ CL_DECLARE();
 CL_DOCSTRING("listen");
 CL_DEFUN bool cl__listen(T_sp strm) {
   strm = coerce::inputStreamDesignator(strm);
-  return clasp_listen_stream(strm);
+  int result = clasp_listen_stream(strm);
+  if (result == CLASP_LISTEN_EOF)
+    return 0;
+  else return result;
 }
 
 CL_LAMBDA(&optional strm);


### PR DESCRIPTION
Test are in pr #560 
Fixes:
```lisp
(test WITH-INPUT-FROM-STRING-1
      (string-equal "23456789"
                    (WITH-INPUT-FROM-STRING (S "0123456789" :START 2)
                      (READ-LINE S))))
(test WITH-INPUT-FROM-STRING-5
      (string-equal "9"
                    (WITH-INPUT-FROM-STRING (S "0123456789" :start 9)
                      (READ-LINE S))))
(test-expect-error
 broadcast-stream
 (make-broadcast-stream 1 2 3)
 :type type-error)
;;; The type of binary streams - sorry forgot test
(test listen-1
      (not (WITH-INPUT-FROM-STRING (S "") (LISTEN S))))
(test listen-3
      (let ((res
             (multiple-value-list
              (WITH-input-from-string (S "xxx")
                (VALUES (NOT (LISTEN S))
                        (HANDLER-CASE
                            (LOCALLY (DECLARE (OPTIMIZE SAFETY)) (LOOP (READ-CHAR S)))
                          (END-OF-FILE NIL (LISTEN S))))))))
        (equalp res (list nil nil))))
````
