### PR TITLE
Fix (copy-readtable nil) to still use the dispatch-macro-character defined in lisp

### DIFF
--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -816,6 +816,8 @@ SYMBOL_EXPORT_SC_(ClPkg, copy_structure);
 SYMBOL_EXPORT_SC_(CorePkg, defcallback);
 SYMBOL_EXPORT_SC_(CorePkg, sharp_a_reader);
 SYMBOL_EXPORT_SC_(CorePkg, sharp_s_reader);
+SYMBOL_EXPORT_SC_(CorePkg, sharpmacros_lisp_redefine);
+
 
 void testConses() {
   printf("%s:%d Testing Conses and iterators\n", __FILE__, __LINE__);

--- a/src/core/readtable.cc
+++ b/src/core/readtable.cc
@@ -850,6 +850,9 @@ ReadTable_sp ReadTable_O::create_standard_readtable() {
     Symbol_sp sym = gc::As<Symbol_sp>(oCadr(cur));
     rt->set_dispatch_macro_character(sharp, ch, sym);
   }
+  //reinstall the things defined in lisp
+  if (core::_sym_sharpmacros_lisp_redefine->fboundp())
+    eval::funcall(core::_sym_sharpmacros_lisp_redefine, rt);
   return rt;
 }
 

--- a/src/lisp/kernel/lsp/sharpmacros.lsp
+++ b/src/lisp/kernel/lsp/sharpmacros.lsp
@@ -133,4 +133,15 @@
   (set-dispatch-macro-character #\# #\# #'sharp-sharp)
   (set-dispatch-macro-character #\# #\I #'read-cxx-object))
 
+(defun sharpmacros-lisp-redefine(readtable)
+  (set-dispatch-macro-character #\# #\= #'sharp-equal readtable)
+  (set-dispatch-macro-character #\# #\# #'sharp-sharp readtable)
+  (set-dispatch-macro-character #\# #\I #'read-cxx-object readtable)
+  (set-dispatch-macro-character #\# #\! 'sharp-!-reader readtable)
+  (set-dispatch-macro-character #\# #\a 'sharp-a-reader readtable)
+  (set-dispatch-macro-character #\# #\A 'sharp-a-reader readtable)
+  (set-dispatch-macro-character #\# #\s 'sharp-s-reader readtable)
+  (set-dispatch-macro-character #\# #\S 'sharp-s-reader readtable)
+  (values))      
+        
 (sharpmacros-enhance)

--- a/src/lisp/regression-tests/read01.lisp
+++ b/src/lisp/regression-tests/read01.lisp
@@ -106,6 +106,36 @@
                        chars))))
         (every #'(lambda(a)(typep a 'reader-error)) result)))
 
-  
+(test readtable-1
+      (and (get-dispatch-macro-character #\# #\=)
+             (get-dispatch-macro-character #\# #\#)
+             (get-dispatch-macro-character #\# #\I)
+             (get-dispatch-macro-character #\# #\!)
+             (get-dispatch-macro-character #\# #\a)
+             (get-dispatch-macro-character #\# #\A)
+             (get-dispatch-macro-character #\# #\s)
+             (get-dispatch-macro-character #\# #\S)))
+
+(test readtable-2
+      (let ((new (copy-readtable)))
+        (and (get-dispatch-macro-character #\# #\= new)
+             (get-dispatch-macro-character #\# #\# new)
+             (get-dispatch-macro-character #\# #\I new)
+             (get-dispatch-macro-character #\# #\! new)
+             (get-dispatch-macro-character #\# #\a new)
+             (get-dispatch-macro-character #\# #\A new)
+             (get-dispatch-macro-character #\# #\s new)
+             (get-dispatch-macro-character #\# #\S new))))
+
+(test readtable-3
+      (let ((new (copy-readtable nil)))
+        (and (get-dispatch-macro-character #\# #\= new)
+             (get-dispatch-macro-character #\# #\# new)
+             (get-dispatch-macro-character #\# #\I new)
+             (get-dispatch-macro-character #\# #\! new)
+             (get-dispatch-macro-character #\# #\a new)
+             (get-dispatch-macro-character #\# #\A new)
+             (get-dispatch-macro-character #\# #\s new)
+             (get-dispatch-macro-character #\# #\S new))))
 
 


### PR DESCRIPTION
Should fix al bugs related with `*readtable*` being defined as (copy-readtable nil) by simply re-instating the 8  dispatch-macro-character defined in lisp.

Allows (ql:quickload :repl-utilities) to load, should allow running clpython with a lot less changes