### PR TITLE
Repair wscript syntax error

### DIFF
--- a/wscript
+++ b/wscript
@@ -223,8 +223,8 @@ DEBUG_OPTIONS = [
     "DEBUG_RECURSIVE_ALLOCATIONS",
     "DEBUG_LLVM_OPTIMIZATION_LEVEL_0",
     "DEBUG_SLOW",    # Code runs slower due to checks - undefine to remove checks
-    "USE_HUMAN_READABLE_BITCODE"
-    "CONFIG_VAR_COOL", # mps setting
+    "USE_HUMAN_READABLE_BITCODE",
+    "CONFIG_VAR_COOL" # mps setting
 ]
 
 def build_extension(bld):


### PR DESCRIPTION
Fix
````
  File "/Users/karstenpoeck/lisp/compiler/clasp-karsten/wscript", line 1056, in configure
    raise Exception("Illegal DEBUG_OPTION %s - allowed options: %s" % (opt, DEBUG_OPTIONS))
Exception: Illegal DEBUG_OPTION USE_HUMAN_READABLE_BITCODE - allowed options: ['DEBUG_DTRACE_LOCK_PROBE', 'DEBUG_STACKMAPS', 'DEBUG_ASSERT_TYPE_CAST', 'SOURCE_DEBUG', 'DEBUG_JIT_LOG_SYMBOLS', 'DEBUG_GUARD', 'DEBUG_GUARD_VALIDATE', 'DEBUG_GUARD_EXHAUSTIVE_VALIDATE', 'DEBUG_TRACE_INTERPRETED_CLOSURES', 'DEBUG_ENVIRONMENTS', 'DEBUG_RELEASE', 'DEBUG_CACHE', 'DEBUG_BITUNIT_CONTAINER', 'DEBUG_LEXICAL_DEPTH', 'DEBUG_FLOW_TRACKER', 'DEBUG_DYNAMIC_BINDING_STACK', 'DEBUG_VALUES', 'DEBUG_IHS', 'DEBUG_STACKMAPS', 'DEBUG_TRACK_UNWINDS', 'DEBUG_NO_UNWIND', 'DEBUG_STARTUP', 'DEBUG_REHASH_COUNT', 'DEBUG_MONITOR', 'DEBUG_MEMORY_PROFILE', 'DEBUG_BCLASP_LISP', 'DEBUG_CCLASP_LISP', 'DEBUG_COUNT_ALLOCATIONS', 'DEBUG_COMPILER', 'DEBUG_LONG_CALL_HISTORY', 'DEBUG_BOUNDS_ASSERT', 'DEBUG_GFDISPATCH', 'DEBUG_CMPFASTGF', 'DEBUG_FASTGF', 'DEBUG_SLOT_ACCESSORS', 'DEBUG_THREADS', 'DEBUG_ENSURE_VALID_OBJECT', 'DEBUG_QUICK_VALIDATE', 'DEBUG_MPS_SIZE', 'DEBUG_MPS_UNDERSCANNING', 'DEBUG_DONT_OPTIMIZE_BCLASP', 'DEBUG_RECURSIVE_ALLOCATIONS', 'DEBUG_LLVM_OPTIMIZATION_LEVEL_0', 'DEBUG_SLOW', 'USE_HUMAN_READABLE_BITCODECONFIG_VAR_COOL']
make: *** [configure] Error 2
````

introduced in https://github.com/clasp-developers/clasp/commit/32d76078684ebde3ea45fddc9fdc73791d4db2d8