### PR TITLE
Respect *print-level* better in print-object for structure

### DIFF
--- a/src/lisp/kernel/clos/print.lsp
+++ b/src/lisp/kernel/clos/print.lsp
@@ -186,11 +186,13 @@ printer and we should rather use MAKE-LOAD-FORM."
 (defmethod print-object ((obj structure-object) stream)
   (let* ((class (si:instance-class obj))
 	 (slotds (class-slots class)))
-    (when (and slotds
-               ;; *p-readably* effectively disables *p-level*
-	       (not *print-readably*)
-	       *print-level*
-	       (zerop *print-level*))
+    (when (and ;; to fix ansi-tests PRINT-LEVEL.8 & PRINT-LEVEL.9
+           ;; printing a struct w/o slots
+           ;; don't test for slotds
+           ;; *p-readably* effectively disables *p-level*
+           (not *print-readably*)
+           *print-level*
+           (zerop *print-level*))
       (write-string "#" stream)
       (return-from print-object obj))
     (write-string "#S(" stream)
@@ -211,7 +213,10 @@ printer and we should rather use MAKE-LOAD-FORM."
                         (load-time-value (find-package "KEYWORD")))))
         (prin1 kw stream))
       (write-string " " stream)
-      (prin1 sv stream))
+      (if *print-level*
+          (let ((*print-level* (1- *print-level*)))
+            (prin1 sv stream))
+          (prin1 sv stream)))
     (write-string ")" stream)
     obj))
 


### PR DESCRIPTION
- if print-level = 0 behave for (destruct test) as for (defstruct test a)
- Decrement *print-level* in printing the slot-values
- complements #611