### PR TITLE
Fix cl__length for non-proper-list (by drmeister)

### DIFF
--- a/src/core/cons.cc
+++ b/src/core/cons.cc
@@ -652,7 +652,11 @@ List_sp Cons_O::copyTreeCar() const {
 
 size_t Cons_O::length() const {
   size_t sz = 1;
-  for (T_sp cur = this->_Cdr; cur.consp(); cur = gc::As_unsafe<Cons_sp>(cur)->_Cdr) ++sz; 
+  T_sp cur = _Nil<T_O>();
+  for (cur = this->_Cdr; cur.consp(); cur = gc::As_unsafe<Cons_sp>(cur)->_Cdr) ++sz;
+  if (cur.notnilp()) {
+    TYPE_ERROR_PROPER_LIST(cur->asSmartPtr());
+  }
   return sz;
 };
 


### PR DESCRIPTION
Fix by drmeister, just changed the error object

fixes 
```lisp
(length (cons 1 2)) -> error 2 is not a cons instead of silently returning 1
````
Was already correct in the lisp definition, so only fixes cl_length calls in c++