### PR TITLE
Use class for all hash-tables in core__hash_table_setf_gethash

### DIFF
--- a/src/core/hashTable.cc
+++ b/src/core/hashTable.cc
@@ -786,7 +786,7 @@ T_sp HashTable_O::hash_table_setf_gethash(T_sp key, T_sp value) {
 }
 
 CL_LISPIFY_NAME("core:hash-table-setf-gethash");
-CL_DEFUN T_sp core__hash_table_setf_gethash(HashTable_sp hash_table, T_sp key, T_sp value) {
+CL_DEFUN T_sp core__hash_table_setf_gethash(HashTableBase_sp hash_table, T_sp key, T_sp value) {
   return hash_table->hash_table_setf_gethash(key,value);
 }
 


### PR DESCRIPTION
Make
```lisp
(let ((table (make-hash-table :weakness :key)))
           (setf (gethash :key table) 23)
           (setf (gethash :key1 table) 22)
           (setf (gethash :key table) 25)
           (hash-table-count table))
````
work again