### PR TITLE
Fix expected type in type-error for fmakunbound

### DIFF
--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -1018,7 +1018,10 @@ CL_DEFUN T_mv cl__fmakunbound(T_sp functionName) {
     sym->fmakunbound();
     return (Values(sym));
   }
-  TYPE_ERROR(functionName,cl::_sym_function);
+  TYPE_ERROR(functionName, // type of function names
+             Cons_O::createList(cl::_sym_or, cl::_sym_symbol,
+                                Cons_O::createList(cl::_sym_cons,
+                                                   Cons_O::createList(cl::_sym_eql, cl::_sym_setf))));
 }
 
 CL_LAMBDA(char &optional input-stream-designator recursive-p);


### PR DESCRIPTION
e.g. (fmakunbound #'car)
error complained about #'car not being a function which is wrong.
Now:
```lisp
COMMON-LISP-USER> (fmakunbound #'car)
Condition of type: TYPE-ERROR
#<FUNCTION CAR> is not of type (OR SYMBOL (CONS (EQL SETF))).
````