### PR TITLE
Fix #608 (except for cerror) by fixing the declaration and returning nil

### DIFF
--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -146,8 +146,8 @@ Pathname_sp clasp_input_pathname(T_sp strm);
 /*! Return the filename of the stream if possible, error if errorp=true and no name can be determined */
 T_sp clasp_filename(T_sp strm, bool errorp = false);
 
- void cl__unread_char(Character_sp ch, T_sp dstrm);
-  T_sp cl__get_output_stream_string(T_sp strm);
+T_sp cl__unread_char(Character_sp ch, T_sp dstrm);
+T_sp cl__get_output_stream_string(T_sp strm);
 
 T_sp clasp_file_length(T_sp strm);
 T_sp clasp_file_position(T_sp strm);

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -5766,9 +5766,10 @@ void clasp_terpri(T_sp s) {
 CL_LAMBDA(&optional output-stream);
 CL_DECLARE();
 CL_DOCSTRING("Send a newline to the output stream");
-CL_DEFUN void cl__terpri(T_sp outputStreamDesig) {
+CL_DEFUN T_sp cl__terpri(T_sp outputStreamDesig) {
   // outputStreamDesign in clasp_terpri
   clasp_terpri(outputStreamDesig);
+  return _Nil<T_O>();
 };
 
 bool clasp_freshLine(T_sp s) {
@@ -5868,17 +5869,19 @@ CL_DEFUN Character_sp cl__write_char(Character_sp chr, T_sp stream) {
 CL_LAMBDA(&optional dstrm);
 CL_DECLARE();
 CL_DOCSTRING("clearInput");
-CL_DEFUN void cl__clear_input(T_sp dstrm) {
+CL_DEFUN T_sp cl__clear_input(T_sp dstrm) {
   dstrm = coerce::inputStreamDesignator(dstrm);
   clasp_clear_input(dstrm);
+  return _Nil<T_O>();
 }
 
 CL_LAMBDA(&optional dstrm);
 CL_DECLARE();
 CL_DOCSTRING("clearOutput");
-CL_DEFUN void cl__clear_output(T_sp dstrm) {
+CL_DEFUN T_sp cl__clear_output(T_sp dstrm) {
   dstrm = coerce::outputStreamDesignator(dstrm);
   clasp_clear_output(dstrm);
+  return _Nil<T_O>();
 }
 
 CL_LAMBDA(&optional dstrm);
@@ -5895,25 +5898,28 @@ CL_DEFUN bool cl__listen(T_sp strm) {
 CL_LAMBDA(&optional strm);
 CL_DECLARE();
 CL_DOCSTRING("force_output");
-CL_DEFUN void cl__force_output(T_sp ostrm) {
+CL_DEFUN T_sp cl__force_output(T_sp ostrm) {
   ostrm = coerce::outputStreamDesignator(ostrm);
   clasp_force_output(ostrm);
+  return _Nil<T_O>();
 };
 
 CL_LAMBDA(&optional strm);
 CL_DECLARE();
 CL_DOCSTRING("finish_output");
-CL_DEFUN void cl__finish_output(T_sp ostrm) {
+CL_DEFUN T_sp cl__finish_output(T_sp ostrm) {
   ostrm = coerce::outputStreamDesignator(ostrm);
   clasp_finish_output(ostrm);
+  return _Nil<T_O>();
 };
 
 CL_LAMBDA(char &optional strm);
 CL_DECLARE();
 CL_DOCSTRING("unread_char");
-CL_DEFUN void cl__unread_char(Character_sp ch, T_sp dstrm) {
+CL_DEFUN T_sp cl__unread_char(Character_sp ch, T_sp dstrm) {
   dstrm = coerce::inputStreamDesignator(dstrm);
   clasp_unread_char(clasp_as_claspCharacter(ch), dstrm);
+  return _Nil<T_O>();
 };
 
 CL_LAMBDA(arg);


### PR DESCRIPTION
Fixes #608 

Cerror does not seem to be fixable so easy, since that calls universal-error-handler that supposedly never returns.

Tested via streams-test of ansi-tests