### PR TITLE
add -cst or -non-cst cl__lisp_implementation_version()

### DIFF
--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -318,6 +318,7 @@ SYMBOL_EXPORT_SC_(KeywordPkg, append);
 SYMBOL_EXPORT_SC_(KeywordPkg, debugStartup);
 SYMBOL_EXPORT_SC_(KeywordPkg, debugStartupVerbose);
 SYMBOL_EXPORT_SC_(KeywordPkg, cclasp);
+SYMBOL_EXPORT_SC_(KeywordPkg, cst);
 SYMBOL_EXPORT_SC_(KeywordPkg, bclasp);
 SYMBOL_EXPORT_SC_(KeywordPkg, load);
 SYMBOL_EXPORT_SC_(KeywordPkg, eval);

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -213,6 +213,7 @@ CL_DOCSTRING("lisp-implementation-version");
 CL_DEFUN T_sp cl__lisp_implementation_version() {
   stringstream ss;
   List_sp cleavir = gc::As<Cons_sp>(cl::_sym_STARfeaturesSTAR->symbolValue())->memberEq(kw::_sym_cclasp);
+  List_sp cst = gc::As<Cons_sp>(cl::_sym_STARfeaturesSTAR->symbolValue())->memberEq(kw::_sym_cst);
   if (cleavir.notnilp()) {
     ss << "c";
   }
@@ -225,6 +226,10 @@ CL_DEFUN T_sp cl__lisp_implementation_version() {
   ss << "boehm-";
 #endif
   ss << CLASP_VERSION;
+  if (cst.notnilp())
+    ss << "-cst";
+  else
+    ss << "-non-cst";
   return SimpleBaseString_O::make(ss.str());
 };
 

--- a/src/lisp/kernel/lsp/prologue.lsp
+++ b/src/lisp/kernel/lsp/prologue.lsp
@@ -22,5 +22,5 @@
   (if (member :clos *features*) nil (setq *features* (cons :clos *features*)))
   (if (member :cclasp *features*) nil (setq *features* (cons :cclasp *features*)))
   (if (core:is-interactive-lisp) 
-      (format t "Starting ~a cclasp ~a ... loading image...~%"
-              (if (member :use-mps *features*) "MPS" "Boehm" ) (software-version))))
+      (format t "Starting ~a ... loading image...~%"
+               (lisp-implementation-version))))


### PR DESCRIPTION
(lisp-implementation-version) ->
* "cclasp-boehm-0.4.2-813-ga2b37b3fe-non-cst" or
* "cclasp-boehm-0.4.2-822-gcc308e33b-cst"

Helps to distinguish the version in cl-bench and the fasls in quicklisp .cache (i have cst and non-cst builds at the same time)