### PR TITLE
workaround for (list-all-packages) not to return deleted packages

### DIFF
--- a/include/clasp/core/package.h
+++ b/include/clasp/core/package.h
@@ -68,6 +68,7 @@ class Package_O : public General_O {
 #endif
   bool systemLockedP = false;
   bool userLockedP = false;
+  bool zombieP = false;
  public: // Creation class functions
   static Package_sp create(const string &p);
 
@@ -209,6 +210,14 @@ class Package_O : public General_O {
 
   bool getUserLockedP () {
     return this->userLockedP;
+  }
+
+   void setZombieP (bool value) {
+    this->zombieP = value;
+  }
+
+  bool getZombieP () {
+    return this->zombieP;
   }
 
  public:

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -1194,6 +1194,7 @@ void Lisp_O::remove_package(const string& name ) {
     PACKAGE_ERROR(SimpleBaseString_O::make(name));
   }
   this->_Roots._PackageNameIndexMap.erase(name);
+  this->_Roots._Packages[fi->second]->setZombieP(true);
 }
 
 bool Lisp_O::recognizesPackage(const string &packageName) const {
@@ -1204,7 +1205,14 @@ bool Lisp_O::recognizesPackage(const string &packageName) const {
 
 List_sp Lisp_O::allPackagesAsCons() const {
   WITH_READ_LOCK(this->_Roots._PackagesMutex);
-  return asCons(this->_Roots._Packages);
+  gctools::Vec0<Package_sp> TempPackages;
+  for (int packageIndex = 0; packageIndex < this->_Roots._Packages.size(); ++packageIndex) {
+    // As a workaround, don't list previously deleted packages
+    if (!this->_Roots._Packages[packageIndex]->getZombieP()) {
+        TempPackages.push_back(this->_Roots._Packages[packageIndex]);
+      }
+  }
+  return asCons(TempPackages);
 }
 
 void Lisp_O::inPackage(const string &p) {


### PR DESCRIPTION
Now the following works:
```common-lisp
CL-USER> (list-all-packages)
(#<PACKAGE GCTOOLS> #<PACKAGE CLBIND> #<PACKAGE LLVM-SYS>
 #<PACKAGE SOCKETS-INTERNAL> #<PACKAGE SERVE-EVENT-INTERNAL>
 #<PACKAGE AST-TOOLING> #<PACKAGE CLEAVIR-ENVIRONMENT>
 #<PACKAGE CLEAVIR-PRIMOP> #<PACKAGE KEYWORD> #<PACKAGE COMMON-LISP>
 #<PACKAGE COMMON-LISP-USER> #<PACKAGE CLANG-COMPILE> #<PACKAGE CLANG-AST>
 #<PACKAGE MPI> #<PACKAGE CLASP-FFI> #<PACKAGE GRAY> #<PACKAGE CLOS>
 #<PACKAGE COMPILER> #<PACKAGE EXT> #<PACKAGE CORE> #<PACKAGE MP>
 #<PACKAGE CLASP!> #<PACKAGE SB-BSD-CLBIND> #<PACKAGE CLBIND-TEST>
 #<PACKAGE LLVM> #<PACKAGE SB-BSD-SOCKETS> #<PACKAGE CLANG-COMMENTS>
 #<PACKAGE CLASP-CLEAVIR> #<PACKAGE CLEAVIR-AST> #<PACKAGE CLASP-CLEAVIR-AST>
 #<PACKAGE C> #<PACKAGE CC-GENERATE-AST> #<PACKAGE LITERAL>
 #<PACKAGE ACCLIMATION> #<PACKAGE CONCRETE-SYNTAX-TREE>
 #<PACKAGE ALEXANDRIA.0.DEV> #<PACKAGE CLOSER-MOP>
 #<PACKAGE CLOSER-COMMON-LISP> #<PACKAGE CLOSER-COMMON-LISP-USER>
 #<PACKAGE ECLECTOR.BASE> #<PACKAGE ECLECTOR.READTABLE>
 #<PACKAGE ECLECTOR.READTABLE.SIMPLE> #<PACKAGE ECLECTOR.READER>
 #<PACKAGE ECLECTOR.PARSE-RESULT> #<PACKAGE ECLECTOR.CONCRETE-SYNTAX-TREE>
 #<PACKAGE CLEAVIR-IO> #<PACKAGE CLEAVIR-METER> #<PACKAGE CLEAVIR-AST-GRAPHVIZ>
 #<PACKAGE CLEAVIR-AST-TRANSFORMATIONS> #<PACKAGE CLEAVIR-CODE-UTILITIES>
 #<PACKAGE CLEAVIR-COMPILATION-POLICY> #<PACKAGE CLEAVIR-GENERATE-AST>
 #<PACKAGE CLEAVIR-CST-TO-AST> #<PACKAGE CLEAVIR-IR>
 #<PACKAGE CLEAVIR-IR-GRAPHVIZ> #<PACKAGE CLEAVIR-AST-TO-HIR>
 #<PACKAGE CLEAVIR-KILDALL> #<PACKAGE CLEAVIR-KILDALL-GRAPHVIZ>
 #<PACKAGE CLEAVIR-LIVENESS> #<PACKAGE CLEAVIR-KILDALL-TYPE-INFERENCE>
 #<PACKAGE CLEAVIR-TYPE-DESCRIPTORS> #<PACKAGE CLEAVIR-ESCAPE>
 #<PACKAGE CLEAVIR-HIR-TRANSFORMATIONS>
 #<PACKAGE CLEAVIR-REMOVE-USELESS-INSTRUCTIONS>
 #<PACKAGE CLEAVIR-PARTIAL-INLINING> #<PACKAGE CLEAVIR-HIR-TO-MIR>
 #<PACKAGE CLEAVIR-UTILITIES> #<PACKAGE CLEAVIR-BASIC-BLOCKS>
 #<PACKAGE SICL-ADDITIONAL-TYPES> #<PACKAGE SICL-ADDITIONAL-CONDITIONS>
 #<PACKAGE CCLASP-BUILD> #<PACKAGE CLASP-CLEAVIR-HIR>
 #<PACKAGE CLASP-CLEAVIR-AST-TO-HIR> #<PACKAGE CC-HIR-TO-MIR> #<PACKAGE CC-MIR>
 #<PACKAGE CLEAVIR-IR-GML> #<PACKAGE LISP-EXECUTABLE.CREATION>
 #<PACKAGE PRIMOP> #<PACKAGE SWANK-LOADER> #<PACKAGE SWANK/BACKEND>
 #<PACKAGE SWANK/RPC> #<PACKAGE SWANK/MATCH> #<PACKAGE SWANK-MOP>
 #<PACKAGE SWANK> #<PACKAGE SWANK/CLASP> #<PACKAGE SWANK/GRAY>
 #<PACKAGE SWANK-IO-PACKAGE> #<PACKAGE SWANK-TRACE-DIALOG>
 #<PACKAGE SWANK-REPL> #<PACKAGE SWANK-MACROSTEP>)
CL-USER> (defpackage :foo)
#<PACKAGE FOO>
CL-USER> (list-all-packages)
(#<PACKAGE GCTOOLS> #<PACKAGE CLBIND> #<PACKAGE LLVM-SYS>
 #<PACKAGE SOCKETS-INTERNAL> #<PACKAGE SERVE-EVENT-INTERNAL>
 #<PACKAGE AST-TOOLING> #<PACKAGE CLEAVIR-ENVIRONMENT>
 #<PACKAGE CLEAVIR-PRIMOP> #<PACKAGE KEYWORD> #<PACKAGE COMMON-LISP>
 #<PACKAGE COMMON-LISP-USER> #<PACKAGE CLANG-COMPILE> #<PACKAGE CLANG-AST>
 #<PACKAGE MPI> #<PACKAGE CLASP-FFI> #<PACKAGE GRAY> #<PACKAGE CLOS>
 #<PACKAGE COMPILER> #<PACKAGE EXT> #<PACKAGE CORE> #<PACKAGE MP>
 #<PACKAGE CLASP!> #<PACKAGE SB-BSD-CLBIND> #<PACKAGE CLBIND-TEST>
 #<PACKAGE LLVM> #<PACKAGE SB-BSD-SOCKETS> #<PACKAGE CLANG-COMMENTS>
 #<PACKAGE CLASP-CLEAVIR> #<PACKAGE CLEAVIR-AST> #<PACKAGE CLASP-CLEAVIR-AST>
 #<PACKAGE C> #<PACKAGE CC-GENERATE-AST> #<PACKAGE LITERAL>
 #<PACKAGE ACCLIMATION> #<PACKAGE CONCRETE-SYNTAX-TREE>
 #<PACKAGE ALEXANDRIA.0.DEV> #<PACKAGE CLOSER-MOP>
 #<PACKAGE CLOSER-COMMON-LISP> #<PACKAGE CLOSER-COMMON-LISP-USER>
 #<PACKAGE ECLECTOR.BASE> #<PACKAGE ECLECTOR.READTABLE>
 #<PACKAGE ECLECTOR.READTABLE.SIMPLE> #<PACKAGE ECLECTOR.READER>
 #<PACKAGE ECLECTOR.PARSE-RESULT> #<PACKAGE ECLECTOR.CONCRETE-SYNTAX-TREE>
 #<PACKAGE CLEAVIR-IO> #<PACKAGE CLEAVIR-METER> #<PACKAGE CLEAVIR-AST-GRAPHVIZ>
 #<PACKAGE CLEAVIR-AST-TRANSFORMATIONS> #<PACKAGE CLEAVIR-CODE-UTILITIES>
 #<PACKAGE CLEAVIR-COMPILATION-POLICY> #<PACKAGE CLEAVIR-GENERATE-AST>
 #<PACKAGE CLEAVIR-CST-TO-AST> #<PACKAGE CLEAVIR-IR>
 #<PACKAGE CLEAVIR-IR-GRAPHVIZ> #<PACKAGE CLEAVIR-AST-TO-HIR>
 #<PACKAGE CLEAVIR-KILDALL> #<PACKAGE CLEAVIR-KILDALL-GRAPHVIZ>
 #<PACKAGE CLEAVIR-LIVENESS> #<PACKAGE CLEAVIR-KILDALL-TYPE-INFERENCE>
 #<PACKAGE CLEAVIR-TYPE-DESCRIPTORS> #<PACKAGE CLEAVIR-ESCAPE>
 #<PACKAGE CLEAVIR-HIR-TRANSFORMATIONS>
 #<PACKAGE CLEAVIR-REMOVE-USELESS-INSTRUCTIONS>
 #<PACKAGE CLEAVIR-PARTIAL-INLINING> #<PACKAGE CLEAVIR-HIR-TO-MIR>
 #<PACKAGE CLEAVIR-UTILITIES> #<PACKAGE CLEAVIR-BASIC-BLOCKS>
 #<PACKAGE SICL-ADDITIONAL-TYPES> #<PACKAGE SICL-ADDITIONAL-CONDITIONS>
 #<PACKAGE CCLASP-BUILD> #<PACKAGE CLASP-CLEAVIR-HIR>
 #<PACKAGE CLASP-CLEAVIR-AST-TO-HIR> #<PACKAGE CC-HIR-TO-MIR> #<PACKAGE CC-MIR>
 #<PACKAGE CLEAVIR-IR-GML> #<PACKAGE LISP-EXECUTABLE.CREATION>
 #<PACKAGE PRIMOP> #<PACKAGE SWANK-LOADER> #<PACKAGE SWANK/BACKEND>
 #<PACKAGE SWANK/RPC> #<PACKAGE SWANK/MATCH> #<PACKAGE SWANK-MOP>
 #<PACKAGE SWANK> #<PACKAGE SWANK/CLASP> #<PACKAGE SWANK/GRAY>
 #<PACKAGE SWANK-IO-PACKAGE> #<PACKAGE SWANK-TRACE-DIALOG>
 #<PACKAGE SWANK-REPL> #<PACKAGE SWANK-MACROSTEP> #<PACKAGE FOO>)
CL-USER> (delete-package (find-package :foo))
T
CL-USER> (list-all-packages)
(#<PACKAGE GCTOOLS> #<PACKAGE CLBIND> #<PACKAGE LLVM-SYS>
 #<PACKAGE SOCKETS-INTERNAL> #<PACKAGE SERVE-EVENT-INTERNAL>
 #<PACKAGE AST-TOOLING> #<PACKAGE CLEAVIR-ENVIRONMENT>
 #<PACKAGE CLEAVIR-PRIMOP> #<PACKAGE KEYWORD> #<PACKAGE COMMON-LISP>
 #<PACKAGE COMMON-LISP-USER> #<PACKAGE CLANG-COMPILE> #<PACKAGE CLANG-AST>
 #<PACKAGE MPI> #<PACKAGE CLASP-FFI> #<PACKAGE GRAY> #<PACKAGE CLOS>
 #<PACKAGE COMPILER> #<PACKAGE EXT> #<PACKAGE CORE> #<PACKAGE MP>
 #<PACKAGE CLASP!> #<PACKAGE SB-BSD-CLBIND> #<PACKAGE CLBIND-TEST>
 #<PACKAGE LLVM> #<PACKAGE SB-BSD-SOCKETS> #<PACKAGE CLANG-COMMENTS>
 #<PACKAGE CLASP-CLEAVIR> #<PACKAGE CLEAVIR-AST> #<PACKAGE CLASP-CLEAVIR-AST>
 #<PACKAGE C> #<PACKAGE CC-GENERATE-AST> #<PACKAGE LITERAL>
 #<PACKAGE ACCLIMATION> #<PACKAGE CONCRETE-SYNTAX-TREE>
 #<PACKAGE ALEXANDRIA.0.DEV> #<PACKAGE CLOSER-MOP>
 #<PACKAGE CLOSER-COMMON-LISP> #<PACKAGE CLOSER-COMMON-LISP-USER>
 #<PACKAGE ECLECTOR.BASE> #<PACKAGE ECLECTOR.READTABLE>
 #<PACKAGE ECLECTOR.READTABLE.SIMPLE> #<PACKAGE ECLECTOR.READER>
 #<PACKAGE ECLECTOR.PARSE-RESULT> #<PACKAGE ECLECTOR.CONCRETE-SYNTAX-TREE>
 #<PACKAGE CLEAVIR-IO> #<PACKAGE CLEAVIR-METER> #<PACKAGE CLEAVIR-AST-GRAPHVIZ>
 #<PACKAGE CLEAVIR-AST-TRANSFORMATIONS> #<PACKAGE CLEAVIR-CODE-UTILITIES>
 #<PACKAGE CLEAVIR-COMPILATION-POLICY> #<PACKAGE CLEAVIR-GENERATE-AST>
 #<PACKAGE CLEAVIR-CST-TO-AST> #<PACKAGE CLEAVIR-IR>
 #<PACKAGE CLEAVIR-IR-GRAPHVIZ> #<PACKAGE CLEAVIR-AST-TO-HIR>
 #<PACKAGE CLEAVIR-KILDALL> #<PACKAGE CLEAVIR-KILDALL-GRAPHVIZ>
 #<PACKAGE CLEAVIR-LIVENESS> #<PACKAGE CLEAVIR-KILDALL-TYPE-INFERENCE>
 #<PACKAGE CLEAVIR-TYPE-DESCRIPTORS> #<PACKAGE CLEAVIR-ESCAPE>
 #<PACKAGE CLEAVIR-HIR-TRANSFORMATIONS>
 #<PACKAGE CLEAVIR-REMOVE-USELESS-INSTRUCTIONS>
 #<PACKAGE CLEAVIR-PARTIAL-INLINING> #<PACKAGE CLEAVIR-HIR-TO-MIR>
 #<PACKAGE CLEAVIR-UTILITIES> #<PACKAGE CLEAVIR-BASIC-BLOCKS>
 #<PACKAGE SICL-ADDITIONAL-TYPES> #<PACKAGE SICL-ADDITIONAL-CONDITIONS>
 #<PACKAGE CCLASP-BUILD> #<PACKAGE CLASP-CLEAVIR-HIR>
 #<PACKAGE CLASP-CLEAVIR-AST-TO-HIR> #<PACKAGE CC-HIR-TO-MIR> #<PACKAGE CC-MIR>
 #<PACKAGE CLEAVIR-IR-GML> #<PACKAGE LISP-EXECUTABLE.CREATION>
 #<PACKAGE PRIMOP> #<PACKAGE SWANK-LOADER> #<PACKAGE SWANK/BACKEND>
 #<PACKAGE SWANK/RPC> #<PACKAGE SWANK/MATCH> #<PACKAGE SWANK-MOP>
 #<PACKAGE SWANK> #<PACKAGE SWANK/CLASP> #<PACKAGE SWANK/GRAY>
 #<PACKAGE SWANK-IO-PACKAGE> #<PACKAGE SWANK-TRACE-DIALOG>
 #<PACKAGE SWANK-REPL> #<PACKAGE SWANK-MACROSTEP>)
CL-USER> 
````

Previously and empty package object would have been returned by (list-all-packages) after deleting foo

Fixes: #432 