### PR TITLE
Fix unbreak cffi (fixes 789)

### DIFF
--- a/src/lisp/kernel/cleavir/ast.lisp
+++ b/src/lisp/kernel/cleavir/ast.lisp
@@ -111,14 +111,16 @@
 ;;; This AST is used to represent a call to an intrinsic function inserted into the generated code.
 
 (defclass base-foreign-call-ast (cleavir-ast:ast)
-  ((%argument-asts :initarg :argument-asts :reader argument-asts)))
+  ((%foreign-types :initarg :foreign-types :accessor foreign-types :initform nil)
+   (%argument-asts :initarg :argument-asts :reader argument-asts)))
 
 (cleavir-io:define-save-info base-foreign-call-ast
-  (:argument-asts argument-asts))
+    (:foreign-types foreign-types)
+    (:argument-asts argument-asts))
 
 (defmethod cleavir-ast-graphviz::label ((ast base-foreign-call-ast))
   (with-output-to-string (s)
-    (format s "base-foreign-call")))
+    (format s "base-foreign-call ~a" (foreign-types ast))))
 
 (defmethod cleavir-ast:children ((ast base-foreign-call-ast))
   (argument-asts ast))
@@ -150,11 +152,9 @@
 ;;;   inserted into the generated code.
 
 (defclass foreign-call-ast (base-foreign-call-ast cleavir-ast:one-value-ast-mixin)
-  ((%foreign-types :initarg :foreign-types :accessor foreign-types)
-   (%function-name :initarg :function-name :accessor function-name)))
+  ((%function-name :initarg :function-name :accessor function-name)))
 
 (cleavir-io:define-save-info foreign-call-ast
-    (:foreign-types foreign-types)
     (:function-name function-name))
 
 (defmethod cleavir-ast-graphviz::label ((ast foreign-call-ast))


### PR DESCRIPTION
Fixes #789 
To test
```lisp
COMMON-LISP-USER> (require :asdf)

("ASDF" "asdf" "UIOP" "uiop")
COMMON-LISP-USER> (load "~/quicklisp/setup.lisp")

T
COMMON-LISP-USER> (ql:quickload :trivial-features-tests) 
To load "trivial-features-tests":
  Load 1 ASDF system:
    trivial-features-tests
; Loading "trivial-features-tests"
[package trivial-features-tests]; cc -o /Users/karstenpoeck/.cache/common-lisp/clasp-cclasp-boehm-0.4.2-1052-gdb2bc0fa6-non-cst-macosx-x64/Users/karstenpoeck/quicklisp/dists/quicklisp/software/trivial-features-20161204-git/tests/utsname__grovel-tmpUEHX7WQD.o -c -m64 -I /opt/local/include/ -fPIC -I/Users/karstenpoeck/quicklisp/local-projects/fork-cffi/ /Users/karstenpoeck/.cache/common-lisp/clasp-cclasp-boehm-0.4.2-1052-gdb2bc0fa6-non-cst-macosx-x64/Users/karstenpoeck/quicklisp/dists/quicklisp/software/trivial-features-20161204-git/tests/utsname__grovel.c
; cc -o /Users/karstenpoeck/.cache/common-lisp/clasp-cclasp-boehm-0.4.2-1052-gdb2bc0fa6-non-cst-macosx-x64/Users/karstenpoeck/quicklisp/dists/quicklisp/software/trivial-features-20161204-git/tests/utsname__grovel-tmpUW17QWQR -m64 /Users/karstenpoeck/.cache/common-lisp/clasp-cclasp-boehm-0.4.2-1052-gdb2bc0fa6-non-cst-macosx-x64/Users/karstenpoeck/quicklisp/dists/quicklisp/software/trivial-features-20161204-git/tests/utsname__grovel.o
; /Users/karstenpoeck/.cache/common-lisp/clasp-cclasp-boehm-0.4.2-1052-gdb2bc0fa6-non-cst-macosx-x64/Users/karstenpoeck/quicklisp/dists/quicklisp/software/trivial-features-20161204-git/tests/utsname__grovel /Users/karstenpoeck/.cache/common-lisp/clasp-cclasp-boehm-0.4.2-1052-gdb2bc0fa6-non-cst-macosx-x64/Users/karstenpoeck/quicklisp/dists/quicklisp/software/trivial-features-20161204-git/tests/utsname__grovel.grovel-tmp.lisp
..
(:TRIVIAL-FEATURES-TESTS)
COMMON-LISP-USER> (trivial-features-tests::do-tests)

Doing 9 pending tests of 9 tests total.
 TRIVIAL-FEATURES-TESTS::ENDIANNESS.1 TRIVIAL-FEATURES-TESTS::OS.1
 TRIVIAL-FEATURES-TESTS::OS.2 TRIVIAL-FEATURES-TESTS::OS.3
 TRIVIAL-FEATURES-TESTS::OS.4 TRIVIAL-FEATURES-TESTS::CPU.1
 TRIVIAL-FEATURES-TESTS::CPU.2 TRIVIAL-FEATURES-TESTS::NIL.1
 TRIVIAL-FEATURES-TESTS::NIL.2
No tests failed.
T
````