### PR TITLE
Change from_object<char> & to_object<char> to use map char to int, not a lisp char

### DIFF
--- a/include/clasp/core/character.h
+++ b/include/clasp/core/character.h
@@ -90,24 +90,15 @@ namespace translate {
     typedef char DeclareType;
 
     DeclareType _v;
-  from_object( core::T_sp o ) : _v( o.unsafe_character() ){};
+  from_object( core::T_sp o ) : _v( o.unsafe_fixnum() ){};
   };
-
-  // template <>
-  //   struct from_object< unsigned char, std::true_type >
-  // {
-  //   typedef unsigned char DeclareType;
-
-  //   DeclareType _v;
-  // from_object( core::T_sp o ) : _v( o.unsafe_character() ){};
-  // };
 
   template <>
     struct to_object<char> {
     typedef uint GivenType;
     static core::T_sp convert(GivenType v) {
       _G();
-      return core::clasp_make_character(v);
+      return core::clasp_make_fixnum(v);
     }
   };
 };


### PR DESCRIPTION
To test:
```lisp
(load "~/quicklisp/setup.lisp")
(ql:quickload :cffi)
(in-package :cffi)
(= (foreign-funcall "toupper" :char (char-code #\a) :char)
                      (char-code #\A))
````