### PR TITLE
defclass: make sure that defclass option "NIL" errors

### DIFF
--- a/src/lisp/kernel/clos/standard.lsp
+++ b/src/lisp/kernel/clos/standard.lsp
@@ -636,11 +636,11 @@ because it contains a reference to the undefined class~%  ~A"
     (do* ((name-loc initargs (cddr name-loc))
 	  (allow-other-keys nil)
 	  (allow-other-keys-found nil)
-	  (unknown-key nil))
+	  (unknown-key-names nil))
 	 ((null name-loc)
-	  (when (and (not allow-other-keys) unknown-key)
-	    (simple-program-error "Unknown initialization option ~S for class ~A"
-				  unknown-key class)))
+	  (when (and (not allow-other-keys) unknown-key-names)
+            (simple-program-error "Unknown initialization options ~S for class ~A."
+                                  (nreverse unknown-key-names) class)))
       (let ((name (first name-loc)))
 	(cond ((null (cdr name-loc))
 	       (simple-program-error "No value supplied for the init-name ~S." name))
@@ -656,7 +656,7 @@ because it contains a reference to the undefined class~%  ~A"
               ((member name cached-keywords))
 	      ((and methods (member name methods :test #'member :key #'method-keywords)))
 	      (t
-	       (setf unknown-key name)))))))
+	       (push name unknown-key-names)))))))
 
 ;;; ----------------------------------------------------------------------
 ;;; Methods


### PR DESCRIPTION
This is as for CLHS section 7.1.2. Error was caused by the fact that
unknown-key was a flag, so if the initarg was NIL, we were assigning
it value NIL, what is also a boolean false. Right now we collect all
invalid initargs in a list, so in case of NIL we'll get (NIL) what is
a generalized boolean true value. Closes #703.

Note that I didn't compile clasp to test this change. It takes too long
for me and I don't have a complete set of dependencies.