### PR TITLE
Fix some subtypep ansi-tests, added regression-tests

### DIFF
--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -1539,9 +1539,12 @@ T_sp type_of(T_sp x) {
   } else if (x.valistp() ) {
     return core::_sym_valist;
   } else if (x.characterp()) {
-    if (cl__standard_char_p(gc::As<Character_sp>(x)))
+    Character_sp character = gc::As<Character_sp>(x);
+    if (cl__standard_char_p(character))
       return cl::_sym_standard_char;
-    return cl::_sym_character;
+    else if (clasp_base_char_p(character))
+      return cl::_sym_base_char;
+    else return cl::_sym_character;
   } else if (Integer_sp ix = x.asOrNull<Integer_O>()) {
     ql::list res;
     res << cl::_sym_integer << ix << ix;

--- a/src/lisp/kernel/lsp/predlib.lsp
+++ b/src/lisp/kernel/lsp/predlib.lsp
@@ -1089,11 +1089,16 @@ if not possible."
       (PACKAGE)
       (COMPILED-FUNCTION)
       (FUNCTION (OR COMPILED-FUNCTION GENERIC-FUNCTION))
+      ;;; backported from ecl
+      (FIXNUM (INTEGER #.most-negative-fixnum #.most-positive-fixnum))
+      (BIGNUM (OR (INTEGER * (#.most-negative-fixnum)) (INTEGER (#.most-positive-fixnum) *)))
       
       (INTEGER (INTEGER * *))
+      ;;; the type need to exist, even if short-float is equal to single-float
+      (SHORT-FLOAT (SHORT-FLOAT * *))
       (SINGLE-FLOAT (SINGLE-FLOAT * *))
       (DOUBLE-FLOAT (DOUBLE-FLOAT * *))
-      #+long-float
+      ;;; the type need to exist, even if long-float is equal to double-float
       (LONG-FLOAT (LONG-FLOAT * *))
       (RATIO (RATIO * *))
       
@@ -1190,11 +1195,12 @@ if not possible."
       (SYNONYM-STREAM)
       (TWO-WAY-STREAM)
       (EXT:SEQUENCE-STREAM)
+      ;;; backported from ecl
       (EXT:ANSI-STREAM (OR BROADCAST-STREAM CONCATENATED-STREAM ECHO-STREAM
                         FILE-STREAM STRING-STREAM SYNONYM-STREAM TWO-WAY-STREAM
-                        EXT:SEQUENCE-STREAM
-                        #+clos-streams GRAY:FUNDAMENTAL-STREAM))
-      (STREAM EXT:ANSI-STREAM)
+                        EXT:SEQUENCE-STREAM))
+      #+clos-streams (GRAY:FUNDAMENTAL-STREAM)
+      (STREAM (OR EXT:ANSI-STREAM #+clos-streams GRAY:FUNDAMENTAL-STREAM))
 
       (READTABLE)
       #+threads (MP::PROCESS)

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -32,6 +32,7 @@
 (load-if-compiled-correctly "sys:regression-tests;read01.lisp")
 (load-if-compiled-correctly "sys:regression-tests;printer01.lisp")
 (load-if-compiled-correctly "sys:regression-tests;streams01.lisp")
+(load-if-compiled-correctly "sys:regression-tests;types01.lisp")
 (load-if-compiled-correctly "sys:regression-tests;loop.lisp")
 
 (progn

--- a/src/lisp/regression-tests/types01.lisp
+++ b/src/lisp/regression-tests/types01.lisp
@@ -1,0 +1,57 @@
+(in-package #:clasp-tests)
+
+(TEST
+ types-classes-1
+ (multiple-value-bind
+       (subtype-p valid-p)
+     (subtypep 'fixnum (find-class 'fixnum))
+   (and subtype-p valid-p)))
+
+(TEST
+ types-classes-2
+ (multiple-value-bind
+       (subtype-p valid-p)
+     (subtypep (find-class 'fixnum) 'fixnum)
+   (and subtype-p valid-p)))
+
+(TEST
+ types-classes-3
+ (multiple-value-bind
+       (subtype-p valid-p)
+     (subtypep 'bignum (find-class 'bignum))
+   (and subtype-p valid-p)))
+
+(TEST
+ types-classes-4
+ (multiple-value-bind
+       (subtype-p valid-p)
+     (subtypep (find-class 'bignum) 'bignum)
+   (and subtype-p valid-p)))
+
+(TEST
+ types-classes-5
+ (multiple-value-bind
+       (subtype-p valid-p)
+     (subtypep 'long-float (find-class 'long-float))
+   (and subtype-p valid-p)))
+
+(TEST
+ types-classes-6
+ (multiple-value-bind
+       (subtype-p valid-p)
+     (subtypep (find-class 'long-float) 'long-float)
+   (and subtype-p valid-p)))
+
+(TEST
+ types-classes-7
+ (multiple-value-bind
+       (subtype-p valid-p)
+     (subtypep 'short-float (find-class 'short-float))
+   (and subtype-p valid-p)))
+
+(TEST
+ types-classes-8
+ (multiple-value-bind
+       (subtype-p valid-p)
+     (subtypep (find-class 'short-float) 'short-float)
+   (and subtype-p valid-p)))


### PR DESCRIPTION
See regresion-tests, additionally fixed (type-of #\a) -> STANDARD-CHAR