### PR TITLE
Verify to displaced-to array is big enough 

### DIFF
--- a/src/lisp/kernel/lsp/arraylib.lsp
+++ b/src/lisp/kernel/lsp/arraylib.lsp
@@ -75,7 +75,9 @@ contiguous block."
     (if (let ((array-element-type (array-element-type displaced-to)))
           (not (and (subtypep array-element-type upgraded-element-type)
                     (subtypep upgraded-element-type array-element-type))))
-        (error "Cannot displace the array, because the element types don't match")))
+        (error "Cannot displace the array, because the element types don't match"))
+    (when (< (core::%array-total-size displaced-to) displaced-index-offset)
+        (error "Cannot displace the array, because the total size of the displaced-to-array is too small.")))
   (cond
     ((null dimensions)
      (make-mdarray dimensions upgraded-element-type adjustable displaced-to displaced-index-offset


### PR DESCRIPTION
for the displaced-index-offset
```lisp
(test-expect-error make-array-6
                   (make-array 5 :element-type (array-element-type "") :displaced-index-offset 2 :displaced-to "")
                   :type simple-error)
````