### PR TITLE
Fix constituent invalid trait & reader macros

### DIFF
--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -814,6 +814,8 @@ SYMBOL_EXPORT_SC_(ClPkg, standard_object);
 SYMBOL_EXPORT_SC_(ClPkg, copy_structure);
 
 SYMBOL_EXPORT_SC_(CorePkg, defcallback);
+SYMBOL_EXPORT_SC_(CorePkg, sharp_a_reader);
+SYMBOL_EXPORT_SC_(CorePkg, sharp_s_reader);
 
 void testConses() {
   printf("%s:%d Testing Conses and iterators\n", __FILE__, __LINE__);

--- a/src/core/lispReader.cc
+++ b/src/core/lispReader.cc
@@ -541,6 +541,9 @@ SimpleString_sp symbolTokenStr(T_sp stream, Token &token, size_t start, size_t e
     printf("%s:%d The symbolTokenStr is empty\n", __FILE__, __LINE__ );
   }
   for (size_t i=start,iEnd(end); i<iEnd; ++i) {
+    if (TRAIT_MATCH_ANY(token[i], TRAIT_INVALID))
+         READER_ERROR(SimpleBaseString_O::make("A char with trait invalid was encountered by the reader."),
+                  _Nil<T_O>(), stream);
     claspCharacter c = CHR(token[i]);
     if (c != '.') only_dots = false;
     buffer.string()->vectorPushExtend_claspCharacter(CHR(token[i]));
@@ -1098,7 +1101,8 @@ step1:
   //    step2:
   if (xxx_syntax_type == kw::_sym_invalid) {
     LOG_READ(BF("step2 - invalid-character[%c]") % clasp_as_claspCharacter(xxx));
-    SIMPLE_ERROR(BF("ReaderError_O::create(sin,_lisp)"));
+    READER_ERROR(SimpleBaseString_O::make("A char with syntax type invalid was encountered by the reader."),
+                 _Nil<T_O>(), sin);
   }
   //    step3:
   if (xxx_syntax_type == kw::_sym_whitespace) {

--- a/src/core/readtable.cc
+++ b/src/core/readtable.cc
@@ -546,7 +546,7 @@ CL_DEFUN T_mv core__sharp_colon(T_sp sin, Character_sp ch, T_sp num) {
 CL_LAMBDA(stream subchar radix);
 CL_DECLARE();
 CL_DOCSTRING("sharp_r");
-CL_DEFUN T_mv core__sharp_r(T_sp sin, Character_sp ch, gc::Nilable<Fixnum_sp> nradix) {
+CL_DEFUN T_mv core__sharp_r(T_sp sin, Character_sp ch, T_sp nradix) {
   if (cl::_sym_STARread_suppressSTAR->symbolValue().isTrue()) {
     T_sp object = cl__read(sin, _lisp->_true(), _Nil<T_O>(), _lisp->_true());
     (void)object; // suppress warning
@@ -554,8 +554,7 @@ CL_DEFUN T_mv core__sharp_r(T_sp sin, Character_sp ch, gc::Nilable<Fixnum_sp> nr
   } else if (nradix.nilp()) {
     SIMPLE_ERROR(BF("Radix missing in #R reader macro"));
   } else {
-    T_sp tradix = nradix;
-    Fixnum_sp radix = gc::As<Fixnum_sp>(tradix);
+    Fixnum_sp radix = gc::As<Fixnum_sp>(nradix);
     int iradix = unbox_fixnum(radix);
     if (iradix < 2 || iradix > 36) {
       SIMPLE_ERROR(BF("Illegal radix for #R: %d") % iradix);
@@ -575,14 +574,14 @@ CL_DEFUN T_mv core__sharp_r(T_sp sin, Character_sp ch, gc::Nilable<Fixnum_sp> nr
 CL_LAMBDA(stream ch num);
 CL_DECLARE();
 CL_DOCSTRING("sharp_b");
-CL_DEFUN T_mv core__sharp_b(T_sp sin, Character_sp ch, gc::Nilable<Fixnum_sp> num) {
+CL_DEFUN T_mv core__sharp_b(T_sp sin, Character_sp ch, T_sp num) {
   return core__sharp_r(sin, ch, make_fixnum(2));
 };
 
 CL_LAMBDA(stream ch num);
 CL_DECLARE();
 CL_DOCSTRING("sharp_o");
-CL_DEFUN T_mv core__sharp_o(T_sp sin, Character_sp ch, gc::Nilable<Fixnum_sp> num) {
+CL_DEFUN T_mv core__sharp_o(T_sp sin, Character_sp ch, T_sp num) {
   return core__sharp_r(sin, ch, make_fixnum(8));
 };
 
@@ -616,6 +615,8 @@ CL_LAMBDA(stream ch num);
 CL_DECLARE();
 CL_DOCSTRING("sharp_a");
 CL_DEFUN T_mv core__sharp_a(T_sp sin, Character_sp ch, T_sp num) {
+   if (core::_sym_sharp_a_reader->fboundp())
+     return eval::funcall(core::_sym_sharp_a_reader, sin, ch, num);
   if (num.nilp()) {
     T_sp initial_contents = core::eval::funcall(cl::_sym_read,sin,_Nil<T_O>(),_lisp->_true());
     if (cl::_sym_STARread_suppressSTAR->symbolValue().notnilp()) {
@@ -623,10 +624,13 @@ CL_DEFUN T_mv core__sharp_a(T_sp sin, Character_sp ch, T_sp num) {
     } else if (num.nilp()) {
       // readably-pretty-printed array: #A(type dims initial-contents)
       T_sp elt_type = oCar(initial_contents);
-      List_sp dims = gc::As<List_sp>(oCadr(initial_contents));
+      T_sp dims = gc::As<T_sp>(oCadr(initial_contents));
+      // is either a number or a list of n elements
       List_sp linitial_contents = gc::As<List_sp>(oCaddr(initial_contents));
-      if (cl__length(dims)==1) {
-        Vector_sp vec = core__make_vector(elt_type,oCar(dims).unsafe_fixnum(),false,_Nil<T_O>(),_Nil<T_O>(),core::make_fixnum(0),_Nil<T_O>(),true);
+      if (!dims.consp() || cl__length(dims)==1) {
+        if (dims.consp()) 
+            dims = oCar(dims);
+        Vector_sp vec = core__make_vector(elt_type,dims.unsafe_fixnum(),false,_Nil<T_O>(),_Nil<T_O>(),core::make_fixnum(0),_Nil<T_O>(),true);
         size_t idx = 0;
         for ( auto e : linitial_contents ) {
           T_sp val = CONS_CAR(e);
@@ -645,6 +649,8 @@ CL_LAMBDA(stream ch num);
 CL_DECLARE();
 CL_DOCSTRING("sharp_s");
 CL_DEFUN T_mv core__sharp_s(T_sp sin, Character_sp ch, T_sp num) {
+   if (core::_sym_sharp_s_reader->fboundp())
+     return eval::funcall(core::_sym_sharp_s_reader, sin, ch, num);
   IMPLEMENT_MEF("Implement sharp_s");
 }; // core__sharp_s
 


### PR DESCRIPTION
* Use the lisp version of sharp-a if defined
* Use the lisp version of sharp-s if defined 
* make the above 2 symbols known
* check for invalid traits in symbolTokenStr
* correct some types that gave errors in the lisp->c++ conversion
* return reader_errors and not simple-errors when possible
* regression tests for all