### PR TITLE
Add __write__ for ratios, did use method for symbols

### DIFF
--- a/include/clasp/core/numbers.h
+++ b/include/clasp/core/numbers.h
@@ -726,6 +726,9 @@ namespace core {
     bool minusp_() const {
       return clasp_minusp(this->_numerator);
     }
+
+    virtual void __write__(T_sp strm) const;
+    
     Ratio_O() : _numerator(clasp_make_fixnum(0)), _denominator(clasp_make_fixnum(1)) {};
     virtual ~Ratio_O() {};
   };

--- a/src/core/write_ugly.cc
+++ b/src/core/write_ugly.cc
@@ -145,6 +145,12 @@ void Integer_O::__write__(T_sp stream) const {
   cl__write_sequence(buffer._Buffer, stream, make_fixnum(0), _Nil<T_O>());
 }
 
+void Ratio_O::__write__(T_sp stream) const {
+  write_ugly_object(this->num(), stream);
+  clasp_write_char('/', stream);
+  write_ugly_object(this->den(), stream);
+}
+
 void Complex_O::__write__(T_sp stream) const {
   clasp_write_string("#C(", stream);
   write_ugly_object(this->_real, stream);

--- a/src/core/write_ugly.cc
+++ b/src/core/write_ugly.cc
@@ -145,10 +145,19 @@ void Integer_O::__write__(T_sp stream) const {
   cl__write_sequence(buffer._Buffer, stream, make_fixnum(0), _Nil<T_O>());
 }
 
-void Ratio_O::__write__(T_sp stream) const {
-  write_ugly_object(this->num(), stream);
-  clasp_write_char('/', stream);
-  write_ugly_object(this->den(), stream);
+void Ratio_O::__write__(T_sp stream) const {  
+  SafeBufferStr8Ns buffer;
+  int print_base = clasp_print_base();
+  core__integer_to_string(buffer._Buffer, this->num()->const_sharedThis<Integer_O>(),
+                       make_fixnum(print_base),
+                       cl::_sym_STARprint_radixSTAR->symbolValue().isTrue(),
+                       false);
+  buffer._Buffer->vectorPushExtend(clasp_make_character('/'));
+  core__integer_to_string(buffer._Buffer, this->den()->const_sharedThis<Integer_O>(),
+                       make_fixnum(print_base),
+                       false,
+                       false);
+  cl__write_sequence(buffer._Buffer, stream, make_fixnum(0), _Nil<T_O>());
 }
 
 void Complex_O::__write__(T_sp stream) const {


### PR DESCRIPTION
Before:
```lisp
(let ((*read-base* 10)
        (ratio (read-from-string "2140/969")))
            (let ((*print-base* 4))
               (write-to-string ratio)))
"2140/969"
````
after
```lisp
(let ((*read-base* 10)
        (ratio (read-from-string "2140/969")))
            (let ((*print-base* 4))
               (write-to-string ratio)))

"201130/33021"

````