### PR TITLE
Fix gray-stream:read-byte, see #339

### DIFF
--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -5611,6 +5611,8 @@ CL_DEFUN T_sp cl__read_byte(T_sp strm, T_sp eof_error_p, T_sp eof_value) {
   // Should signal an error of type error if stream is not a binary input stream.
   if (strm.nilp())
     TYPE_ERROR(strm, cl::_sym_Stream_O);
+   if (!AnsiStreamP(strm))
+     return eval::funcall(gray::_sym_stream_read_byte, strm);
   // as a side effect verifies that strm is really a stream.
   T_sp elt_type = clasp_stream_element_type(strm);
   if (elt_type == cl::_sym_character || elt_type == cl::_sym_base_char)


### PR DESCRIPTION
Fixes partially #339
To test
```lisp
Starting cclasp-boehm-0.4.2-813-ga2b37b3fe-non-cst ... loading image...
Top level in: #<PROCESS TOP-LEVEL @0x11a7faa39>.
COMMON-LISP-USER> (load "~/quicklisp/setup.lisp")

T
COMMON-LISP-USER> (ql:quickload :trivial-gray-streams-test)
To load "trivial-gray-streams-test":
  Load 1 ASDF system:
    trivial-gray-streams-test
; Loading "trivial-gray-streams-test"

(:TRIVIAL-GRAY-STREAMS-TEST)
COMMON-LISP-USER> (asdf:test-system "trivial-gray-streams")

T
COMMON-LISP-USER> (trivial-gray-streams-test:run-tests)
Running test GRAY:STREAM-READ-CHAR... OK
Running test GRAY:STREAM-UNREAD-CHAR... OK
Running test GRAY:STREAM-READ-CHAR-NO-HANG... OK
Running test GRAY:STREAM-PEEK-CHAR... OK
Running test GRAY:STREAM-LISTEN... OK
Running test GRAY:STREAM-READ-LINE... OK
Running test GRAY:STREAM-CLEAR-INPUT... OK
Running test GRAY:STREAM-WRITE-CHAR... OK
Running test GRAY:STREAM-LINE-COLUMN... OK
Running test GRAY::STREAM-START-LINE-P... OK
Running test GRAY:STREAM-WRITE-STRING... OK
Running test GRAY:STREAM-TERPRI... OK
Running test GRAY:STREAM-FRESH-LINE... OK
Running test GRAY:STREAM-FINISH-OUTPUT... OK
Running test GRAY:STREAM-FORCE-OUTPUT... OK
Running test GRAY:STREAM-CLEAR-OUTPUT... OK
Running test GRAY:STREAM-ADVANCE-TO-COLUMN... FAIL: expected invocation: (gray:stream-advance-to-column #<trivial-gray-streams-test::test-stream2> 10) actual: (gray:stream-line-column #<trivial-gray-streams-test::test-stream2>), (gray:stream-write-string #<trivial-gray-streams-test::test-stream2>
                          "                                                                                                    "
                          0
                          10)
Running test GRAY:STREAM-READ-BYTE... OK
Running test GRAY:STREAM-WRITE-BYTE... OK
Running test TRIVIAL-GRAY-STREAMS:STREAM-READ-SEQUENCE... OK
Running test TRIVIAL-GRAY-STREAMS:STREAM-WRITE-SEQUENCE... OK
Running test TRIVIAL-GRAY-STREAMS:STREAM-FILE-POSITION... OK
Running test TRIVIAL-GRAY-STREAMS-TEST::SETF-STREAM-FILE-POSITION... OK
(#<TEST-RESULT GRAY:STREAM-READ-CHAR :OK>
 #<TEST-RESULT GRAY:STREAM-UNREAD-CHAR :OK>
 #<TEST-RESULT GRAY:STREAM-READ-CHAR-NO-HANG :OK>
 #<TEST-RESULT GRAY:STREAM-PEEK-CHAR :OK> #<TEST-RESULT GRAY:STREAM-LISTEN :OK>
 #<TEST-RESULT GRAY:STREAM-READ-LINE :OK>
 #<TEST-RESULT GRAY:STREAM-CLEAR-INPUT :OK>
 #<TEST-RESULT GRAY:STREAM-WRITE-CHAR :OK>
 #<TEST-RESULT GRAY:STREAM-LINE-COLUMN :OK>
 #<TEST-RESULT GRAY::STREAM-START-LINE-P :OK>
 #<TEST-RESULT GRAY:STREAM-WRITE-STRING :OK>
 #<TEST-RESULT GRAY:STREAM-TERPRI :OK>
 #<TEST-RESULT GRAY:STREAM-FRESH-LINE :OK>
 #<TEST-RESULT GRAY:STREAM-FINISH-OUTPUT :OK>
 #<TEST-RESULT GRAY:STREAM-FORCE-OUTPUT :OK>
 #<TEST-RESULT GRAY:STREAM-CLEAR-OUTPUT :OK>
 #<TEST-RESULT GRAY:STREAM-ADVANCE-TO-COLUMN :FAIL expected invocation: (gray:stream-advance-to-column #<trivial-gray-streams-test::test-stream2> 10) actual: (gray:stream-line-column #<trivial-gray-streams-test::test-stream2>), (gray:stream-write-string #<trivial-gray-streams-test::test-stream2>
                          "                                                                                                    "
                          0
                          10)>
 #<TEST-RESULT GRAY:STREAM-READ-BYTE :OK>
 #<TEST-RESULT GRAY:STREAM-WRITE-BYTE :OK>
 #<TEST-RESULT TRIVIAL-GRAY-STREAMS:STREAM-WRITE-SEQUENCE :OK>
 #<TEST-RESULT TRIVIAL-GRAY-STREAMS:STREAM-FILE-POSITION :OK>
 #<TEST-RESULT TRIVIAL-GRAY-STREAMS-TEST::SETF-STREAM-FILE-POSITION :OK>)
````
The remaining failure for GRAY:STREAM-ADVANCE-TO-COLUMN... FAIL does not work in any lisp I tested, so I propose to ignore it.