### PR TITLE
Fix printing  negative integers at base 16

### DIFF
--- a/src/core/numberToString.cc
+++ b/src/core/numberToString.cc
@@ -109,6 +109,10 @@ CL_DEFUN StrNs_sp core__integer_to_string(StrNs_sp buffer, Integer_sp integer,
   if (integer.fixnump()) {
     char txt[64];
     gc::Fixnum fn = unbox_fixnum(gc::As<Fixnum_sp>(integer));
+    if (fn < 0) {
+      StringPushStringCharStar(buffer,"-");
+      fn = - fn;
+    }
     switch (unbox_fixnum(base)) {
     case 8:
       sprintf(txt, "%" PRFoctal, fn);

--- a/src/lisp/regression-tests/printer01.lisp
+++ b/src/lisp/regression-tests/printer01.lisp
@@ -1,0 +1,14 @@
+(in-package #:clasp-tests)
+
+(test print-1
+      (string=
+       "-1"
+       (LET ((*PRINT-BASE* 16))
+         (WITH-OUTPUT-TO-STRING (*STANDARD-OUTPUT*) (write -1)))))
+
+
+
+
+  
+
+

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -29,6 +29,7 @@
 (load (compile-file "sys:regression-tests;hash-tables0.lisp"))
 (load (compile-file "sys:regression-tests;misc.lisp"))
 (load (compile-file "sys:regression-tests;read01.lisp"))
+(load (compile-file "sys:regression-tests;printer01.lisp"))
 (load (compile-file "sys:regression-tests;streams01.lisp"))
 
 (progn


### PR DESCRIPTION
Fixes #605 
Test:
```lisp
(test print-1
      (string=
       "-1"
       (LET ((*PRINT-BASE* 16))
         (WITH-OUTPUT-TO-STRING (*STANDARD-OUTPUT*) (write -1)))))
````