### PR TITLE
Various fixes in for inline

### DIFF
--- a/src/lisp/kernel/cleavir/inline.lisp
+++ b/src/lisp/kernel/cleavir/inline.lisp
@@ -576,40 +576,41 @@
           (when (typep ,arrayname '(simple-array * (*))) (return)))))
      ,@body))
 
+
+#|
 (defun %non-empty-array-p (array)
   (> (array-total-size array) 0))
 
 (deftype non-empty-array ()
   `(and array (satisfies %non-empty-array-p)))
 
-#|
 (typep (make-array 0) 'NON-EMPTY-ARRAY)
 (typep (make-array 1) 'NON-EMPTY-ARRAY)
 |#
 
-(declaim (inline fast-vector-access))
-(defun fast-vector-access (vector index)
-  ;; First, undisplace. This can be done independently
+(declaim (inline vector-read))
+(defun vector-read (vector index)
+  ;; first bounds check. Use the original arguments.
+  ;; second, undisplace. This can be done independently
   ;; of the index, meaning it could potentially be
   ;; moved out of loops, though that can invite inconsistency
   ;; in a multithreaded environment.
-  (with-array-data (underlying-array offset vector)
-    ;; Now bounds check. Use the original arguments.
     (unless (vector-in-bounds-p vector index)
       ;; From elt: Should signal an error of type type-error if index is not a valid sequence index for sequence.
       (etypecase vector
         ((simple-vector *)
          (let ((max (core::vector-length vector)))
            (if (zerop max)
-               (error 'type-error :datum vector :expected-type 'non-empty-array)
+             (error 'simple-type-error :FORMAT-CONTROL "Array ~a not valid for index ~a~%" :format-arguments (list vector index) :datum index :expected-type '(integer 0 (0)))
                (error 'type-error :datum index :expected-type `(integer 0 ,(1- max))))))
         (array
          (let ((max (core::%array-total-size vector)))
            (when (array-has-fill-pointer-p vector)
                (setq max (min max (fill-pointer vector))))
            (if (zerop max)
-               (error 'type-error :datum vector :expected-type 'non-empty-array)
+             (error 'simple-type-error :FORMAT-CONTROL "Array ~a not valid for index ~a~%" :format-arguments (list vector index) :datum index :expected-type '(integer 0 (0)))
                (error 'type-error :datum index :expected-type `(integer 0 ,(1- max))))))))
+  (with-array-data (underlying-array offset vector)
     ;; Okay, now array is a vector/simple, and index is valid.
     ;; This function takes care of element type discrimination.
     (%unsafe-vector-ref underlying-array (+ index offset))))
@@ -627,16 +628,27 @@
         ((simple-array * (*))
          (let ((max (core::vector-length array)))
            (if (zerop max)
-               (error 'type-error :datum array :expected-type 'non-empty-array)
+               (error 'simple-type-error :FORMAT-CONTROL "Array not valid ~a for index ~a ~%" :format-arguments (list array index) :datum index :expected-type '(integer 0 (0)))
                (error 'type-error :datum index :expected-type `(integer 0 ,(1- max))))))
         (array
          (let ((max (core::%array-total-size array)))
            (if (zerop max)
-               (error 'type-error :datum array :expected-type 'non-empty-array)
+               (error 'simple-type-error :FORMAT-CONTROL "Array not valid ~a for index ~a ~%" :format-arguments (list array index) :datum index :expected-type '(integer 0 (0)))
                (error 'type-error :datum index :expected-type `(integer 0 ,(1- max))))))))
     ;; Okay, now array is a vector/simple, and index is valid.
     ;; This function takes care of element type discrimination.
     (%unsafe-vector-ref underlying-array (+ index offset))))
+
+(declaim (inline vector-set))
+(defun vector-set (vector index value)
+  (unless (vector-in-bounds-p vector index)
+    (let ((max (core::vector-length vector)))
+      (if (zerop max)
+          (error 'simple-type-error :FORMAT-CONTROL "Array ~a not valid for index ~a~%" :format-arguments (list vector index) :datum index :expected-type '(integer 0 (0)))
+          (error 'type-error :datum index :expected-type `(integer 0 ,max)))))
+  (with-array-data (underlying-array offset vector)
+    (%unsafe-vector-set underlying-array (+ index offset) value))
+  )
 
 (declaim (inline core:row-major-aset))
 (defun core:row-major-aset (array index value)
@@ -646,12 +658,12 @@
         ((simple-array * (*))
          (let ((max (core::vector-length array)))
            (if (zerop max)
-               (error 'type-error :datum array :expected-type 'non-empty-array)
+               (error 'simple-type-error :FORMAT-CONTROL "Array ~a not valid for index~a~%" :format-arguments (list array index) :datum index :expected-type '(integer 0 (0)))
                (error 'type-error :datum index :expected-type `(integer 0 ,max)))))
         (array
          (let ((max (core::%array-total-size array)))
            (if (zerop max)
-               (error 'type-error :datum array :expected-type 'non-empty-array)
+               (error 'simple-type-error :FORMAT-CONTROL "Array ~a not valid for index ~a~%" :format-arguments (list array index) :datum index :expected-type '(integer 0 (0)))
                (error 'type-error :datum index :expected-type `(integer 0 ,max)))))))
     (%unsafe-vector-set underlying-array (+ index offset) value)))
 
@@ -770,24 +782,34 @@
   (defun elt (sequence index)
   (etypecase sequence
     (list (if (null sequence)
-              (error 'type-error :datum index :expected-type 'cons)
+              (error 'type-error :datum sequence :expected-type 'cons)
               (let ((cell (nthcdr index sequence)))
                 (if (consp cell)
                     (car (the cons cell))
                     (if cell
                         ;;; we expect a proper list
-                        (error 'type-error :datum sequence :expected-type 'sequence)
+                        (error 'type-error :datum cell :expected-type 'list)
                         ;;; index must be wrong
-                        (error 'type-error :datum sequence :expected-type (list 'integer 0 (1- (length sequence)))))))))
-    (vector (fast-vector-access sequence index))
+                        (error 'type-error :datum index :expected-type (list 'integer 0 (1- (length sequence)))))))))
+    (vector (vector-read sequence index))
     (t (error 'type-error :datum sequence :expected-type 'sequence))))
 
   (debug-inline "core:setf-elt")
   (declaim (inline core:setf-elt))
   (defun core:setf-elt (sequence index new-value)
     (etypecase sequence
-      (list (setf (nth index sequence) new-value))
-      (vector (setf (row-major-aref sequence index) new-value))
+      (list (if (null sequence)
+                (error 'type-error :datum sequence :expected-type 'cons)
+                (let ((cell (nthcdr index sequence)))
+                  (if (consp cell)
+                      (setf (car cell) new-value)
+                      (if cell
+                        ;;; we expect a proper list
+                          (error 'type-error :datum sequence :expected-type 'list)
+                        ;;; index must be wrong
+                          (error 'type-error :datum index :expected-type (list 'integer 0 (1- (length sequence)))))))))
+      ;;; Need to test if index fits respecting the fill-pointer
+      (vector (vector-set sequence index new-value))
       (t (error 'type-error :datum sequence :expected-type 'sequence)))))
 
 ;;; ------------------------------------------------------------


### PR DESCRIPTION
- elt for lists cannot be transferred to nth, since nth does not error, when the index is too large, use nthcdr instead
- elt for vectors similar problem, cannot be transferred symply to aref, since fill-pointer treament is different (elt need to respect, aref not)
- more precise errors, if index out of bounds
- treat empty arrays 