### PR TITLE
Speed-up log* functions for fixnums

### DIFF
--- a/src/core/numbers.cc
+++ b/src/core/numbers.cc
@@ -246,20 +246,237 @@ CL_DEFUN Real_sp cl__max(Real_sp max, List_sp nums) {
   return max;
 }
 
+// logand, logxor, logior, logeqv are all nearly the same, apart from the operation
+// logandc1_id until lognor_id as well
+
+typedef enum {
+    logand_id = 0,
+    logxor_id = 1,
+    logior_id = 2,
+    logeqv_id = 3,
+    logandc1_id = 4,
+    logandc2_id =5,
+    logorc1_id = 6,
+    logorc2_id = 7,
+    lognand_id = 8,
+    lognor_id = 9
+} log_operations;
+
+Integer_sp log_operation_2op(log_operations operation, Integer_sp first, Integer_sp second) {
+  // if the arguments are all fixnum, don't convert everything to mpz, but stay in fixnums
+  if (first.fixnump() && second.fixnump()){
+    gc::Fixnum first_internal = first.unsafe_fixnum();
+    gc::Fixnum second_internal = second.unsafe_fixnum();
+    gc::Fixnum result;
+    switch (operation) {
+    case logand_id:
+        result = first_internal & second_internal;
+        break;
+    case logxor_id:
+        result = first_internal ^ second_internal;
+        break;
+    case logior_id:
+        result = first_internal | second_internal;
+        break;
+    case logeqv_id:
+        result = (~(first_internal ^ second_internal));
+        break;
+    case logandc1_id:
+        result = (~first_internal) & second_internal;
+        break;
+    case logandc2_id:
+        result = first_internal & (~second_internal);
+        break;
+    case logorc1_id:
+        result = (~first_internal) | second_internal;
+        break;
+    case logorc2_id:
+        result = first_internal | (~second_internal);
+        break;
+    case lognand_id:
+        result = ~(first_internal & second_internal);
+        break;
+    case lognor_id:
+        result = ~(first_internal | second_internal);
+        break;
+    default:
+        SIMPLE_ERROR(BF("Unknown operation in log_operation_2op"));
+    }
+    return clasp_make_fixnum(result);
+  }
+  else {
+    mpz_class result_bignum;
+    mpz_class temp_bignum;
+    switch (operation) {
+    case logand_id:
+        mpz_and(result_bignum.get_mpz_t(), clasp_to_mpz(first).get_mpz_t(), clasp_to_mpz(second).get_mpz_t());
+        break;
+    case logxor_id:
+        mpz_xor(result_bignum.get_mpz_t(), clasp_to_mpz(first).get_mpz_t(), clasp_to_mpz(second).get_mpz_t());
+        break;
+    case logior_id:
+        mpz_ior(result_bignum.get_mpz_t(), clasp_to_mpz(first).get_mpz_t(), clasp_to_mpz(second).get_mpz_t());
+        break;
+    case logeqv_id:
+        mpz_xor(temp_bignum.get_mpz_t(), clasp_to_mpz(first).get_mpz_t(), clasp_to_mpz(second).get_mpz_t());
+        mpz_com(result_bignum.get_mpz_t(), temp_bignum.get_mpz_t());
+        break;
+    case logandc1_id:
+        mpz_com(temp_bignum.get_mpz_t(), clasp_to_mpz(first).get_mpz_t());
+        mpz_and(result_bignum.get_mpz_t(), temp_bignum.get_mpz_t(), clasp_to_mpz(second).get_mpz_t());
+        break;
+    case logandc2_id:
+        mpz_com(temp_bignum.get_mpz_t(), clasp_to_mpz(second).get_mpz_t());
+        mpz_and(result_bignum.get_mpz_t(), clasp_to_mpz(first).get_mpz_t(), temp_bignum.get_mpz_t());
+        break;
+    case logorc1_id:
+        mpz_com(temp_bignum.get_mpz_t(), clasp_to_mpz(first).get_mpz_t());
+        mpz_ior(result_bignum.get_mpz_t(), temp_bignum.get_mpz_t(), clasp_to_mpz(second).get_mpz_t());
+        break;
+    case logorc2_id:
+        mpz_com(temp_bignum.get_mpz_t(), clasp_to_mpz(second).get_mpz_t());
+        mpz_ior(result_bignum.get_mpz_t(), clasp_to_mpz(first).get_mpz_t(), temp_bignum.get_mpz_t());
+        break;
+    case lognand_id:
+        mpz_and(temp_bignum.get_mpz_t(), clasp_to_mpz(first).get_mpz_t(), clasp_to_mpz(second).get_mpz_t());
+        mpz_com(result_bignum.get_mpz_t(), temp_bignum.get_mpz_t());
+        break;
+    case lognor_id:
+        mpz_ior(temp_bignum.get_mpz_t(), clasp_to_mpz(first).get_mpz_t(), clasp_to_mpz(second).get_mpz_t());
+        mpz_com(result_bignum.get_mpz_t(), temp_bignum.get_mpz_t());
+        break;
+    default:
+        SIMPLE_ERROR(BF("Unknown operation in cl__log_operation_rest"));
+    }
+    return Integer_O::create(result_bignum);
+  }
+}
+
+CL_LAMBDA(first second);
+CL_DECLARE();
+CL_DOCSTRING("logand_2op");
+CL_DEFUN Integer_sp core__logand_2op(Integer_sp first, Integer_sp second) {
+  return log_operation_2op(logand_id, first, second);
+}
+
+CL_LAMBDA(first second);
+CL_DECLARE();
+CL_DOCSTRING("logxor_2op");
+CL_DEFUN Integer_sp core__logxor_2op(Integer_sp first, Integer_sp second) {
+  return log_operation_2op(logxor_id, first, second);
+}
+
+CL_LAMBDA(first second);
+CL_DECLARE();
+CL_DOCSTRING("logior_2op");
+CL_DEFUN Integer_sp core__logior_2op(Integer_sp first, Integer_sp second) {
+  return log_operation_2op(logior_id, first, second);
+}
+
+CL_LAMBDA(first second);
+CL_DECLARE();
+CL_DOCSTRING("logeqv_2op");
+CL_DEFUN Integer_sp core__logeqv_2op(Integer_sp first, Integer_sp second) {
+  return log_operation_2op(logeqv_id, first, second);
+}
+
+Integer_sp log_operation_rest(List_sp integers, log_operations operation) {
+  // if the arguments are all fixnum, don't convert everything to mpz, but stay in fixnums
+  bool acc_fixnum_p = true;
+  Integer_sp first = gc::As<Integer_sp>(oCar(integers));
+  gc::Fixnum acc_fixnum;
+  mpz_class acc_bignum;
+  if (first.fixnump()) {
+    acc_fixnum = first.unsafe_fixnum();
+  }
+  else {
+    acc_fixnum_p = false;
+    acc_bignum = clasp_to_mpz(first);
+  }
+  for (auto cur : (List_sp)oCdr(integers)) {
+    Integer_sp icur = gc::As<Integer_sp>(oCar(cur));
+    if (acc_fixnum_p) {
+      if (icur.fixnump()) {
+        // we stay in fixnum
+        switch (operation) {
+        case logand_id:
+            acc_fixnum = acc_fixnum & icur.unsafe_fixnum();
+            break;
+        case logxor_id:
+            acc_fixnum = acc_fixnum ^ icur.unsafe_fixnum();
+            break;
+        case logior_id:
+            acc_fixnum = acc_fixnum | icur.unsafe_fixnum();
+            break;
+        case logeqv_id:
+            acc_fixnum = (~(acc_fixnum ^ icur.unsafe_fixnum()));
+            break;
+        default:
+            SIMPLE_ERROR(BF("Unknown operation in cl__log_operation_rest"));
+        }
+      }
+      else {
+        // need to go bignum
+        acc_fixnum_p = false;
+        acc_bignum = clasp_to_mpz(Integer_O::create(acc_fixnum));
+        mpz_class temp;
+        mpz_class temp1;
+        switch (operation) {
+        case logand_id:
+            mpz_and(temp.get_mpz_t(), acc_bignum.get_mpz_t(), clasp_to_mpz(icur).get_mpz_t());
+            break;
+        case logxor_id:
+            mpz_xor(temp.get_mpz_t(),  acc_bignum.get_mpz_t(), clasp_to_mpz(icur).get_mpz_t());
+            break;
+        case logior_id:
+            mpz_ior(temp.get_mpz_t(),  acc_bignum.get_mpz_t(), clasp_to_mpz(icur).get_mpz_t());
+            break;
+        case logeqv_id:
+            mpz_xor(temp1.get_mpz_t(), acc_bignum.get_mpz_t(), clasp_to_mpz(icur).get_mpz_t());
+            mpz_com(temp.get_mpz_t(), temp1.get_mpz_t());
+        default:
+            SIMPLE_ERROR(BF("Unknown operation in cl__log_operation_rest"));
+        }
+        acc_bignum = temp;
+      }
+    } else {
+      mpz_class temp;
+      mpz_class temp1;
+      switch (operation) {
+      case logand_id:
+          mpz_and(temp.get_mpz_t(), acc_bignum.get_mpz_t(), clasp_to_mpz(icur).get_mpz_t());
+          break;
+      case logxor_id:
+          mpz_xor(temp.get_mpz_t(),  acc_bignum.get_mpz_t(), clasp_to_mpz(icur).get_mpz_t());
+          break;
+      case logior_id:
+          mpz_ior(temp.get_mpz_t(),  acc_bignum.get_mpz_t(), clasp_to_mpz(icur).get_mpz_t());
+          break;
+      case logeqv_id:
+          mpz_xor(temp1.get_mpz_t(), acc_bignum.get_mpz_t(), clasp_to_mpz(icur).get_mpz_t());
+          mpz_com(temp.get_mpz_t(), temp1.get_mpz_t());
+          break;
+      default:
+          SIMPLE_ERROR(BF("Unknown operation in cl__log_operation_rest"));
+      }
+      acc_bignum = temp;
+    }
+  }
+  if (acc_fixnum_p)
+    return Integer_O::create(acc_fixnum);
+  else
+    return Integer_O::create(acc_bignum);
+}
+
 CL_LAMBDA(&rest integers);
 CL_DECLARE();
 CL_DOCSTRING("logand");
 CL_DEFUN Integer_sp cl__logand(List_sp integers) {
+  // if the arguments are all fixnum, don't convert everything to mpz, but stay in fixnums
   if (integers.nilp())
-    return Integer_O::create((gc::Fixnum) - 1);
-  mpz_class acc = clasp_to_mpz(gc::As<Integer_sp>(oCar(integers)));
-  for (auto cur : (List_sp)oCdr(integers)) {
-    Integer_sp icur = gc::As<Integer_sp>(oCar(cur));
-    mpz_class temp;
-    mpz_and(temp.get_mpz_t(), acc.get_mpz_t(), clasp_to_mpz(icur).get_mpz_t());
-    acc = temp;
-  }
-  return Integer_O::create(acc);
+    return clasp_make_fixnum(-1);
+  else
+    return log_operation_rest(integers, logand_id); 
 };
 
 CL_LAMBDA(&rest integers);
