### PR TITLE
Fix (MAKE-LIST -1)

### DIFF
--- a/src/core/cons.cc
+++ b/src/core/cons.cc
@@ -135,12 +135,18 @@ CL_LAMBDA(osize &key initial-element);
 CL_DECLARE();
 CL_DOCSTRING("make_list");
 CL_DEFUN List_sp cl__make_list(Fixnum_sp osize, T_sp initial_element) {
-  size_t size = osize.unsafe_fixnum();
+  // Might be a negative Fixnum, take the right type, size_t is unsigned
+  gc::Fixnum size = osize.unsafe_fixnum();
+  // osize must be 0 or positive
+  if (size < 0)
+    TYPE_ERROR(osize, cl::_sym_UnsignedByte);
+  else {
   ql::list result;
   for (size_t i = 0; i < size; i++) {
     result << initial_element;
   }
   return (result.cons());
+  }
 };
 
 Cons_sp Cons_O::createList(T_sp o1) {


### PR DESCRIPTION
Before fix
```lisp
COMMON-LISP-USER> (make-list -1)
Too many heap sections: Increase MAXHINCR or MAX_HEAP_SECTS
Abort trap: 6
````
now:
```lisp
COMMON-LISP-USER> (MAKE-LIST -1)
Condition of type: TYPE-ERROR
-1 is not of type UNSIGNED-BYTE.
````