### PR TITLE
Use *.o files whenever possible, only link once in build-fasl

### DIFF
--- a/src/lisp/kernel/cmp/cmpbundle.lsp
+++ b/src/lisp/kernel/cmp/cmpbundle.lsp
@@ -340,21 +340,14 @@ Return the **output-pathname**."
 
 (export '(builder))
 
-
 (defun build-fasl (out-file &key lisp-files init-name)
   "Link the object files in lisp-files into a shared library in out-file.
 Note: 'object-files' would be a better name than 'lisp-files' - but 'lisp-files' is what asdf provides.
 Return the truename of the output file.
 NOTE: On Linux it looks like we MUST link all of the bitcode files first into one and then convert that into a fasb.
 This is to ensure that the RUN-ALL functions are evaluated in the correct order."
-  ;; fixme cracauer - figure out what FreeBSD needs here
-  (declare (ignore init-name))
-  ;;  (bformat t "cmpbundle.lsp:build-fasl  building fasl for %s from files: %s%N" out-file lisp-files)
-  (with-compiler-timer (:message "build-fasl" :report-link-time t :verbose t)
-    (let ((bitcode-files (mapcar (lambda (p) (make-pathname :type (core:bitcode-extension) :defaults p))
-                                 lisp-files))
-          (temp-bitcode-file (make-pathname :type (core:bitcode-extension) :defaults out-file)))
-      (link-bitcode-modules temp-bitcode-file bitcode-files)
-      (execute-link-fasl out-file (list temp-bitcode-file)))))
+  (llvm-link out-file :input-files lisp-files :input-type :object :link-type :fasl))
+
+
 
 (export 'build-fasl)


### PR DESCRIPTION
This fix should:
- Delete again the files left behind the parallel compiler
- Only link *.ll or *.bc when really necessary (e.g. the parallel compiler produces both *.bc/*.ll and *.o files, otherwise link the *.o files
- Fix build-fasl not start all over, if there is already a *.o file (e.g. just link the *.o to a fasl, don't regenerate a *.bc/*.ll) file. This is independent from parallel or sequential compile

Only with these fixes I was able to compile cl-jpeg and that only in parallel mode.

To test:
in the shell `export GC_INITIAL_HEAP_SIZE=5G`
```lisp
(setq cmp::*compile-file-parallel* nil) ;;; or (setq cmp::*compile-file-parallel* t)
(time (ql:quickload :cl-jpeg :verbose t))
````
Should produce a jpeg.fasl of about 400 MB after ca. 40 minutes (parallel) or 90 minutes (sequentially) on my laptop.

This PR overwrites #810