### PR TITLE
Allow setter plist operations on nil

### DIFF
--- a/src/core/symbol.cc
+++ b/src/core/symbol.cc
@@ -61,10 +61,6 @@ CL_LAMBDA(plist sym);
 CL_DECLARE();
 CL_DOCSTRING("Set the symbol plist");
 CL_DEFUN_SETF List_sp core__set_symbol_plist(List_sp plist, Symbol_sp sym) {
-  // FIXME: necessary?
-  if (sym.nilp()) {
-    SIMPLE_ERROR(BF("You cannot set the plist of nil"));
-  }
   sym->setf_plist(plist);
   return plist;
 }
@@ -82,9 +78,6 @@ CL_DECLARE();
 CL_DOCSTRING("Set the value of a plist property");
 CL_DEFUN_SETF T_sp core__putprop(T_sp val, Symbol_sp sym, T_sp indicator, T_sp defval) {
   (void)(defval); // unused
-  if (sym.nilp()) {
-    SIMPLE_ERROR(BF("You cannot set the plist of nil"));
-  };
   sym->_PropertyList = core__put_f(sym->_PropertyList, val, indicator);
   return val;
 }

--- a/src/lisp/regression-tests/symbol0.lisp
+++ b/src/lisp/regression-tests/symbol0.lisp
@@ -66,3 +66,6 @@
                    (gentemp nil)
                    :type type-error)
 
+(test build-sbcl-1 (setf (symbol-plist nil)(list 1 2)))
+(test build-sbcl-2 (setf (get nil 1) 2))
+


### PR DESCRIPTION
does allow to compile sbcl with (in my case)
* sh make.sh --xc-host=/Users/karstenpoeck/lisp/compiler/clasp2/build/clasp
Adapt paths as neccessary.

The final build fails  :multiple-use-lvar-interpreted-as-NIL :cast fro the wrong reason, the issue is that in the warning (simple-condition-format-control warning)is not of type SB-FORMAT::FMT-CONTROL.

When cross-compiled with ccl, this does not happen, so could be something in clasp, but need help from the sbcl-guys to figure that out