### PR TITLE
Fix pathname* to throw a type-error, when nil is passed as stream, instead of simple-error

### DIFF
--- a/src/core/pathname.cc
+++ b/src/core/pathname.cc
@@ -711,7 +711,8 @@ CL_DEFUN T_sp core__pathname_translations(T_sp host, T_sp hostp, T_sp set) {
         T_sp item = CAR(l);
         T_sp from = coerce_to_from_pathname(oCar(item), host);
         T_sp pn = oCadr(item);
-        if (pn.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+        if (pn.nilp())
+          TYPE_ERROR(pn, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
         T_sp to = cl__pathname(oCadr(item));
         set = Cons_O::create(Cons_O::create(from, Cons_O::create(to, _Nil<T_O>())), set);
       }
@@ -988,11 +989,12 @@ L:
     x = cl__parse_namestring(x);
   } else if (gc::IsA<Pathname_sp>(x)) {
     // do nothing
-  } else if (gc::IsA<Stream_sp>(x)) {
+  } else if ((gc::IsA<FileStream_sp>(x)) or (gc::IsA<SynonymStream_sp>(x))){
+    // other streams don't have an associated pathname, no use return "-no-name-" here, SBCL says SynonymStream_sp also valid
     x = clasp_filename(x);
     goto L;
   } else {
-    ERROR_WRONG_TYPE_ONLY_ARG(cl::_sym_pathname, x, Cons_O::createList(cl::_sym_or, cl::_sym_fileStream, cl::_sym_string, cl::_sym_pathname));
+    ERROR_WRONG_TYPE_ONLY_ARG(cl::_sym_pathname, x, Cons_O::createList(cl::_sym_or, cl::_sym_fileStream, cl::_sym_string, cl::_sym_pathname, cl::_sym_SynonymStream_O));
   }
   return gc::As<Pathname_sp>(x);
 }
