### PR TITLE
simplify & correct ltvc_make_complex

### DIFF
--- a/src/llvmo/link_intrinsics.cc
+++ b/src/llvmo/link_intrinsics.cc
@@ -199,7 +199,8 @@ LtvcReturn ltvc_make_complex(gctools::GCRootsInModule* holder, size_t index, gct
 {NO_UNWIND_BEGIN();
   core::Number_sp nreal((gctools::Tagged)real);
   core::Number_sp nimag((gctools::Tagged)imag);
-  core::T_sp val = core::Complex_O::create(clasp_to_double(nreal),clasp_to_double(nimag));
+  // Do not convert nreal and nimag to double, can be all types of Real_sp
+  core::T_sp val = core::Complex_O::create(nreal,nimag);
   LTVCRETURN holder->set(index,val.tagged_());
   NO_UNWIND_END();
 }


### PR DESCRIPTION
Fixes #589 

Tests:
```lisp
(test ltv-complex-0
      (let ((a #C(0 2))
            (b (complex 0 2)))
        (print `(should ,b))
        (print `(is ,a))
        (equal a b)))

(test ltv-complex-1
      (let ((a #C(0.0 2.0))
            (b (complex 0.0 2.0)))
        (print `(should ,b))
        (print `(is ,a))
        (equal a b)))

(test ltv-complex-2
      (let ((a #C(0.0d0 2.0d0))
            (b (complex 0.0d0 2.0d0)))
        (print `(should ,b))
        (print `(is ,a))
        (equal a b)))

(test ltv-complex-3
      (let ((a #C(1/2 1/3))
            (b (complex 1/2 1/3)))
        (print `(should ,b))
        (print `(is ,a))
        (equal a b)))

(test ltv-complex-4
      (let ((a #C(23058430092136939510 230584300921369395100))
            (b (complex 23058430092136939510 230584300921369395100)))
        (print `(should ,b))
        (print `(is ,a))
        (equal a b)))
````