### PR TITLE
Have arrays print more ansi-like. 

### DIFF
--- a/include/clasp/core/array_double.h
+++ b/include/clasp/core/array_double.h
@@ -64,6 +64,7 @@ namespace core {
     virtual T_sp element_type() const override { return cl::_sym_double_float;};
     virtual T_sp arrayElementType() const override { return cl::_sym_double_float; };
     virtual clasp_elttype elttype() const { return clasp_aet_df; };
+    virtual void __write__(T_sp stream) const;
   public: // Provide the API that I used for NVector_sp
     static SimpleVectorDouble_sp create(size_t sz) {
       return make(sz,0.0,false,0,NULL);

--- a/include/clasp/core/array_fixnum.h
+++ b/include/clasp/core/array_fixnum.h
@@ -56,6 +56,7 @@ namespace core {
     virtual T_sp element_type() const override { return cl::_sym_fixnum;};
     virtual T_sp arrayElementType() const override { return cl::_sym_fixnum; };
     virtual clasp_elttype elttype() const { return clasp_aet_fix; };
+    virtual void __write__(T_sp stream) const;
   };
 };
 

--- a/include/clasp/core/array_float.h
+++ b/include/clasp/core/array_float.h
@@ -64,6 +64,7 @@ namespace core {
     virtual T_sp element_type() const override { return cl::_sym_single_float;};
     virtual T_sp arrayElementType() const override { return cl::_sym_single_float; };
     virtual clasp_elttype elttype() const { return clasp_aet_sf; };
+    virtual void __write__(T_sp stream) const;
   };
 };
 

--- a/include/clasp/core/array_int16.h
+++ b/include/clasp/core/array_int16.h
@@ -55,6 +55,7 @@ namespace core {
     virtual T_sp element_type() const override { return ext::_sym_byte16;};
     virtual T_sp arrayElementType() const override { return ext::_sym_byte16; };
     virtual clasp_elttype elttype() const { return clasp_aet_byte16_t; };
+    virtual void __write__(T_sp stream) const;
   };
 };
 

--- a/include/clasp/core/array_int32.h
+++ b/include/clasp/core/array_int32.h
@@ -55,6 +55,7 @@ namespace core {
     virtual T_sp element_type() const override { return ext::_sym_byte32;};
     virtual T_sp arrayElementType() const override { return ext::_sym_byte32; };
     virtual clasp_elttype elttype() const { return clasp_aet_byte32_t; };
+    virtual void __write__(T_sp stream) const;
   };
 };
 
@@ -212,6 +213,7 @@ namespace core {
     virtual T_sp element_type() const override { return ext::_sym_integer32;};
     virtual T_sp arrayElementType() const override { return ext::_sym_integer32; };
     virtual clasp_elttype elttype() const { return clasp_aet_int32_t; };
+    virtual void __write__(T_sp stream) const;
   };
 };
 

--- a/include/clasp/core/array_int64.h
+++ b/include/clasp/core/array_int64.h
@@ -55,6 +55,7 @@ namespace core {
     virtual T_sp element_type() const override { return ext::_sym_byte64;};
     virtual T_sp arrayElementType() const override { return ext::_sym_byte64; };
     virtual clasp_elttype elttype() const { return clasp_aet_byte64_t; };
+    virtual void __write__(T_sp stream) const;
   };
 };
 
@@ -212,6 +213,7 @@ namespace core {
     virtual T_sp element_type() const override { return ext::_sym_integer64;};
     virtual T_sp arrayElementType() const override { return ext::_sym_integer64; };
     virtual clasp_elttype elttype() const { return clasp_aet_int64_t; };
+    virtual void __write__(T_sp stream) const;
   };
 };
 

--- a/include/clasp/core/array_int8.h
+++ b/include/clasp/core/array_int8.h
@@ -213,6 +213,7 @@ namespace core {
     virtual T_sp element_type() const override { return ext::_sym_integer8;};
     virtual T_sp arrayElementType() const override { return ext::_sym_integer8; };
     virtual clasp_elttype elttype() const { return clasp_aet_int8_t; };
+    virtual void __write__(T_sp stream) const;
   };
 };
 

