### PR TITLE
Unclash symbol core:enqueue

### DIFF
--- a/src/lisp/kernel/cmp/compile-file-parallel.lsp
+++ b/src/lisp/kernel/cmp/compile-file-parallel.lsp
@@ -164,7 +164,7 @@
                  (when *compile-print* (cmp::describe-form form))
                  (unless ast-only
                    (push ast-job ast-jobs)
-                   (core:enqueue ast-queue ast-job))
+                   (core:atomic-enqueue ast-queue ast-job))
                  #+(or)
                  (compile-from-ast ast-job
                                    :optimize optimize
@@ -175,8 +175,8 @@
         ;; Now send :quit messages to all threads
         (loop for thread in ast-threads
               do (cfp-log "Sending two :quit (why not?) for thread ~a~%" (mp:process-name thread))
-              do (core:enqueue ast-queue :quit)
-                 (core:enqueue ast-queue :quit))
+              do (core:atomic-enqueue ast-queue :quit)
+                 (core:atomic-enqueue ast-queue :quit))
         ;; Now wait for all threads to join
         (loop for thread in ast-threads
               do (mp:process-join thread)

--- a/src/lisp/kernel/lsp/queue.lsp
+++ b/src/lisp/kernel/lsp/queue.lsp
@@ -40,7 +40,7 @@
   (setf *readtable* (copy-readtable nil)))
 
 (in-package :core)
-(export '(make-queue queue-p enqueue dequeue dequeue-timed queue-count queue-emptyp))
+(export '(make-queue queue-p atomic-enqueue dequeue dequeue-timed queue-count queue-emptyp))
 
 (defstruct (queue
             (:constructor make-queue
@@ -75,7 +75,7 @@ RETURN:     The lock of the QUEUE.
 RETURN:     The NOT-EMPTY condition variable of the QUEUE.
 "))
 
-(defun enqueue (queue message)
+(defun atomic-enqueue (queue message)
   "
 DO:         Atomically enqueues the MESSAGE in the QUEUE.  
 


### PR DESCRIPTION
* https://github.com/clasp-developers/clasp/blob/dev/src/lisp/kernel/lsp/queue.lsp#L78 as function
* https://github.com/clasp-developers/clasp/blob/dev/src/lisp/kernel/lsp/pprint.lsp#L303 as macro

Would be nice to get a style-warning if a macro is redefined as a function or vice versa