@@ -267,17 +484,9 @@ CL_DECLARE();
 CL_DOCSTRING("logior");
 CL_DEFUN Integer_sp cl__logior(List_sp integers) {
   if (integers.nilp())
-    return Integer_O::create((gc::Fixnum)0);
-  Integer_sp ifirst = gc::As<Integer_sp>(oCar(integers));
-  mpz_class acc = clasp_to_mpz(ifirst);
-  List_sp rints = oCdr(integers);
-  for (auto cur : rints) {
-    Integer_sp icur = gc::As<Integer_sp>(oCar(cur));
-    mpz_class temp;
-    mpz_ior(temp.get_mpz_t(), acc.get_mpz_t(), clasp_to_mpz(icur).get_mpz_t());
-    acc = temp;
-  }
-  return Integer_O::create(acc);
+    return clasp_make_fixnum(0);
+  else
+    return log_operation_rest(integers, logior_id); 
 };
 
 CL_LAMBDA(&rest integers);
@@ -285,129 +494,77 @@ CL_DECLARE();
 CL_DOCSTRING("logxor");
 CL_DEFUN Integer_sp cl__logxor(List_sp integers) {
   if (integers.nilp())
-    return Integer_O::create((gc::Fixnum)0);
-  Integer_sp ifirst = gc::As<Integer_sp>(oCar(integers));
-  mpz_class acc = clasp_to_mpz(ifirst);
-  for (auto cur : (List_sp)oCdr(integers)) {
-    Integer_sp icur = gc::As<Integer_sp>(oCar(cur));
-    mpz_class temp;
-    mpz_xor(temp.get_mpz_t(), acc.get_mpz_t(), clasp_to_mpz(icur).get_mpz_t());
-    acc = temp;
-  }
-  return Integer_O::create(acc);
+    return clasp_make_fixnum(0);
+  else
+    return log_operation_rest(integers, logxor_id);
 };
 
 CL_LAMBDA(&rest integers);
 CL_DECLARE();
 CL_DOCSTRING("logeqv");