--- a/include/clasp/core/write_ugly.h
+++ b/include/clasp/core/write_ugly.h
@@ -36,6 +36,7 @@ namespace core {
 void write_fixnum(T_sp strm, T_sp i);
 T_sp write_ugly_object(T_sp x, T_sp stream);
 void _clasp_write_fixnum(gc::Fixnum i, T_sp stream);
+void write_float(Float_sp f, T_sp stream);
 
 };
 #endif

--- a/src/core/write_array.cc
+++ b/src/core/write_array.cc
@@ -150,6 +150,7 @@ namespace core {
 	    write_array_inner(0, this->asSmartPtr(), stream);
 	}
     }
+    
     void SimpleVector_O::__write__(T_sp stream) const {
 	if (this->rank() == 0) {
 	    writestr_stream("#0A0", stream);
@@ -188,13 +189,15 @@ namespace core {
 	} else {
 	    cl_index ndx;
 	    writestr_stream("#*", stream);
-	    for (ndx=0; ndx<this->length(); ++ndx)
-		//      if (x->vector.self.bit[(ndx /*+ x->vector.offset*/) / 8] & (0200 >> (ndx /*+ x->vector.offset*/) % 8))
-		if (this->testBit(ndx))
-		    clasp_write_char('1', stream);
-		else
-		    clasp_write_char('0', stream);
-	}
+	    if (clasp_print_array()) {
+	    	for (ndx=0; ndx<this->length(); ++ndx)
+			//      if (x->vector.self.bit[(ndx /*+ x->vector.offset*/) / 8] & (0200 >> (ndx /*+ x->vector.offset*/) % 8))
+			if (this->testBit(ndx))
+		    	clasp_write_char('1', stream);
+			else
+		    	clasp_write_char('0', stream);
+		    	}
+		}	
     }
 
     void BitVector_O::__write__(T_sp stream) const {
@@ -205,36 +208,154 @@ namespace core {
 	} else {
 	    cl_index ndx;
 	    writestr_stream("#*", stream);
-	    for (ndx = 0; ndx < this->length(); ndx++)
-		//      if (x->vector.self.bit[(ndx /*+ x->vector.offset*/) / 8] & (0200 >> (ndx /*+ x->vector.offset*/) % 8))
-		if (this->testBit(ndx))
-		    clasp_write_char('1', stream);
-		else
-		    clasp_write_char('0', stream);
-	}
+	    if  (clasp_print_array()) {
+	    	for (ndx = 0; ndx < this->length(); ndx++)
+			//      if (x->vector.self.bit[(ndx /*+ x->vector.offset*/) / 8] & (0200 >> (ndx /*+ x->vector.offset*/) % 8))
+			if (this->testBit(ndx))
+		    	clasp_write_char('1', stream);
+			else
+		    	clasp_write_char('0', stream);
+		    }
+		}
     }
 
