### PR TITLE
Fix signum for complex (totally wrong definition)

### DIFF
--- a/src/core/numbers.cc
+++ b/src/core/numbers.cc
@@ -2006,8 +2006,10 @@ void Ratio_O::setFromString(const string &str) {
 // --------------------------------------------------------------------------------
 
 Number_sp Complex_O::signum_() const {
-  return clasp_make_complex(gc::As<Real_sp>(clasp_signum(this->_real)),
-                            gc::As<Real_sp>(clasp_signum(this->_imaginary)));
+  if (this->zerop_())
+    return this->asSmartPtr();
+  else
+    return clasp_divide(this->asSmartPtr(), this->abs_());
 }
 
 string Complex_O::__repr__() const {


### PR DESCRIPTION
Test with (equal (SIGNUM (COMPLEX 3/5 4/5)) #c(0.6 0.8))

Did run ansi-test w/o errors for signum after the change