### PR TITLE
Fix #536 by using the algorithm from ecl

### DIFF
--- a/src/core/bignum.cc
+++ b/src/core/bignum.cc
@@ -308,9 +308,16 @@ void Bignum_O::setFromString(const string &strVal) {
 gc::Fixnum Bignum_O::bit_length_() const {
   Bignum x = this->_value;
   if (this->sign() < 0) {
-    x = -x;
+    // issue #536
+    // from ECL: logxor(2,x,ecl_make_fixnum(-1)); before calling mpz_sizeinbase on x
+    mpz_class temp;
+    mpz_xor(temp.get_mpz_t(),clasp_to_mpz(clasp_make_fixnum(2)).get_mpz_t(), x.get_mpz_t());
+    mpz_class temp1;
+    mpz_xor(temp1.get_mpz_t(), temp.get_mpz_t(), clasp_to_mpz(clasp_make_fixnum(-1)).get_mpz_t());
+    return mpz_sizeinbase(temp1.get_mpz_t(), 2);
+  } else {
+    return mpz_sizeinbase(x.get_mpz_t(), 2);
   }
-  return mpz_sizeinbase(x.get_mpz_t(), 2);
 }
 
 /*! Return the value shifted by BITS bits.


### PR DESCRIPTION
Tests (will be comitted separately)
```lisp
;;;; taken from ansi-tests https://gitlab.common-lisp.net/ansi-test/ansi-test.git
;;;; Author:   Paul Dietz
;;;; Created:  Sun Sep  7 10:10:10 2003
;;;; Contains: Tests for INTEGER-LENGTH

(test integer-length.1
  (loop for len from 0 to 100
        for i = (1- (ash 1 len))
        for vals = (multiple-value-list (integer-length i))
        for len2 = (car vals)
        always (and (= (length vals) 1)
                    (eql len len2))))

(test integer-length.2
  (loop for len from 0 to 100
        for i = (ash 1 len)
        for vals = (multiple-value-list (integer-length i))
        for len2 = (car vals)
        always (and (= (length vals) 1)
                    (eql (1+ len) len2))))

(test integer-length.3
  (loop for len from 0 to 100
        for i = (- (ash 1 len))
        for vals = (multiple-value-list (integer-length i))
        for len2 = (car vals)
        always (and (= (length vals) 1)
                    (eql len len2))))

(test integer-length.4
  (loop for len from 0 to 100
        for i = (- -1 (ash 1 len))
        for vals = (multiple-value-list (integer-length i))
        for len2 = (car vals)
        always (and (= (length vals) 1)
                    (eql (1+ len) len2))))
```