### PR TITLE
Fix infinite recursion blowing up statck for StrWNs_O

### DIFF
--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -1124,7 +1124,7 @@ namespace core {
   public:
     void this_asAbstractSimpleVectorRange(AbstractSimpleVector_sp& sv, size_t& start, size_t& end) const  {
       unlikely_if (gc::IsA<my_smart_ptr_type>(this->_Data)) {
-        this->asAbstractSimpleVectorRange(sv,start,end);
+        this->_Data->asAbstractSimpleVectorRange(sv, start, end);
         start += this->_DisplacedIndexOffset;
         end = this->length()+this->_DisplacedIndexOffset;
         return;


### PR DESCRIPTION
Fixes:
```lisp
COMMON-LISP-USER> (CLPYTHON.PARSER:PARSE  (CLPYTHON.PARSER:PY-PPRINT (CLPYTHON.PARSER:PARSE "-1.0" :ONE-EXPR T)))

(CLPYTHON.AST.NODE:|module-stmt|
 (CLPYTHON.AST.NODE:|suite-stmt|
  ((CLPYTHON.AST.NODE:|unary-expr| CLPYTHON.AST.OPERATOR:-
                                   (CLPYTHON.AST.TOKEN:|literal-expr| :NUMBER
                                                                      1.0d0)))))
````