### PR TITLE
protect core::monitor_message with #ifdef DEBUG_MONITOR

### DIFF
--- a/src/llvmo/llvmoExpose.cc
+++ b/src/llvmo/llvmoExpose.cc
@@ -4015,9 +4015,11 @@ SYMBOL_EXPORT_SC_(CorePkg,repl);
 CL_DEFUN core::Function_sp llvm_sys__jitFinalizeReplFunction(ClaspJIT_sp jit, ModuleHandle_sp handle, const string& replName, const string& startupName, const string& shutdownName, core::T_sp initialData) {
   // Stuff to support MCJIT
   if (core::_sym_STARdebugStartupSTAR->symbolValue().notnilp()) {
+#ifdef DEBUG_MONITOR
     core::monitor_message("startup llvm_sys__jitFinalizeReplFunction replName->");
     core::monitor_message(replName);
     core::monitor_message("\n");
+#endif
   }
   core::Pointer_sp replPtr;
   if (replName!="") {


### PR DESCRIPTION
t o avoid
```c++
../../src/llvmo/llvmoExpose.cc:4018:11: error: no member named 'monitor_message' in namespace 'core'
    core::monitor_message("startup llvm_sys__jitFinalizeReplFunction replName->");
    ~~~~~~^
../../src/llvmo/llvmoExpose.cc:4019:11: error: no type named 'monitor_message' in namespace 'core'
    core::monitor_message(replName);
    ~~~~~~^
../../src/llvmo/llvmoExpose.cc:4020:11: error: no member named 'monitor_message' in namespace 'core'
    core::monitor_message("\n");
    ~~~~~~^
3 errors generated.
````