### PR TITLE
Let core__reader_double_quote_string return SimpleCharacterString_sp

### DIFF
--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -1389,6 +1389,7 @@ namespace core {
     bool all_base_char_p() const;
     /*! Return the smallest character simple-string that can hold this */
     SimpleString_sp asMinimalSimpleString() const final;
+    SimpleCharacterString_sp asSimpleString () const;
   };
 };
 

--- a/src/core/array.cc
+++ b/src/core/array.cc
@@ -2334,6 +2334,12 @@ SimpleString_sp StrWNs_O::asMinimalSimpleString() const {
   }
 }
 
+SimpleCharacterString_sp StrWNs_O::asSimpleString() const {
+  SimpleCharacterString_sp strw = SimpleCharacterString_O::make(this->length());
+  strw->unsafe_setf_subseq(0,this->length(),this->asSmartPtr());
+  return strw;
+}
+
 // ------------------------------------------------------------
 //
 // Class BitVectorNs

--- a/src/core/readtable.cc
+++ b/src/core/readtable.cc
@@ -197,7 +197,7 @@ CL_DEFUN T_sp core__reader_double_quote_string(T_sp stream, Character_sp ch) {
     }
     buffer.string()->vectorPushExtend(clasp_make_character(cc));
   }
-  SimpleString_sp result = buffer.string()->asMinimalSimpleString();
+  SimpleCharacterString_sp result = buffer.string()->asSimpleString();
   return result;
 };
 

--- a/src/lisp/regression-tests/strings01.lisp
+++ b/src/lisp/regression-tests/strings01.lisp
@@ -108,3 +108,10 @@
 ;;; These should not return t, but the first index, where it is different
 (test eql-1 (eql 0 (string/= "a" "b")))
 (test eql-2 (eql 0 (string-not-equal "a" "b")))
+
+(test babel-simple-strings
+      (string-equal
+       (make-array 4 :element-type 'character :initial-contents (list #\? (code-char 256) #\? #\? ))
+       (let ((var (copy-seq "????")))
+         (setf (char var 1) (code-char 256))
+         var)))

--- a/src/lisp/regression-tests/strings01.lisp
+++ b/src/lisp/regression-tests/strings01.lisp
@@ -1,3 +1,4 @@
+(in-package #:clasp-tests)
 
 (test read-from-string0 (eq (read-from-string (concatenate 'string "abc" (string #\nul) "AA")) (intern (concatenate 'string "ABC" (string #\nul) "AA"))))
 (test reverse-string (let ((s "abc")) (string= (reverse s) "cba")))
@@ -109,9 +110,19 @@
 (test eql-1 (eql 0 (string/= "a" "b")))
 (test eql-2 (eql 0 (string-not-equal "a" "b")))
 
-(test babel-simple-strings
+;;; 
+;;; The reader reads "????" now as a simpe-string
+;;; But the file-compiler converts its simply into a simple-base-string
+;;; By using ltv/base-string
+(test babel-simple-strings-1
       (string-equal
        (make-array 4 :element-type 'character :initial-contents (list #\? (code-char 256) #\? #\? ))
        (let ((var (copy-seq "????")))
          (setf (char var 1) (code-char 256))
          var)))
+
+;;; What does the file-compiler do with a real unicode
+(test babel-simple-strings-2
+      (equal
+       (type-of "zażółć gęślą jaźń")
+       '(SIMPLE-ARRAY CHARACTER (17))))


### PR DESCRIPTION
Solves the following in the repl:
```lisp
(string-equal
       (make-array 4 :element-type 'character :initial-contents (list #\? (code-char 256) #\? #\? ))
       (let ((var (copy-seq "????")))
         (setf (char var 1) (code-char 256))
         var))
T
````
With the pr var would be a simple-base-string and (setf (char var 1) (code-char 256)) would fail.

Unfortunately this only solves half the problem, since in cmpliteral.lsp, strings are treated with ltv/base-string, which will again convert strings to simple-base-string.

I seem to lack know-how on the c++ side, so I do this as a first part to solve the problem.

Here advise from drmeister on #clasp 
::notify kpoeck I'd use ltvc_make_simple_string(gctools::GCRootsInModule* holder, size_t index, size_t string_length, const int* str) - you want to use unicode code points - right?  So an array of 4-byte integers for the code points would be way more than enough.  I'd have to show you how to add support for it to the new byte code intepreter - but it's easy enough.