### PR TITLE
consider clasp_print_readably in BitVector_O::__write__ and SimpleBitVector_O::__write__

### DIFF
--- a/src/core/write_array.cc
+++ b/src/core/write_array.cc
@@ -197,41 +197,37 @@ namespace core {
 #endif
 
     void SimpleBitVector_O::__write__(T_sp stream) const {
-	if (!clasp_print_array() && !clasp_print_readably()) {
-	    writestr_stream("#<simple-bit-vector ", stream);
-	    clasp_write_addr(this->asSmartPtr(), stream);
-	    clasp_write_char('>', stream);
-	} else {
-	    cl_index ndx;
-	    writestr_stream("#*", stream);
-	    if (clasp_print_array() || clasp_print_readably()) {
-	    	for (ndx=0; ndx<this->length(); ++ndx)
-			//      if (x->vector.self.bit[(ndx /*+ x->vector.offset*/) / 8] & (0200 >> (ndx /*+ x->vector.offset*/) % 8))
-			if (this->testBit(ndx))
-		    	clasp_write_char('1', stream);
-			else
-		    	clasp_write_char('0', stream);
-		    	}
-		}	
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    writestr_stream("#<simple-bit-vector ", stream);
+                    clasp_write_addr(this->asSmartPtr(), stream);
+                    clasp_write_char('>', stream);
+            } else {
+                    if (clasp_print_array() || clasp_print_readably()) {
+                            writestr_stream("#*", stream);
+                            for (cl_index ndx=0; ndx<this->length(); ++ndx)
+                                    if (this->testBit(ndx))
+                                            clasp_write_char('1', stream);
+                                    else
+                                            clasp_write_char('0', stream);
+                    }
+            }	
     }
 
     void BitVector_O::__write__(T_sp stream) const {
-	if (!clasp_print_array() && !clasp_print_readably()) {
-	    writestr_stream("#<bit-vector ", stream);
-	    clasp_write_addr(this->asSmartPtr(), stream);
-	    clasp_write_char('>', stream);
-	} else {
-	    cl_index ndx;
-	    writestr_stream("#*", stream);
-	    if  (clasp_print_array() || clasp_print_readably()) {
-	    	for (ndx = 0; ndx < this->length(); ndx++)
-			//      if (x->vector.self.bit[(ndx /*+ x->vector.offset*/) / 8] & (0200 >> (ndx /*+ x->vector.offset*/) % 8))
-			if (this->testBit(ndx))
-		    	clasp_write_char('1', stream);
-			else
-		    	clasp_write_char('0', stream);
+            if (!clasp_print_array() && !clasp_print_readably()) {
+                    writestr_stream("#<bit-vector ", stream);
+                    clasp_write_addr(this->asSmartPtr(), stream);
+                    clasp_write_char('>', stream);
+            } else {
+                    if (clasp_print_array() || clasp_print_readably()) {
+                            writestr_stream("#*", stream);
+                            for (cl_index ndx = 0; ndx < this->length(); ndx++)
+                                    if (this->testBit(ndx))
+                                            clasp_write_char('1', stream);
+                                    else
+                                            clasp_write_char('0', stream);
 		    }
-		}
+            }
     }
 
     static void write_simple_vector_simple (const char *title, Array_sp x, T_sp stream) {

--- a/src/core/write_array.cc
+++ b/src/core/write_array.cc
@@ -202,14 +202,13 @@ namespace core {
                     clasp_write_addr(this->asSmartPtr(), stream);
                     clasp_write_char('>', stream);
             } else {
-                    if (clasp_print_array() || clasp_print_readably()) {
-                            writestr_stream("#*", stream);
-                            for (cl_index ndx=0; ndx<this->length(); ++ndx)
-                                    if (this->testBit(ndx))
-                                            clasp_write_char('1', stream);
-                                    else
-                                            clasp_write_char('0', stream);
-                    }
+                    writestr_stream("#*", stream);
+                    for (cl_index ndx=0; ndx<this->length(); ++ndx)
+                            if (this->testBit(ndx))
+                                    clasp_write_char('1', stream);
+                            else
+                                    clasp_write_char('0', stream);
+
             }	
     }
 
@@ -219,14 +218,12 @@ namespace core {
                     clasp_write_addr(this->asSmartPtr(), stream);
                     clasp_write_char('>', stream);
             } else {
-                    if (clasp_print_array() || clasp_print_readably()) {
-                            writestr_stream("#*", stream);
-                            for (cl_index ndx = 0; ndx < this->length(); ndx++)
-                                    if (this->testBit(ndx))
-                                            clasp_write_char('1', stream);
-                                    else
-                                            clasp_write_char('0', stream);
-		    }
+                    writestr_stream("#*", stream);
+                    for (cl_index ndx = 0; ndx < this->length(); ndx++)
+                            if (this->testBit(ndx))
+                                    clasp_write_char('1', stream);
+                            else
+                                    clasp_write_char('0', stream);
             }
     }
 

--- a/src/core/write_array.cc
+++ b/src/core/write_array.cc
@@ -204,7 +204,7 @@ namespace core {
 	} else {
 	    cl_index ndx;
 	    writestr_stream("#*", stream);
-	    if (clasp_print_array()) {
+	    if (clasp_print_array() || clasp_print_readably()) {
 	    	for (ndx=0; ndx<this->length(); ++ndx)
 			//      if (x->vector.self.bit[(ndx /*+ x->vector.offset*/) / 8] & (0200 >> (ndx /*+ x->vector.offset*/) % 8))
 			if (this->testBit(ndx))
@@ -223,7 +223,7 @@ namespace core {
 	} else {
 	    cl_index ndx;
 	    writestr_stream("#*", stream);
-	    if  (clasp_print_array()) {
+	    if  (clasp_print_array() || clasp_print_readably()) {
 	    	for (ndx = 0; ndx < this->length(); ndx++)
 			//      if (x->vector.self.bit[(ndx /*+ x->vector.offset*/) / 8] & (0200 >> (ndx /*+ x->vector.offset*/) % 8))
 			if (this->testBit(ndx))


### PR DESCRIPTION
so that
```lisp
(let ((*print-array* nil)
      (*print-pretty* nil)
      (*PRINT-READABLY* t))
  (with-output-to-string (stream)
      (princ (make-array 2 :element-type 'bit :initial-element 0) stream)))
````
results in
```lisp
"#*00"
````
and not in
```lisp
"#*"
````