### PR TITLE
Fix dcumentation for compiler macros

### DIFF
--- a/src/lisp/kernel/clos/inspect.lsp
+++ b/src/lisp/kernel/clos/inspect.lsp
@@ -455,11 +455,11 @@ q (or Q):             quits the inspection.~%~
     (setf (slot-value object 'docstring) new-value)))
 
 (defmethod documentation ((object function) doc-type)
-  (when (member doc-type '(t function))
+  (when (member doc-type '(t function compiler-macro))
     (core:function-docstring object)))
 
 (defmethod (setf documentation) (new-value (object function) doc-type)
-  (when (member doc-type '(t function))
+  (when (member doc-type '(t function compiler-macro))
     (setf (core:function-docstring object) new-value)))
 
 (defmethod documentation ((object slot-definition) doc-type)

--- a/src/lisp/regression-tests/environment01.lisp
+++ b/src/lisp/regression-tests/environment01.lisp
@@ -13,4 +13,22 @@
 (TEST-EXPECT-ERROR
  sleep-3
  (sleep -1)
-  :type type-error)
+ :type type-error)
+
+(defun %%test%% (n)
+  (* n 2))
+
+(define-compiler-macro %%test%% (&whole form arg)
+  (if (constantp arg)
+      (* arg 2)
+      form))
+
+(test DOCUMENTATION.LIST.COMPILER-MACRO.2
+      (let ((doc "Buh"))
+        (setf (documentation '%%test%% 'compiler-macro) doc)
+        (string= doc (documentation '%%test%% 'compiler-macro))))
+
+;;; (funcall (compiler-macro-function '%%test%%) '(%%test%% 2) nil)
+
+
+


### PR DESCRIPTION
Before:
```lisp
COMMON-LISP-USER> (defun %%test%% (n)
  (* n 2))
%%TEST%%
COMMON-LISP-USER> (define-compiler-macro %%test%% (&whole form arg)
  (if (constantp arg)
      (* arg 2)
      form))
%%TEST%%
COMMON-LISP-USER> (let ((doc "Buh"))
        (setf (documentation '%%test%% 'compiler-macro) doc)
        (string= doc (documentation '%%test%% 'compiler-macro)))
NIL
```
After
```lisp
COMMON-LISP-USER> (defun %%test%% (n)
  (* n 2))
%%TEST%%
COMMON-LISP-USER> (define-compiler-macro %%test%% (&whole form arg)
  (if (constantp arg)
      (* arg 2)
      form))
%%TEST%%
COMMON-LISP-USER> (let ((doc "Buh"))
        (setf (documentation '%%test%% 'compiler-macro) doc)
        (string= doc (documentation '%%test%% 'compiler-macro)))
T
````