### PR TITLE
Fix parse-integer to throw an error if no number is returned and junk…

### DIFF
--- a/src/core/array.cc
+++ b/src/core/array.cc
@@ -1836,7 +1836,12 @@ CL_DEFUN T_mv cl__parse_integer(String_sp str, Fixnum start, T_sp end, uint radi
       LOG(BF("Returning parse-integer with result = %s  cur = %d") % _rep_(iresult) % cur );
       return (Values(iresult, make_fixnum(cur)));
     } else {
-      return (Values(_Nil<T_O>(), make_fixnum(cur)));
+      //If junk-allowed is false, an error of type parse-error is signaled if substring does not consist entirely of the representation
+      // of a signed integer, possibly surrounded on either side by whitespace[1] characters.
+      // The first value returned is either the integer that was parsed, or else nil if no syntactically correct integer was seen but junk-allowed was true.
+      if (junkAllowed.notnilp())
+        return (Values(_Nil<T_O>(), make_fixnum(cur)));
+      else PARSE_ERROR(SimpleBaseString_O::make("Could not parse integer from ~S"), Cons_O::create(str,_Nil<T_O>()));
     }
   }
   PARSE_ERROR(SimpleBaseString_O::make("Could not parse integer from ~S"), Cons_O::create(str,_Nil<T_O>()));


### PR DESCRIPTION
…-allowed isn't t
tests (to be sent separately)
```lisp
(test-expect-error parse-integer6
      (multiple-value-bind (val pos)
          (parse-integer "+"))
      :type parse-error)

(test-expect-error parse-integer7
      (multiple-value-bind (val pos)
          (parse-integer "-"))
      :type parse-error)

(test-expect-error parse-integer8
      (multiple-value-bind (val pos)
          (parse-integer ""))
      :type parse-error)

(test parse-integer9
      (not
       (multiple-value-bind (val pos)
           (parse-integer "+" :junk-allowed t))))

(test parse-integer10
      (not
       (multiple-value-bind (val pos)
           (parse-integer "-" :junk-allowed t))))

(test parse-integer11
      (not
       (multiple-value-bind (val pos)
           (parse-integer "" :junk-allowed t))))
````