@@ -1019,7 +1021,8 @@ Pathname_sp clasp_mergePathnames(T_sp tpath, T_sp tdefaults, T_sp defaultVersion
   T_sp host, device, directory, name, type, version;
   Symbol_sp tocase;
 
-  if (tdefaults.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tdefaults.nilp())
+    TYPE_ERROR(tdefaults, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp defaults = cl__pathname(tdefaults);
   Pathname_sp path = cl__parse_namestring(tpath, _Nil<T_O>(), defaults);
   host = path->_Host;
@@ -1083,9 +1086,11 @@ CL_LAMBDA(arg &optional (default-pathname (core::safe-default-pathname-defaults)
 CL_DECLARE();
 CL_DOCSTRING("mergePathnames");
 CL_DEFUN Pathname_sp cl__merge_pathnames(T_sp path, T_sp defaults, T_sp defaultVersion) {
-  if (path.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (path.nilp())
+    TYPE_ERROR(path, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   path = cl__pathname(path);
-  if (defaults.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (defaults.nilp())
+    TYPE_ERROR(defaults, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   defaults = cl__pathname(defaults);
   return clasp_mergePathnames(path, defaults, defaultVersion);
 }
@@ -1097,7 +1102,8 @@ CL_DECLARE();
 CL_DOCSTRING("wildPathnameP");
 CL_DEFUN bool cl__wild_pathname_p(T_sp tpathname, T_sp component) {
   bool checked = 0;
-  if (tpathname.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpathname.nilp())
+    TYPE_ERROR(tpathname, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pathname = cl__pathname(tpathname);
   if (component.nilp() || component == kw::_sym_host) {
     if (pathname->_Host == kw::_sym_wild)
@@ -1158,7 +1164,8 @@ CL_LAMBDA(tpathname);
 CL_DECLARE();
 CL_DOCSTRING("coerceToFilePathname");
 CL_DEFUN Pathname_sp core__coerce_to_file_pathname(T_sp tpathname) {
-  if (tpathname.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to core__coerce_to_physical_pathname") % __FUNCTION__);
+  if (tpathname.nilp())
+    TYPE_ERROR(tpathname, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pathname = core__coerce_to_physical_pathname(tpathname);
   pathname = cl__merge_pathnames(pathname);
 #if 0
@@ -1186,7 +1193,8 @@ CL_LAMBDA(x);
 CL_DECLARE();
 CL_DOCSTRING("coerceToPhysicalPathname");
 CL_DEFUN Pathname_sp core__coerce_to_physical_pathname(T_sp x) {
-  if (x.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (x.nilp())
+    TYPE_ERROR(x, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp px = cl__pathname(x);
   if (core__logical_pathname_p(px))
     return cl__translate_logical_pathname(px);
@@ -1249,7 +1257,8 @@ T_sp clasp_namestring(T_sp tx, int flags) {
   T_sp host;
   bool truncate_if_unreadable = flags & CLASP_NAMESTRING_TRUNCATE_IF_ERROR;
 
-  if (tx.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tx.nilp())
+    TYPE_ERROR(tx, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp x = cl__pathname(tx);
 
   /* INV: Pathnames can only be created by mergin, parsing namestrings
@@ -1407,14 +1416,16 @@ CL_LAMBDA(thing &optional host (defaults (core::safe-default-pathname-defaults))
 CL_DECLARE();
 CL_DOCSTRING("parseNamestring");
 CL_DEFUN T_mv cl__parse_namestring(T_sp thing, T_sp host, T_sp tdefaults, Fixnum_sp start, T_sp end, bool junkAllowed) {
-  if (tdefaults.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tdefaults.nilp())
+    TYPE_ERROR(tdefaults, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp tempdefaults = cl__pathname(tdefaults);
   T_sp output;
   if (host.notnilp()) {
     host = cl__string(host);
   }
   if (!cl__stringp(thing)) {
-    if (thing.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+    if (thing.nilp())
+      TYPE_ERROR(thing, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
     output = cl__pathname(thing);
   } else {
     T_sp default_host = host;
@@ -1460,7 +1471,8 @@ CL_DEFUN Pathname_sp cl__make_pathname(T_sp host, bool hostp, T_sp device, bool 
                                         _Nil<T_O>(), _Nil<T_O>(), _Nil<T_O>(), _Nil<T_O>(), _Nil<T_O>(),
                                         kw::_sym_local);
   } else {
-    if (odefaults.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+    if (odefaults.nilp())
+      TYPE_ERROR(odefaults, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
     defaults = cl__pathname(odefaults);
   }
   if (!hostp)
@@ -1488,7 +1500,8 @@ CL_LAMBDA(pname &key ((:case scase) :local));
 CL_DECLARE();
 CL_DOCSTRING("pathnameHost");
 CL_DEFUN T_sp cl__pathname_host(T_sp tpname, Symbol_sp scase) {
-  if (tpname.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpname.nilp())
+    TYPE_ERROR(tpname, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pname = cl__pathname(tpname);
   return translate_component_case(pname->_Host,
                                   normalize_case(pname, kw::_sym_local),
@@ -1499,7 +1512,8 @@ CL_LAMBDA(pname &key ((:case scase) :local));
 CL_DECLARE();
 CL_DOCSTRING("pathnameDevice");
 CL_DEFUN T_sp cl__pathname_device(T_sp tpname, Symbol_sp scase) {
-  if (tpname.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpname.nilp())
+    TYPE_ERROR(tpname, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pname = cl__pathname(tpname);
   return translate_component_case(pname->_Device,
                                   normalize_case(pname, kw::_sym_local),
@@ -1510,7 +1524,8 @@ CL_LAMBDA(pname &key ((:case scase) :local));
 CL_DECLARE();
 CL_DOCSTRING("pathnameDirectory");
 CL_DEFUN T_sp cl__pathname_directory(T_sp tpname, Symbol_sp scase) {
-  if (tpname.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpname.nilp())
+    TYPE_ERROR(tpname, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pname = cl__pathname(tpname);
   return translate_component_case(pname->_Directory,
                                   normalize_case(pname, kw::_sym_local),
@@ -1522,7 +1537,8 @@ CL_LAMBDA(pname &key ((:case scase) :local));
 CL_DECLARE();
 CL_DOCSTRING("pathnameName");
 CL_DEFUN T_sp cl__pathname_name(T_sp tpname, Symbol_sp scase) {
-  if (tpname.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpname.nilp())
+    TYPE_ERROR(tpname, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pname = cl__pathname(tpname);
   return translate_component_case(pname->_Name,
                                   normalize_case(pname, kw::_sym_local),
@@ -1534,7 +1550,8 @@ CL_LAMBDA(pname &key ((:case scase) :local));
 CL_DECLARE();
 CL_DOCSTRING("pathnameType");
 CL_DEFUN T_sp cl__pathname_type(T_sp tpname, Symbol_sp scase) {
-  if (tpname.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpname.nilp())
+    TYPE_ERROR(tpname, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pname = cl__pathname(tpname);
   return translate_component_case(pname->_Type,
                                   normalize_case(pname, kw::_sym_local),
@@ -1546,7 +1563,8 @@ CL_LAMBDA(pname);
 CL_DECLARE();
 CL_DOCSTRING("pathnameVersion");
 CL_DEFUN T_sp cl__pathname_version(T_sp tpname) {
-  if (tpname.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpname.nilp())
+    TYPE_ERROR(tpname, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pname = cl__pathname(tpname);
   return pname->_Version;
 };
@@ -1555,7 +1573,8 @@ CL_LAMBDA(tpname);
 CL_DECLARE();
 CL_DOCSTRING("fileNamestring");
 CL_DEFUN T_sp cl__file_namestring(T_sp tpname) {
-  if (tpname.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpname.nilp())
+    TYPE_ERROR(tpname, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pname = cl__pathname(tpname);
   return clasp_namestring(Pathname_O::makePathname(_Nil<T_O>(), _Nil<T_O>(), _Nil<T_O>(),
                                                    pname->_Name,
@@ -1569,7 +1588,8 @@ CL_LAMBDA(tpname);
 CL_DECLARE();
 CL_DOCSTRING("directoryNamestring");
 CL_DEFUN T_sp cl__directory_namestring(T_sp tpname) {
-  if (tpname.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpname.nilp())
+    TYPE_ERROR(tpname, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pname = cl__pathname(tpname);
   return clasp_namestring(Pathname_O::makePathname(_Nil<T_O>(), _Nil<T_O>(),
                                                    pname->_Directory,
@@ -1582,7 +1602,8 @@ CL_LAMBDA(tpname);
 CL_DECLARE();
 CL_DOCSTRING("hostNamestring");
 CL_DEFUN T_sp cl__host_namestring(T_sp tpname) {
-  if (tpname.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpname.nilp())
+    TYPE_ERROR(tpname, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pname = cl__pathname(tpname);
   T_sp host = pname->_Host;
   return host;
@@ -1595,9 +1616,11 @@ CL_DECLARE();
 CL_DOCSTRING("enough-namestring");
 CL_DEFUN T_sp cl__enough_namestring(T_sp tpath, T_sp tdefaults) {
   T_sp newpath, fname;
-  if (tdefaults.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tdefaults.nilp()) 
+    TYPE_ERROR(tdefaults, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp defaults = cl__pathname(tdefaults);
-  if (tpath.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpath.nilp())
+    TYPE_ERROR(tpath, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp path = cl__pathname(tpath);
   T_sp pathdir = path->_Directory;
   T_sp defaultdir = defaults->_Directory;
@@ -1784,9 +1807,11 @@ CL_DECLARE();
 CL_DOCSTRING("pathnameMatchP");
 CL_DEFUN bool cl__pathname_match_p(T_sp tpath, T_sp tmask) {
   bool output = false;
-  if (tpath.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tpath.nilp())
+    TYPE_ERROR(tpath, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp path = cl__pathname(tpath);
-  if (tmask.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tmask.nilp())
+    TYPE_ERROR(tmask, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp mask = cl__pathname(tmask);
   if (core__logical_pathname_p(path) != core__logical_pathname_p(mask))
     goto OUTPUT;
@@ -1984,14 +2009,17 @@ CL_DEFUN Pathname_sp cl__translate_pathname(T_sp tsource, T_sp tfrom, T_sp tto, 
   T_sp host, device, directory, name, type, version;
   T_sp tocase;
   /* The pathname from which we get the data */
-  if (tsource.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tsource.nilp())
+    TYPE_ERROR(tsource, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp source = cl__pathname(tsource);
   /* The mask applied to the source pathname */
-  if (tfrom.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tfrom.nilp())
+     TYPE_ERROR(tfrom, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp from = cl__pathname(tfrom);
   T_sp fromcase = normalize_case(from, kw::_sym_local);
   /* The pattern which says what the output should look like */
-  if (tto.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tto.nilp())
+     TYPE_ERROR(tto, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp to = cl__pathname(tto);
   tocase = normalize_case(to, kw::_sym_local);
 
@@ -2075,7 +2103,8 @@ CL_LAMBDA(source &key);
 CL_DECLARE();
 CL_DOCSTRING("translateLogicalPathname");
 CL_DEFUN Pathname_sp cl__translate_logical_pathname(T_sp tsource) {
-  if (tsource.nilp()) SIMPLE_ERROR(BF("%s was about to pass nil to pathname") % __FUNCTION__);
+  if (tsource.nilp())
+    TYPE_ERROR(tsource, Cons_O::createList(cl::_sym_or,cl::_sym_string,cl::_sym_Pathname_O));
   Pathname_sp pathname = cl__pathname(tsource);
 begin:
   if (!core__logical_pathname_p(pathname)) {

--- a/src/core/pathname.cc
+++ b/src/core/pathname.cc
@@ -989,7 +989,7 @@ L:
     x = cl__parse_namestring(x);
   } else if (gc::IsA<Pathname_sp>(x)) {
     // do nothing
-  } else if ((gc::IsA<FileStream_sp>(x)) or (gc::IsA<SynonymStream_sp>(x))){
+  } else if ((gc::IsA<FileStream_sp>(x)) || (gc::IsA<SynonymStream_sp>(x))){
     // other streams don't have an associated pathname, no use return "-no-name-" here, SBCL says SynonymStream_sp also valid
     x = clasp_filename(x);
     goto L;


### PR DESCRIPTION
e.g.
```lisp
COMMON-LISP-USER> (pathname nil)

Condition of type: SIMPLE-TYPE-ERROR
In function PATHNAME,the value of the only argument is
  NIL
which is not of the expected type (OR FILE-STREAM STRING PATHNAME SYNONYM-STREAM)

Available restarts:
(use :r1 to invoke restart 1)

1. (RESTART-TOPLEVEL) Go back to Top-Level REPL.
````
validated running the ansi-tests