-    void SimpleVector_byte8_t_O::__write__(T_sp stream) const {
-            writestr_stream("#<SIMPLE-VECTOR-BYTE8-T ", stream);
+    static void write_simple_vector_simple (const char *title, Array_sp x, T_sp stream) {
+            writestr_stream(title, stream);
             SafeBufferStr8Ns buffer;
             clasp_write_string(" length:",stream);
             stringstream slen;
-            slen << this->length();
+            slen << x->length();
             clasp_write_characters(slen.str().c_str(),slen.str().size(),stream);
-            clasp_write_string(" data: ",stream);
-            int print_base = clasp_print_base();
-            for (size_t ndx=0; ndx<this->length(); ++ndx) {
-                    core__integer_to_string(buffer._Buffer, clasp_make_fixnum((*this)[ndx]),
-                                            make_fixnum(print_base),
-                                            cl::_sym_STARprint_radixSTAR->symbolValue().isTrue(),
-                                            true);
-                    cl__write_sequence(buffer._Buffer,stream,make_fixnum(0),_Nil<T_O>());
-                    clasp_write_string(" ",stream);
-                    buffer._Buffer->fillPointerSet(0);
+            if  (clasp_print_array()) {
+                    clasp_write_string(" data: ",stream);
+                    int print_base = clasp_print_base();
+                    for (size_t ndx=0; ndx<x->length(); ++ndx) {
+                            core__integer_to_string(buffer._Buffer, clasp_make_fixnum(x->rowMajorAref(ndx)),
+                                                    make_fixnum(print_base),
+                                                    cl::_sym_STARprint_radixSTAR->symbolValue().isTrue(),
+                                                    true);
+                            cl__write_sequence(buffer._Buffer,stream,make_fixnum(0),_Nil<T_O>());
+                            clasp_write_string(" ",stream);
+                            buffer._Buffer->fillPointerSet(0);
+                    }
             }
             clasp_write_string(">",stream);
     }
 
+    static void write_simple_vector_simple_float (const char *title, Array_sp x, T_sp stream) {
+            writestr_stream(title, stream);
+            clasp_write_string(" length:",stream);
+            stringstream slen;
+            slen << x->length();
+            clasp_write_characters(slen.str().c_str(),slen.str().size(),stream);
+            if (clasp_print_array()) {
+                    clasp_write_string(" data: ",stream);
+                    for (size_t ndx=0; ndx<x->length(); ++ndx) {
+                            write_float(x->rowMajorAref(ndx), stream);
+                            clasp_write_string(" ",stream);
+                    }
+            }
+            clasp_write_string(">",stream);
+    }
+    
+    void SimpleVector_byte8_t_O::__write__(T_sp stream) const {
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    const char *title = "#<SIMPLE-VECTOR-BYTE8-T ";
+                    write_simple_vector_simple(title, this->asSmartPtr(), stream);
+            }
+            else
+                    write_array_inner(true, this->asSmartPtr(), stream);
+
+    }
+
+    void SimpleVector_byte16_t_O::__write__(T_sp stream) const {
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    const char *title = "#<SimpleVector_byte16_t_O>";
+                    write_simple_vector_simple(title, this->asSmartPtr(), stream);
+            }
+            else 
+                    write_array_inner(true, this->asSmartPtr(), stream);
+    }
+
+    void SimpleVector_byte32_t_O::__write__(T_sp stream) const {
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    const char *title = "#<SimpleVector_byte32_t_O>";
+                    write_simple_vector_simple(title, this->asSmartPtr(), stream);
+             }
+            else
+                    write_array_inner(true, this->asSmartPtr(), stream);
+    }
+
+    void SimpleVector_byte64_t_O::__write__(T_sp stream) const {
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    const char *title = "#<SimpleVector_byte64_t_O>";
+                    write_simple_vector_simple(title, this->asSmartPtr(), stream);
+            }
+            else
+                    write_array_inner(true, this->asSmartPtr(), stream);
+    }
+
+    void   SimpleVector_fixnum_O::__write__(T_sp stream) const {
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    const char *title = "#<SimpleVector_fixnum_O>";
+                    write_simple_vector_simple(title, this->asSmartPtr(), stream);
+            }
+            else write_array_inner(true, this->asSmartPtr(), stream);
+    }
+
+    void SimpleVector_int8_t_O::__write__(T_sp stream) const {
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    const char *title = "#<SimpleVector_int8_t_O>";
+                    write_simple_vector_simple(title, this->asSmartPtr(), stream);
+            }
+            else
+                    write_array_inner(true, this->asSmartPtr(), stream);
+    }
+
+    void SimpleVector_int16_t_O::__write__(T_sp stream) const {
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    const char *title = "#<SimpleVector_int16_t_O>";
+                    write_simple_vector_simple(title, this->asSmartPtr(), stream);
+            }
+            else
+                    write_array_inner(true, this->asSmartPtr(), stream);
+    }
+
+    void SimpleVector_int32_t_O::__write__(T_sp stream) const {
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    const char *title = "#<SimpleVector_int32_t_O>";
+                    write_simple_vector_simple(title, this->asSmartPtr(), stream);
+            }
+            else
+                    write_array_inner(true, this->asSmartPtr(), stream);
+    }
+
+    void SimpleVector_int64_t_O::__write__(T_sp stream) const {
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    const char *title ="#<SimpleVector_int64_t_O>";
+                    write_simple_vector_simple(title, this->asSmartPtr(), stream);
+            }
+            else
+                    write_array_inner(true, this->asSmartPtr(), stream);
+    }
+
+    void SimpleVectorFloat_O::__write__(T_sp stream) const {
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    const char *title ="#<SimpleVectorFloat_O>";
+                    write_simple_vector_simple_float(title, this->asSmartPtr(), stream);
+            }
+            else
+                    write_array_inner(true, this->asSmartPtr(), stream);
+    }
+
+    void SimpleVectorDouble_O::__write__(T_sp stream) const {
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    const char *title ="#<SimpleVectorDouble_O>";
+                    write_simple_vector_simple_float(title, this->asSmartPtr(), stream);
+             }
+            else 
+                    write_array_inner(true, this->asSmartPtr(), stream);
+    }
     
     void unsafe_write_SimpleBaseString(SimpleBaseString_sp str, size_t start, size_t end, T_sp stream) {
 	cl_index ndx;
@@ -263,7 +384,7 @@ namespace core {
 	} else {
 	    clasp_write_char('"', stream);
 	    for (ndx = start; ndx < end; ndx++) {
-		char c = (*str)[ndx];
+		claspCharacter c = (*str)[ndx];
 		if (c == '"' || c == '\\')
 		    clasp_write_char('\\', stream);
 		clasp_write_char((*str)[ndx],stream);
@@ -271,6 +392,7 @@ namespace core {
 	    clasp_write_char('"', stream);
 	}
     }
+    
     void SimpleBaseString_O::__write__(T_sp stream) const {
 	unsafe_write_SimpleBaseString(this->asSmartPtr(),0,this->length(),stream);
     }
@@ -282,9 +404,11 @@ namespace core {
 	SimpleBaseString_sp sb = gc::As<SimpleBaseString_sp>(str);
 	unsafe_write_SimpleBaseString(sb,start,end,stream);
     }
+    
     void SimpleCharacterString_O::__write__(T_sp stream) const {
 	unsafe_write_SimpleCharacterString(this->asSmartPtr(),0,this->length(),stream);
     }
+    
     void StrWNs_O::__write__(T_sp stream) const {
 	size_t start, end;
 	AbstractSimpleVector_sp str;

--- a/src/lisp/regression-tests/printer01.lisp
+++ b/src/lisp/regression-tests/printer01.lisp
@@ -6,6 +6,151 @@
        (LET ((*PRINT-BASE* 16))
          (WITH-OUTPUT-TO-STRING (*STANDARD-OUTPUT*) (write -1)))))
 
+(test print-1a
+      (string=
+       "-2000000000000000"
+       (LET ((*PRINT-BASE* 16))
+         (WITH-OUTPUT-TO-STRING (*STANDARD-OUTPUT*)
+           (write most-negative-fixnum)))))
+
+(test print-2
+      (null
+       (multiple-value-list
+        (pprint 23))))
+
+(test print-3
+      (equal '(nil)
+             (MULTIPLE-VALUE-LIST
+              (PRINT-UNREADABLE-OBJECT (nil t)))))
+
+(test print-4
+      (= 10
+         (let ((*package* (find-package "COMMON-LISP-USER"))
+               (*print-array* t)
+               (*print-base* 10)
+               (*print-case* :upcase)
+               (*print-circle* nil)
+               (*print-escape* t)
+               (*print-gensym* t)
+               (*print-length* nil)
+               (*print-level* nil)
+               (*print-lines* nil)
+               (*print-miser-width* nil)
+               (*print-pretty* nil)
+               (*print-radix* nil)
+               (*print-readably* t)
+               (*print-right-margin* nil)
+               (*read-base* 10)
+               (*read-default-float-format* 'single-float)
+               (*read-eval* t)
+               (*read-suppress* nil)
+               )
+           (let ((*print-pretty* t)
+                 (*print-readably* nil)
+                 (obj (vector nil nil)))
+             (length (write-to-string obj))))))
+
+(test print-5
+      (string= "#()"
+               (WRITE-TO-STRING
+                (MAKE-ARRAY '(4)
+                            :INITIAL-CONTENTS
+                            '(0 1 2 3)
+                            :ELEMENT-TYPE
+                            '(UNSIGNED-BYTE 2)
+                            :FILL-POINTER
+                            0)
+                :READABLY NIL :ARRAY T :PRETTY NIL)))
+
+;;; fails to write readably
+;;; http://www.lispworks.com/documentation/HyperSpec/Body/t_rnd_st.htm#random-state
+;;; It can be printed out and successfully read back in by the same implementation, 
+;;; Implementations are required to provide a read syntax for objects of type random-state,
+;;; but the specific nature of that syntax is implementation-dependent.
+;;; this would work
+;;; (CORE:RANDOM-STATE-set *random-state* (CORE:RANDOM-STATE-GET *random-state*))
+;;; So we perhaps need a reader-macro for random-state
+
+(test print-read-1
+      (read-from-string (WRITE-TO-STRING (MAKE-RANDOM-STATE *RANDOM-STATE*) :READABLY T)))
+
+(test print-all-array-types
+      (let ((arrays
+             (list
+        ;;; MDArray_O?
+              (MAKE-ARRAY (list 2 2) :INITIAL-CONTENTS '((0 1)(1 0)) :ELEMENT-TYPE t)
+        ;;; SimpleVector_O
+              (vector 1 2 3)
+        ;;;BitVector_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0 1)
+                          :adjustable t
+                          :ELEMENT-TYPE 'bit)
+        ;;; SIMPLE-VECTOR-BYTE8-T
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0 1)
+                          :ELEMENT-TYPE '(integer 0 4))
+        ;;; SimpleVector_byte16_t_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0 1)
+                          :ELEMENT-TYPE '(integer 0 300))
+        ;;; SimpleVector_byte32_t_O>
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0 1)
+                          :ELEMENT-TYPE (list 'integer 0 (1+ (* 256 256))))
+        ;;;SimpleVector_byte64_t_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0 1)
+                          :ELEMENT-TYPE (list 'integer 0 (1+ most-positive-fixnum)))
+        ;;; SimpleVector_fixnum_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0 1)
+                          :ELEMENT-TYPE (list 'integer 0 most-positive-fixnum))
+        ;;; SimpleVector_int8_t_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0 1)
+                          :ELEMENT-TYPE (list 'integer -8 8))
+        ;;; SimpleVector_int16_t_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0 1)
+                          :ELEMENT-TYPE (list 'integer -257 257))
+        ;;; SimpleVector_int32_t_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0 1)
+                          :ELEMENT-TYPE (list 'integer (- (expt 2 17)) (expt 2 17)))
+        ;;; SimpleVector_int64_t_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0 1)
+                          :ELEMENT-TYPE (list 'integer (- (expt 2 31)) (1+ most-positive-fixnum)))
+        ;;; SimpleVector_fixnum
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0 1)
+                          :ELEMENT-TYPE (list 'integer (- (expt 2 31)) (expt 2 31)))
+        ;;; SimpleVectorFloat_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0.0 1.0)
+                          :ELEMENT-TYPE 'single-float)
+        ;;;SimpleVectorDouble_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS '(0.0d0 1.0d0)
+                          :ELEMENT-TYPE 'double-float)
+        ;;; SimpleCharacterString_O or SimpleBaseString_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS (list (code-char 65) (code-char 66))
+                          :ELEMENT-TYPE 'base-char)
+        ;;; Str8Ns_O or StrWNs_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS
+                          (list (code-char 256) (code-char 256))
+                          :ELEMENT-TYPE
+                          'character
+                          ))))
+        (dolist (array arrays t)
+          (print (write-to-string array :READABLY nil :ARRAY nil :PRETTY NIL))
+          (print (write-to-string array :READABLY nil :ARRAY t :PRETTY NIL))
+          #+(or)(print (write-to-string array :READABLY t :ARRAY nil :PRETTY NIL))
+          (print (write-to-string array :READABLY t :ARRAY t :PRETTY NIL))
+          (format t "~%"))))
 
 
 


### PR DESCRIPTION
Need to fix in a bunch of places because of templated-arrays:
- define __write__ in every templated array type
- check *print-array* before actually printing the array 
- provide reusable write_simple_vector_simple &  write_simple_vector_simple_float
- use the in every templated array
- fix char vs claspCharacter error (to make clasp more unicode safe)
- test all