### PR TITLE
Applied stassats proposals

### DIFF
--- a/src/gctools/interrupt.cc
+++ b/src/gctools/interrupt.cc
@@ -233,10 +233,12 @@ void handle_all_queued_interrupts()
 }
 
 void handle_or_queue(core::ThreadLocalState* thread, core::T_sp signal_code ) {
-  if (!signal_code) {
-    printf("%s:%d handle_or_queue   signal_code is NULL\n", __FILE__, __LINE__ );
+  if (signal_code.nilp() || !signal_code.fixnump())
+    return;
+  gc::Fixnum signal_int = signal_code.unsafe_fixnum();
+  if ((signal_int == SIGSEGV || signal_int == SIGBUS || signal_int == SIGILL) {
+     handle_signal_now(signal_code,thread->_Process);
   }
-  if (signal_code.nilp() || !signal_code) return;
   if (interrupts_disabled_by_lisp()) {
     queue_signal(thread,signal_code,false);
   }


### PR DESCRIPTION
Basically from stassats on irc clasp (I deleted the names)
```lisp 18:25:50
can you edit handle_or_queue?
to go directly to handle_signal_now when signal_code is sigsegv 
sigbus shouldn't be queued either 
add sigill as well
````

Test as follows
```lisp
(defstruct foo bar)

FOO
COMMON-LISP-USER> (foo-bar 0)
../../src/gctools/interrupt.cc:160 Received a unix signal with code: 11

Condition of type: UNIX-SIGNAL-RECEIVED
Serious signal 11 caught.

Available restarts:
(use :r1 to invoke restart 1)

1. (CONTINUE) Ignore signal
2. (RESTART-TOPLEVEL) Go back to Top-Level REPL.
````
Before this change that used to loop, see e.g. #764 