-CL_DEFUN Integer_mv cl__logeqv(List_sp integers) {
+CL_DEFUN Integer_sp cl__logeqv(List_sp integers) {
   if (integers.nilp())
     return Integer_O::create((gc::Fixnum) - 1);
-  Integer_sp ifirst = gc::As<Integer_sp>(oCar(integers));
-  mpz_class x = clasp_to_mpz(ifirst);
-  for (auto cur : (List_sp)oCdr(integers)) {
-    Integer_sp icur = gc::As<Integer_sp>(oCar(cur));
-    mpz_class y = clasp_to_mpz(icur);
-    mpz_class x_and_y;
-    mpz_and(x_and_y.get_mpz_t(), x.get_mpz_t(), y.get_mpz_t());
-    mpz_class compx;
-    mpz_com(compx.get_mpz_t(), x.get_mpz_t());
-    mpz_class compy;
-    mpz_com(compy.get_mpz_t(), y.get_mpz_t());
-    mpz_class compx_and_compy;
-    mpz_and(compx_and_compy.get_mpz_t(), compx.get_mpz_t(), compy.get_mpz_t());
-    // calculate ex-nor
-    mpz_ior(x.get_mpz_t(), x_and_y.get_mpz_t(), compx_and_compy.get_mpz_t());
-  }
-  return (Values(Integer_O::create(x)));
+  else
+    return log_operation_rest(integers, logeqv_id);
 };
 
 CL_LAMBDA(a b);
 CL_DECLARE();
 CL_DOCSTRING("logandc1");
-CL_DEFUN T_mv cl__logandc1(Integer_sp a, Integer_sp b) {
-  mpz_class za = clasp_to_mpz(a);
-  mpz_class zb = clasp_to_mpz(b);
-  mpz_class cza;
-  mpz_com(cza.get_mpz_t(), za.get_mpz_t());
-  mpz_class r;
-  mpz_and(r.get_mpz_t(), cza.get_mpz_t(), zb.get_mpz_t());
-  return (Values(Integer_O::create(r)));
+CL_DEFUN Integer_sp cl__logandc1(Integer_sp a, Integer_sp b) {
+  return log_operation_2op(logandc1_id, a, b);
 };
 
 CL_LAMBDA(a b);
 CL_DECLARE();
 CL_DOCSTRING("logandc2");
-CL_DEFUN T_mv cl__logandc2(Integer_sp a, Integer_sp b) {
-  mpz_class za = clasp_to_mpz(a);
-  mpz_class zb = clasp_to_mpz(b);
-  mpz_class czb;
-  mpz_com(czb.get_mpz_t(), zb.get_mpz_t());
-  mpz_class r;
-  mpz_and(r.get_mpz_t(), za.get_mpz_t(), czb.get_mpz_t());
-  return (Values(Integer_O::create(r)));
+CL_DEFUN Integer_sp cl__logandc2(Integer_sp a, Integer_sp b) {
+  return log_operation_2op(logandc2_id, a, b);
 };
 
 CL_LAMBDA(a b);
 CL_DECLARE();
 CL_DOCSTRING("logorc1");
-CL_DEFUN T_mv cl__logorc1(Integer_sp a, Integer_sp b) {
-  mpz_class za = clasp_to_mpz(a);
-  mpz_class zb = clasp_to_mpz(b);
-  mpz_class cza;
-  mpz_com(cza.get_mpz_t(), za.get_mpz_t());
-  mpz_class r;
-  mpz_ior(r.get_mpz_t(), cza.get_mpz_t(), zb.get_mpz_t());
-  return (Values(Integer_O::create(r)));
+CL_DEFUN Integer_sp cl__logorc1(Integer_sp a, Integer_sp b) {
+  return log_operation_2op(logorc1_id, a, b);
 };
 
 CL_LAMBDA(a b);
 CL_DECLARE();
 CL_DOCSTRING("logorc2");
-CL_DEFUN T_mv cl__logorc2(Integer_sp a, Integer_sp b) {
-  mpz_class za = clasp_to_mpz(a);
-  mpz_class zb = clasp_to_mpz(b);
-  mpz_class czb;
-  mpz_com(czb.get_mpz_t(), zb.get_mpz_t());
-  mpz_class r;
-  mpz_ior(r.get_mpz_t(), za.get_mpz_t(), czb.get_mpz_t());
-  return (Values(Integer_O::create(r)));
+CL_DEFUN Integer_sp cl__logorc2(Integer_sp a, Integer_sp b) {
+  return log_operation_2op(logorc2_id, a, b);
 };
 
 CL_LAMBDA(a);
 CL_DECLARE();
 CL_DOCSTRING("lognot");
-CL_DEFUN T_mv cl__lognot(Integer_sp a) {
-  mpz_class za = clasp_to_mpz(a);
-  mpz_class cza;
-  mpz_com(cza.get_mpz_t(), za.get_mpz_t());
-  return (Values(Integer_O::create(cza)));
+CL_DEFUN Integer_sp cl__lognot(Integer_sp a) {
+  if (a.fixnump()) {
+    // in ecl return @logxor(2,x,ecl_make_fixnum(-1))
+    return clasp_make_fixnum(a.unsafe_fixnum() ^ -1);   
+  }
+  else {
+    mpz_class za = clasp_to_mpz(a);
+    mpz_class cza;
+    mpz_com(cza.get_mpz_t(), za.get_mpz_t());
+    return Integer_O::create(cza);
+  }
 };
 
 CL_LAMBDA(a b);
 CL_DECLARE();
 CL_DOCSTRING("lognand");
-CL_DEFUN T_mv cl__lognand(Integer_sp a, Integer_sp b) {
-  mpz_class za = clasp_to_mpz(a);
-  mpz_class zb = clasp_to_mpz(b);
-  mpz_class zand;
-  mpz_and(zand.get_mpz_t(), za.get_mpz_t(), zb.get_mpz_t());
-  mpz_class r;
-  mpz_com(r.get_mpz_t(), zand.get_mpz_t());
-  return (Values(Integer_O::create(r)));
+CL_DEFUN Integer_sp cl__lognand(Integer_sp a, Integer_sp b) {
+  return log_operation_2op(lognand_id, a, b);
 };
 
 CL_LAMBDA(a b);
 CL_DECLARE();
 CL_DOCSTRING("lognor");
-CL_DEFUN T_mv cl__lognor(Integer_sp a, Integer_sp b) {
-  mpz_class za = clasp_to_mpz(a);
-  mpz_class zb = clasp_to_mpz(b);
-  mpz_class zor;
-  mpz_ior(zor.get_mpz_t(), za.get_mpz_t(), zb.get_mpz_t());
-  mpz_class r;
-  mpz_com(r.get_mpz_t(), zor.get_mpz_t());
-  return (Values(Integer_O::create(r)));
+CL_DEFUN Integer_sp cl__lognor(Integer_sp a, Integer_sp b) {
+  return log_operation_2op(lognor_id, a, b);
 };
 
 CL_NAME("TWO-ARG-+-FIXNUM-FIXNUM");
@@ -1507,7 +1664,10 @@ SYMBOL_EXPORT_SC_(ClPkg, _PLUS_);
 SYMBOL_EXPORT_SC_(ClPkg, _TIMES_);
 SYMBOL_EXPORT_SC_(ClPkg, _MINUS_);
 SYMBOL_EXPORT_SC_(ClPkg, _DIVIDE_);
-
+SYMBOL_EXPORT_SC_(CorePkg, logand_2op);
+SYMBOL_EXPORT_SC_(CorePkg, logxor_2op);
+SYMBOL_EXPORT_SC_(CorePkg, logior_2op);
+SYMBOL_EXPORT_SC_(CorePkg, logeqv_2op);
 
 
 Number_sp Number_O::create(double val) {

--- a/src/lisp/kernel/cmp/opt-number.lsp
+++ b/src/lisp/kernel/cmp/opt-number.lsp
@@ -60,6 +60,19 @@
 (define-compiler-macro 1- (x)
   `(core:two-arg-- ,x 1))
 
+;;; log* operations
+(define-compiler-macro logand (&rest numbers)
+  (core:expand-associative 'logand 'core:logand-2op numbers -1))
+
+(define-compiler-macro logxor (&rest numbers)
+  (core:expand-associative 'logxor 'core:logxor-2op numbers 0))
+
+(define-compiler-macro logior (&rest numbers)
+  (core:expand-associative 'logior 'core:logior-2op numbers 0))
+
+(define-compiler-macro logeqv (&rest numbers)
+  (core:expand-associative 'logeqv 'core:logeqv-2op numbers -1))
+
 ;;; byte operations: look for calls like (foo ... (byte ...) ...)
 
 (in-package #:core)


### PR DESCRIPTION
Speed up cl-bench test crc40 from cl-bench

```lisp
(declaim (inline crc-division-step))

(defun crc-division-step (bit rmdr poly msb-mask)
  (declare (type (signed-byte 56) rmdr poly msb-mask)
	   (type bit bit))
  ;; Shift in the bit into the LSB of the register (rmdr)
  (let ((new-rmdr (logior bit (* rmdr 2))))
    ;; Divide by the polynomial, and return the new remainder
    (if (zerop (logand msb-mask new-rmdr))
	new-rmdr
	(logxor new-rmdr poly))))

(defun compute-adjustment (poly n)
  (declare (type (signed-byte 56) poly)
	   (fixnum n))
  ;; Precompute X^(n-1) mod poly
  (let* ((poly-len-mask (ash 1 (1- (integer-length poly))))
	 (rmdr (crc-division-step 1 0 poly poly-len-mask)))
    (dotimes (k (- n 1))
      (setf rmdr (crc-division-step 0 rmdr poly poly-len-mask)))
    rmdr))

(defun calculate-crc40 (iterations)
  (declare (fixnum iterations))
  (let ((crc-poly 1099587256329)
	(len 3014633)
	(answer 0))
    (dotimes (k iterations)
      (declare (fixnum k))
      (setf answer (compute-adjustment crc-poly len)))
    answer))

(defun run-crc40 ()
  (calculate-crc40 10))
````

speedup from 108.13 to 28.86 secs
(* rmdr 2) is now slowest part (+ rmdr rmdr) would be much faster