### PR TITLE
Finalize lisp interface of weakHashTable + regression-tests

### DIFF
--- a/include/clasp/core/hashTable.h
+++ b/include/clasp/core/hashTable.h
@@ -56,7 +56,7 @@ namespace core{
     bool fieldsp() const { return true; };
     void fields(Record_sp node);
 
-    friend T_mv cl__maphash(T_sp function_desig, T_sp hash_table);
+    friend T_sp cl__maphash(T_sp function_desig, T_sp hash_table);
   HashTable_O() :
 #ifdef DEBUG_REHASH_COUNT
     _HashTableId(next_hash_table_id()),
@@ -73,7 +73,7 @@ namespace core{
     friend class HashTableEql_O;
     friend class HashTableEqual_O;
     friend class HashTableEqualp_O;
-    friend T_mv cl__maphash(T_sp function_desig, HashTable_sp hash_table);
+    friend T_sp cl__maphash(T_sp function_desig, HashTable_sp hash_table);
     friend T_sp cl__clrhash(HashTable_sp hash_table);
   public: // instance variables here
 #ifdef DEBUG_REHASH_COUNT
@@ -168,7 +168,7 @@ namespace core{
 
     void lowLevelMapHash(KeyValueMapper *mapper) const;
 
-    T_mv maphash(T_sp fn); 
+    void maphash(T_sp fn); 
 
     void mapHash(std::function<void(T_sp, T_sp)> const &fn);
     void maphash(std::function<void(T_sp, T_sp)> const &fn) { this->mapHash(fn); };

--- a/include/clasp/core/hashTable.h
+++ b/include/clasp/core/hashTable.h
@@ -129,6 +129,7 @@ namespace core{
 
   /*! Return a count of the number of keys */
     size_t hashTableCount() const;
+    size_t hashTableSize() const;
     size_t size() { return this->hashTableCount(); };
 
     virtual gc::Fixnum sxhashKey(T_sp key, gc::Fixnum bound, bool willAddKey) const;

--- a/include/clasp/core/hashTableBase.h
+++ b/include/clasp/core/hashTableBase.h
@@ -33,7 +33,7 @@ namespace core {
   FORWARD(HashTableBase);
   class HashTableBase_O : public General_O {
     struct metadata_bootstrap_class {};
-    LISP_CLASS(core, ClPkg, HashTableBase_O, "HashTableBase",core::General_O);
+    LISP_CLASS(core, CorePkg, HashTableBase_O, "HashTableBase",core::General_O);
   HashTableBase_O() {};
   public:
     virtual T_sp hash_table_setf_gethash(T_sp key, T_sp value) = 0;
@@ -44,7 +44,8 @@ namespace core {
     virtual T_sp hash_table_test() = 0;
     virtual T_mv maphash(T_sp function_desig) = 0;
     virtual T_sp clrhash() = 0;
-    virtual size_t hashTableCount() const = 0 ;
+    virtual size_t hashTableCount() const = 0;
+    virtual size_t hashTableSize() const = 0;
   };
 
 };

--- a/include/clasp/core/hashTableBase.h
+++ b/include/clasp/core/hashTableBase.h
@@ -42,7 +42,7 @@ namespace core {
     virtual Number_sp rehash_size() = 0;
     virtual double rehash_threshold() = 0;
     virtual T_sp hash_table_test() = 0;
-    virtual T_mv maphash(T_sp function_desig) = 0;
+    virtual void maphash(T_sp function_desig) = 0;
     virtual T_sp clrhash() = 0;
     virtual size_t hashTableCount() const = 0;
     virtual size_t hashTableSize() const = 0;

--- a/include/clasp/core/weakHashTable.h
+++ b/include/clasp/core/weakHashTable.h
@@ -90,7 +90,7 @@ public:
   gc::Fixnum sxhashKey(T_sp key, gc::Fixnum bound, bool willAddKey) const;
 
   void maphashLowLevel(std::function<void(T_sp, T_sp)> const &fn);
-  T_mv maphash(T_sp functionDesig); 
+  void maphash(T_sp functionDesig); 
 
   T_mv gethash(T_sp key, T_sp defaultValue = _Nil<T_O>());
   bool remhash(T_sp key);

--- a/include/clasp/core/weakHashTable.h
+++ b/include/clasp/core/weakHashTable.h
@@ -77,6 +77,7 @@ public:
 public:
   size_t hashTableCount() const { return this->_HashTable.tableSize();};
   cl_index size() const { return this->hashTableCount(); };
+  size_t hashTableSize() const { return this->_HashTable.length();};
 
   T_sp hash_table_setf_gethash(T_sp key, T_sp value);
 

--- a/src/core/hashTable.cc
+++ b/src/core/hashTable.cc
@@ -229,7 +229,7 @@ HashTable_sp HashTable_O::create_thread_safe(T_sp test, SimpleBaseString_sp read
   return ht;
 }
 
-T_mv HashTable_O::maphash(T_sp function_desig) {
+void HashTable_O::maphash(T_sp function_desig) {
     //        printf("%s:%d starting maphash on hash-table@%p\n", __FILE__, __LINE__, hash_table.raw_());
   Function_sp func = coerce::functionDesignator(function_desig);
   HT_READ_LOCK(this);
@@ -240,13 +240,12 @@ T_mv HashTable_O::maphash(T_sp function_desig) {
     }
   }
   //        printf("%s:%d finished maphash on hash-table@%p\n", __FILE__, __LINE__, hash_table.raw_());
-  return (Values(_Nil<T_O>()));
 }
 
 CL_LAMBDA(function-desig hash-table);
 CL_DECLARE();
 CL_DOCSTRING("see CLHS");
-CL_DEFUN T_mv cl__maphash(T_sp function_desig, HashTableBase_sp hash_table) {
+CL_DEFUN T_sp cl__maphash(T_sp function_desig, HashTableBase_sp hash_table) {
   //        printf("%s:%d starting maphash on hash-table@%p\n", __FILE__, __LINE__, hash_table.raw_());
   Function_sp func = coerce::functionDesignator(function_desig);
   if (hash_table.nilp()) {

--- a/src/core/weakHashTable.cc
+++ b/src/core/weakHashTable.cc
@@ -117,9 +117,8 @@ void WeakKeyHashTable_O::maphashLowLevel(std::function<void(T_sp, T_sp)> const &
   this->_HashTable.maphash(fn);
 }
 
-T_mv WeakKeyHashTable_O::maphash(T_sp func) {
+void WeakKeyHashTable_O::maphash(T_sp func) {
   this->_HashTable.maphashFn(func);
-  return Values(_Nil<T_O>());
 }
 
 bool WeakKeyHashTable_O::remhash(T_sp tkey) {

--- a/src/core/weakHashTable.cc
+++ b/src/core/weakHashTable.cc
@@ -113,10 +113,6 @@ T_mv WeakKeyHashTable_O::gethash(T_sp key, T_sp defaultValue) {
   return this->_HashTable.gethash(key, defaultValue);
 }
 
-T_sp WeakKeyHashTable_O::hash_table_setf_gethash(T_sp key, T_sp value) {
-  this->_HashTable.set(key, value);
-  return value;
-}
 void WeakKeyHashTable_O::maphashLowLevel(std::function<void(T_sp, T_sp)> const &fn) {
   this->_HashTable.maphash(fn);
 }
@@ -156,6 +152,12 @@ CL_DOCSTRING("weakGethash");
 CL_DEFUN T_mv core__weak_gethash(T_sp tkey, WeakKeyHashTable_sp ht, T_sp defaultValue) {
   return ht->gethash(tkey, defaultValue);
 };
+
+CL_LISPIFY_NAME("core:hashTableSetfGethash");
+CL_DEFMETHOD T_sp WeakKeyHashTable_O::hash_table_setf_gethash(T_sp key, T_sp value) {
+  this->_HashTable.set(key, value);
+  return value;
+}
 
 CL_LAMBDA(ht key value);
 CL_DECLARE();

--- a/src/lisp/kernel/clos/hierarchy.lsp
+++ b/src/lisp/kernel/clos/hierarchy.lsp
@@ -248,7 +248,7 @@
 	    (function)
 	    (pathname)
 	      (logical-pathname pathname)
-            #+or() (hash-table)  ;;No longer inherits from (core:general) 
+            ;;; (hash-table)  ;;No longer inherits from (core:general) 
 	    (random-state)
 	    (readtable)
             (si::code-block)

--- a/src/lisp/kernel/clos/hierarchy.lsp
+++ b/src/lisp/kernel/clos/hierarchy.lsp
@@ -248,7 +248,7 @@
 	    (function)
 	    (pathname)
 	      (logical-pathname pathname)
-	    (hash-table)
+            #+or() (hash-table)  ;;No longer inherits from (core:general) 
 	    (random-state)
 	    (readtable)
             (si::code-block)

--- a/src/lisp/regression-tests/hash-tables0.lisp
+++ b/src/lisp/regression-tests/hash-tables0.lisp
@@ -41,11 +41,32 @@
         (and (plusp hash)
              (typep hash 'fixnum))))
 
-(test hash-table-count (hash-table-count (make-hash-table)))
-(test hash-table-size (hash-table-size (make-hash-table)))
+(test hash-table-count (zerop (hash-table-count (make-hash-table))))
+(test hash-table-count-2
+      (= 2
+         (let ((table (make-hash-table)))
+           (setf (gethash :key table) 23)
+           (setf (gethash :key1 table) 22)
+           (setf (gethash :key table) 25)
+           (hash-table-count table))))
+(test hash-table-size (= 128 (hash-table-size (make-hash-table :size 128))))
 (test hash-table-rehash-size (HASH-TABLE-REHASH-SIZE (make-hash-table)))
 (test hash-table-rehash-THRESHOLD (HASH-TABLE-REHASH-THRESHOLD (make-hash-table)))
 (test hash-table-test (HASH-TABLE-TEST (make-hash-table)))
+(test setf-gethash (= 23
+                      (let ((table (make-hash-table)))
+                        (setf (gethash :key table) 23)
+                        (gethash :key table))))
+(test clrhash (clrhash (make-hash-table)))
+(test maphash (progn
+                (maphash #'(lambda(a b))
+                         (make-hash-table))
+                t))
+
+(test remhash (progn
+                (remhash :key (make-hash-table))
+                t))
+
 
 ;;; issue 620
 (test-expect-error hash-table-count-nil (hash-table-count nil) :type type-error)
@@ -53,5 +74,42 @@
 (test-expect-error hash-table-rehash-size-nil (HASH-TABLE-REHASH-SIZE nil) :type type-error)
 (test-expect-error hash-table-rehash-THRESHOLD-nil (HASH-TABLE-REHASH-THRESHOLD nil) :type type-error)
 (test-expect-error hash-table-test-nil (HASH-TABLE-TEST nil) :type type-error)
+
+;;weak tables: weakness :key
+(test hash-table-count-weak-key (zerop (hash-table-count (make-hash-table :weakness :key))))
+(test hash-table-count-2-weak-key
+      (= 2
+         (let ((table (make-hash-table :weakness :key)))
+           (setf (gethash :key table) 23)
+           (setf (gethash :key1 table) 22)
+           (setf (gethash :key table) 25)
+           (hash-table-count table))))
+
+(test hash-table-size-weak-key (= 128 (hash-table-size (make-hash-table :size 128 :weakness :key))))
+(test hash-table-rehash-size-weak-key (HASH-TABLE-REHASH-SIZE (make-hash-table :weakness :key)))
+(test hash-table-rehash-THRESHOLD-weak-key (HASH-TABLE-REHASH-THRESHOLD (make-hash-table :weakness :key)))
+(test hash-table-test-weak-key (HASH-TABLE-TEST (make-hash-table :weakness :key)))
+(test gethash-weak-key (let ((table (make-hash-table :weakness :key)))
+                         (gethash :key table)
+                         t))
+(test setf-gethash-weak-key (= 23
+                               (let ((table (make-hash-table :weakness :key)))
+                                 (setf (gethash :key table) 23)
+                                 (gethash :key table))))
+(test clrhash-weak-key (clrhash (make-hash-table :weakness :key)))
+(test maphash-weak-key (progn
+                         (maphash #'(lambda(a b))
+                                  (make-hash-table :weakness :key))
+                         t))
+(test remhash-weak-key (progn
+                         (remhash :key (make-hash-table  :weakness :key))
+                         t))
+
+(test hash-table-classes
+      (let ((sub (clos:class-direct-subclasses (first (clos:class-direct-superclasses (find-class 'hash-table))))))
+        (and (= 2 (length sub))
+             (find (find-class 'hash-table) sub)
+             (find (find-class 'CORE:WEAK-KEY-HASH-TABLE) sub)
+             t)))
 
 


### PR DESCRIPTION
Did fix the lisp-interface of weak-hash-table (were all failing)
See src/lisp/regression-tests/hash-tables0.lisp for a bit more complete set of tests
Current code now has no failures in the test-suite of cl+ssl (need my pull request for cffi though)

Attention:
* /src/lisp/kernel/clos/boot.lsp depends on src/lisp/kernel/clos/hierarchy.lsp because of a constant
* that does not seem to be taken in by the build process