### PR TITLE
Fix read-byte, write-byte and read-line

### DIFF
--- a/src/core/designators.cc
+++ b/src/core/designators.cc
@@ -247,9 +247,7 @@ T_sp inputStreamDesignator(T_sp obj) {
   } else if (cl__streamp(obj)) {
     return obj;
   }
-  // kpoeck
-  // SIMPLE_ERROR(BF("Cannot convert object[%s] into a Stream") % _rep_(obj));
-  TYPE_ERROR(obj, cl::_sym_streamError);
+  TYPE_ERROR(obj, cl::_sym_Stream_O);
 }
 
 T_sp outputStreamDesignator(T_sp obj) {
@@ -260,9 +258,7 @@ T_sp outputStreamDesignator(T_sp obj) {
   } else if (cl__streamp(obj)) {
     return obj;
   }
-  // kpoeck
-  // SIMPLE_ERROR(BF("Cannot convert object[%s] into a Stream") % _rep_(obj));
-  TYPE_ERROR(obj, cl::_sym_streamError);
+  TYPE_ERROR(obj, cl::_sym_Stream_O);
 }
 
 

--- a/src/lisp/regression-tests/printer01.lisp
+++ b/src/lisp/regression-tests/printer01.lisp
@@ -134,23 +134,42 @@
               (MAKE-ARRAY 2
                           :INITIAL-CONTENTS '(0.0d0 1.0d0)
                           :ELEMENT-TYPE 'double-float)
-        ;;; SimpleCharacterString_O or SimpleBaseString_O
+        ;;; SimpleBaseString_O
               (MAKE-ARRAY 2
                           :INITIAL-CONTENTS (list (code-char 65) (code-char 66))
                           :ELEMENT-TYPE 'base-char)
-        ;;; Str8Ns_O or StrWNs_O
+        ;;; Str8Ns_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS (list (code-char 65) (code-char 66))
+                          :adjustable t
+                          :ELEMENT-TYPE 'base-char)
+        ;;;  SimpleCharacterString_O
               (MAKE-ARRAY 2
                           :INITIAL-CONTENTS
                           (list (code-char 256) (code-char 256))
-                          :ELEMENT-TYPE
-                          'character
-                          ))))
+                          :ELEMENT-TYPE 'character)
+        ;;;  StrWNs_O
+              (MAKE-ARRAY 2
+                          :INITIAL-CONTENTS
+                          (list (code-char 256) (code-char 256))
+                          :adjustable t
+                          :ELEMENT-TYPE 'character)
+              )))
         (dolist (array arrays t)
           (print (write-to-string array :READABLY nil :ARRAY nil :PRETTY NIL))
           (print (write-to-string array :READABLY nil :ARRAY t :PRETTY NIL))
           #+(or)(print (write-to-string array :READABLY t :ARRAY nil :PRETTY NIL))
           (print (write-to-string array :READABLY t :ARRAY t :PRETTY NIL))
           (format t "~%"))))
+
+
+(test-expect-error print-6 (write-byte) :type program-error)
+(test-expect-error print-7 (write-byte 233 nil) :type type-error)
+(test-expect-error print-8 (write-byte 233 t) :type type-error)
+(test-expect-error print-9 (write-byte 233 23) :type type-error)
+(test-expect-error print-10
+                   (with-output-to-string (*standard-output*)
+                     (write-byte 23 *standard-output*)) :type type-error)
 
 
 

--- a/src/lisp/regression-tests/read01.lisp
+++ b/src/lisp/regression-tests/read01.lisp
@@ -33,6 +33,21 @@
 (test-expect-error read-6 (READ-FROM-STRING ",") :type reader-error)
 (test-expect-error read-7 (READ-FROM-STRING "#)" NIL NIL) :type reader-error)
 
+(test read-8
+      (let ((wide-string (make-string 4 :initial-element (code-char 256))))
+        (string= wide-string
+                 (with-input-from-string (stream wide-string)
+                   (read-line stream)))))
+
+(test-expect-error read-9 (read-byte) :type PROGRAM-ERROR)
+(test-expect-error read-10 (read-byte nil) :type type-error)
+(test-expect-error read-11 (read-byte t) :type type-error)
+(test-expect-error read-12 (read-byte 23) :type type-error)
+(test-expect-error read-13
+                   (with-input-from-string (strm "wq12351523765127635765232")
+                     (read-byte strm))
+                   :type type-error)
+
 
   
 


### PR DESCRIPTION
Fix for
* read-byte (stream is not optional, not using stream designators)
* write-byte not using stream designators
* read-line to work with wide strings

Regression tests in the fix, Ansi-tests rerun for verification