### PR TITLE
Improve error parameters in fix from drmeister for cl__length

### DIFF
--- a/src/core/cons.cc
+++ b/src/core/cons.cc
@@ -655,7 +655,7 @@ size_t Cons_O::length() const {
   T_sp cur = _Nil<T_O>();
   for (cur = this->_Cdr; cur.consp(); cur = gc::As_unsafe<Cons_sp>(cur)->_Cdr) ++sz;
   if (cur.notnilp()) {
-    TYPE_ERROR_PROPER_LIST(this->asSmartPtr());
+    TYPE_ERROR_PROPER_LIST(cur->asSmartPtr());
   }
   return sz;
 };


### PR DESCRIPTION
There is no type for non-proper list, so use cur not being a cons