### PR TITLE
Don't compile asdf twice after (require :asdf) while loading "~/quicklisp/setup.lisp"

### DIFF
--- a/src/lisp/kernel/lsp/module.lsp
+++ b/src/lisp/kernel/lsp/module.lsp
@@ -31,7 +31,11 @@ It is used by PROVIDE and REQUIRE.")
 (defun provide (module-name)
   "Adds a new module name to *MODULES* indicating that it has been loaded.
 Module-name is a string designator"
-  (pushnew (string module-name) *modules* :test #'string=)
+  (let ((module-as-string (string module-name)))
+    (pushnew module-as-string *modules* :test #'string=)
+    (when (and (find-package :asdf)(string= "ASDF" (string-upcase module-as-string)))
+      (funcall (find-symbol (string-upcase "register-immutable-system") :asdf) :asdf))
+    )
   t)
 
 (defparameter *requiring* nil)


### PR DESCRIPTION
Now:
```lisp
(require :asdf)
(load "~/quicklisp/setup.lisp")
````
does not compile asdf a second time