### PR TITLE
Fix gensym for nil, bignums and negative numbers + tests

### DIFF
--- a/src/lisp/regression-tests/symbol0.lisp
+++ b/src/lisp/regression-tests/symbol0.lisp
@@ -23,3 +23,42 @@
                    (let ((foo 23))
                      (makunbound 23))
                    :type type-error)
+                   
+(test-expect-error gensym-2
+                   (gensym -1)
+                   :type type-error)
+
+(test-expect-error gensym-3
+                   (gensym (1- most-negative-fixnum))
+                   :type type-error)
+
+(test-expect-error gensym-4
+                   (gensym 'defun)
+                   :type type-error)
+
+(test gensym-5 (gensym (+ most-positive-fixnum  most-positive-fixnum)))
+
+(test gensym-6
+      (let ((bignum 12345678901234567890123456789012345678901234567890))
+        (= (1+ bignum)
+           (LET ((*GENSYM-COUNTER* bignum))
+             (GENSYM)
+             *GENSYM-COUNTER*))))
+
+(test gensym-7
+      (= (1+ most-positive-fixnum)
+         (let ((*gensym-counter* most-positive-fixnum))
+           (gensym)
+           *gensym-counter*)))
+
+(test-expect-error gensym-8
+                   (let ((*gensym-counter* -1))
+                     (gensym)
+                     *gensym-counter*))
+
+(test-expect-error gensym-9
+                   (let ((*gensym-counter* (1- most-negative-fixnum)))
+                     (gensym)
+                     *gensym-counter*))
+      
+


### PR DESCRIPTION
See src/lisp/regression-tests/symbol0.lisp for what is being fixed.

Now no errors for symbols in pfdietz ansi-tests