### PR TITLE
fix mp_process_active_p

### DIFF
--- a/src/core/mpPackage.cc
+++ b/src/core/mpPackage.cc
@@ -345,7 +345,7 @@ CL_DEFUN core::T_sp mp__make_lock(core::T_sp name, bool recursive) {
 }
   
 CL_DEFUN core::T_sp mp__process_active_p(Process_sp p) {
-  return p->_Phase ? _lisp->_true() : _Nil<core::T_O>();
+  return (p->_Phase == Active) ? _lisp->_true() : _Nil<core::T_O>();
 }
 
 SYMBOL_EXPORT_SC_(MpPkg,suspend_loop);


### PR DESCRIPTION
```lisp
(load "~/quicklisp/setup.lisp")
(ql:quickload "bordeaux-threads" :verbose t)
;;; The following should return, assuming that the thread terminates in the 2 seconds
(bt:thread-alive-p (prog1 (bt:make-thread (lambda ())) (sleep 2)))
-> nil
````
with the fix the test-suite terminates (previously hung in DEFAULT-SPECIAL-BINDINGS)
```lisp
(ql:quickload :bordeaux-threads/test)
(bordeaux-threads/test::run! :bordeaux-threads)
Running test suite BORDEAUX-THREADS
 Running test SEMAPHORE-SIGNAL-N-OF-M ..
 Running test SEMAPHORE-WAIT-TIMEOUT ...
 Running test SHOULD-LOCK-WITHOUT-CONTENTION ..
 Running test SHOULD-RETRIEVE-THREAD-NAME .
 Running test SHOULD-IDENTIFY-THREADS-CORRECTLY ...
 Running test DEFAULT-SPECIAL-BINDINGS .ff.
 Running test SHOULD-HAVE-CURRENT-THREAD .
 Running test SHOULD-HAVE-THREAD-INTERACTION ..
 Running test INTERRUPT-THREAD ../../src/gctools/interrupt.cc:132 clasp_interrupt_process process: #<PROCESS Anonymous thread @0x118c86cd9>
../../src/gctools/interrupt.cc:135 clasp_interrupt_process queuing signal
../../src/gctools/interrupt.cc:64 do_interrupt_thread of process #<PROCESS Anonymous thread @0x118c86cd9>
../../src/gctools/interrupt.cc:107 Sending signal 31 to thread
In wake_up_thread interrupt.cc
../../src/gctools/interrupt.cc:228:handle_all_queued_interrupts Handling a signal - there are pending interrupts
../../src/gctools/interrupt.cc:230:handle_all_queued_interrupts Handling a signal: #<CLOSURE-WITH-SLOTS@0x12151ab18  LAMBDA :type cclasp  lambda-list: NIL :fptr 0x1244b29d0>
.
 Running test SEMAPHORE-SIGNAL .
 Running test CURRENT-THREAD-IDENTITY .
 Running test JOIN-THREAD-RETURN-VALUE .
 Running test CONDITION-VARIABLE .
 Running test SEMAPHORE-TYPED ...
 Did 26 checks.
    Pass: 24 (92%)
    Skip: 0 ( 0%)
    Fail: 2 ( 7%)

 Failure Details:
 --------------------------------
 DEFAULT-SPECIAL-BINDINGS []: 
      
'(51 52)

 evaluated to 

(51 52)

 which is not 

SET-EQUAL

 to 

(52 54)

..
 --------------------------------
 --------------------------------
 DEFAULT-SPECIAL-BINDINGS []: 
      
'(151 152)

 evaluated to 

(151 152)

 which is not 

SET-EQUAL

 to 

(152 154)

..
 --------------------------------

NIL
(#<IT.BESE.FIVEAM::TEST-FAILURE> #<IT.BESE.FIVEAM::TEST-FAILURE>)
````
