### PR TITLE
treat result of sched_yield correctly (0 == success)

### DIFF
--- a/src/core/mpPackage.cc
+++ b/src/core/mpPackage.cc
@@ -343,8 +343,10 @@ CL_DEFUN void mp__process_resume(Process_sp process) {
 
 CL_DEFUN void mp__process_yield() {
   // There doesn't appear to be any way to exit sched_yield()
+  // On success, sched_yield() returns 0.
+  // On error, -1 is returned, and errno is set appropriately.
   int res = sched_yield();
-  if (!res) {
+  if (res == -1) {
     SIMPLE_ERROR(BF("sched_yield returned the error %d") % res);
   }
 //  core::clasp_musleep(0.5,true);


### PR DESCRIPTION
```lisp
CL-USER> (mp::process-yield)
NIL
````
used to error, since 0 wasn't treated as success (and sched_yield always returns 0 on Darwin)