### PR TITLE
allow :\. to be read (mcclim)

### DIFF
--- a/src/core/lispReader.cc
+++ b/src/core/lispReader.cc
@@ -787,7 +787,8 @@ T_sp interpret_token_or_throw_reader_error(T_sp sin, Token &token, bool only_dot
       return _Nil<T_O>();
     // interpret good keywords
     LOG_READ(BF("Token[%s] interpreted as keyword") % name_marker);
-    SimpleString_sp keyword_name = symbolTokenStr(sin,token, name_marker - token.data(),token.size(),only_dots_ok);
+    // :\. is a valid keyword symbol, so allow only dots here
+    SimpleString_sp keyword_name = symbolTokenStr(sin,token, name_marker - token.data(),token.size(),true);
     return _lisp->keywordPackage()->intern(keyword_name);
   } break;
   case tsymk:{

--- a/src/lisp/regression-tests/read01.lisp
+++ b/src/lisp/regression-tests/read01.lisp
@@ -48,6 +48,10 @@
                      (read-byte strm))
                    :type type-error)
 
+;;; used to error with A string of dots was encountered by the reader.
+(test error-mcclim-1
+      (list :\.))
+
 
   
 


### PR DESCRIPTION
now:
```lisp
COMMON-LISP-USER> (list :\.)
(:|.|)
````
before:
A string of dots was encountered by the reader.