### PR TITLE
Have (load <file> :print t) print newlines after every sexp

### DIFF
--- a/src/core/load.cc
+++ b/src/core/load.cc
@@ -60,7 +60,7 @@ T_sp load_stream(T_sp strm, bool print) {
     }
     if (x.number_of_values() > 0) {
       if (print)
-        write_bf_stream(BF(";; -read- %s") % _rep_(x));
+        write_bf_stream(BF(";; -read- %s\n") % _rep_(x));
       eval::funcall(core::_sym_STAReval_with_env_hookSTAR->symbolValue(), x, _Nil<T_O>());
     }
   }


### PR DESCRIPTION
test with 
```lisp
(load "sys:regression-tests;framework.lisp" :print t)
;; -read- (DEFPACKAGE #:CLASP-TESTS (:USE :CL :CORE) (:EXPORT #:TEST #:TEST-EXPECT-ERROR));; -read- (IN-PACKAGE #:CLASP-TESTS);; -read- (DEFPARAMETER *PASSES* 0);; -read- (DEFPARAMETER *FAILS* 0);; -read- (DEFPARAMETER *FAILED-TESTS* NIL);; -read- (DEFPARAMETER *EXPECTED-FAILURES* NIL);; -read- (DEFPARAMETER *FILES-FAILED-TO-COMPILE* NIL);; -read- (DEFPARAMETER *TEST-MARKER-TABLE* (MAKE-HASH-TABLE));; -read- (DEFUN RESET-CLASP-TESTS NIL (SETQ *PASSES* 0 *FAILS* 0 *FAILED-TESTS* NIL *FILES-FAILED-TO-COMPILE* NIL *TEST-MARKER-TABLE* (MAKE-HASH-TABLE) *DUPLICATE-TESTS* NIL)); caught WARNING:
;   Undefined variable *DUPLICATE-TESTS*
; 
; compilation unit finished
;   caught 1 WARNING condition
;; -read- (DEFUN NOTE-TEST (NAME) (COND ((GETHASH NAME *TEST-MARKER-TABLE*) (PUSH NAME *DUPLICATE-TESTS*) (WARN ~%Duplicate test ~a~% NAME)) (T (SETF (GETHASH NAME *TEST-MARKER-TABLE*) T)))); caught WARNING:
;   Undefined variable *DUPLICATE-TESTS*
; caught WARNING:
;   Undefined variable *DUPLICATE-TESTS*
; 
; compilation unit finished
;   caught 2 WARNING conditions
;; -read- (DEFUN NOTE-TEST-FINISHED NIL (SETQ *FAILED-TESTS* (NREVERSE *FAILED-TESTS*)));; -read- (DEFUN NOTE-COMPILE-ERROR (FILE&ERROR) (PUSH FILE&ERROR *FILES-FAILED-TO-COMPILE*));; -read- (DEFUN SHOW-FAILED-TESTS NIL (COND (*FAILED-TESTS* (FORMAT T ~%Failed tests ~a~% *FAILED-TESTS*) (SHOW-UNEXPECTED-FAILURES)) (T (FORMAT T ~%No tests failed~%))) (WHEN *FILES-FAILED-TO-COMPILE* (DOLIST (FILE&ERROR *FILES-FAILED-TO-COMPILE*) (FORMAT T Compilation error for file ~a with error  ~a~% (FIRST FILE&ERROR) (SECOND FILE&ERROR)))) (WHEN *DUPLICATE-TESTS* (DOLIST (TEST *DUPLICATE-TESTS*) (FORMAT T Duplicate test ~a~% TEST)))); caught WARNING:
;   Undefined variable *DUPLICATE-TESTS*
; caught WARNING:
;   Undefined variable *DUPLICATE-TESTS*
; caught STYLE-WARNING:
;   Undefined function SHOW-UNEXPECTED-FAILURES
;     at /Users/karstenpoeck/lisp/compiler/clasp-karsten/src/lisp/regression-tests/framework.lisp 34:0
; 
; 
; compilation unit finished
;   caught 2 WARNING conditions
;   caught 1 STYLE-WARNING condition
;; -read- (DEFUN SHOW-UNEXPECTED-FAILURES NIL (LET ((UNEXPECTED-FAILURES NIL)) (DOLIST (FAIL *FAILED-TESTS*) (UNLESS (MEMBER FAIL *EXPECTED-FAILURES*) (PUSH FAIL UNEXPECTED-FAILURES))) (WHEN UNEXPECTED-FAILURES (FORMAT T ~%unexpected failures ~a~% (NREVERSE UNEXPECTED-FAILURES))) (LET ((UNEXPECTED-SUCCESSES NIL)) (DOLIST (FAIL *EXPECTED-FAILURES*) (UNLESS (MEMBER FAIL *FAILED-TESTS*) (PUSH FAIL UNEXPECTED-SUCCESSES))) (WHEN UNEXPECTED-SUCCESSES (FORMAT T ~%unexpected success ~a~% (NREVERSE UNEXPECTED-SUCCESSES))))));; -read- (DEFMACRO TEST (NAME FORM &KEY DESCRIPTION) (QUASIQUOTE (IF (PROGN (NOTE-TEST (QUOTE (UNQUOTE NAME))) (IGNORE-ERRORS (UNQUOTE FORM))) (PROGN (FORMAT T Passed ~s~% (QUOTE (UNQUOTE NAME))) (INCF *PASSES*)) (PROGN (INCF *FAILS*) (PUSH (QUOTE (UNQUOTE NAME)) *FAILED-TESTS*) (FORMAT T Failed ~s~% (QUOTE (UNQUOTE NAME))) (WHEN (UNQUOTE DESCRIPTION) (FORMAT T ~s~% (UNQUOTE DESCRIPTION)))))));; -read- (DEFMACRO TEST-TYPE= (T1 T2) (QUASIQUOTE (TEST (AND (SUBTYPEP (UNQUOTE T1) (UNQUOTE T2)) (SUBTYPEP (UNQUOTE T2) (UNQUOTE T1))))));; -read- (DEFUN EXPAND-TEST-EXPECT-ERROR (FN) (HANDLER-CASE (PROGN (FUNCALL FN) NIL) (ERROR (ERR) T)));; -read- (DEFMACRO TEST-EXPECT-ERROR (NAME FORM &KEY (TYPE (QUOTE ERROR)) DESCRIPTION) (QUASIQUOTE (TEST (UNQUOTE NAME) (HANDLER-CASE (PROGN (UNQUOTE FORM) NIL) ((UNQUOTE TYPE) (ERR) T)) :DESCRIPTION (UNQUOTE DESCRIPTION))));; -read- (DEFUN LOAD-IF-COMPILED-CORRECTLY (FILE) (HANDLER-CASE (MULTIPLE-VALUE-BIND (FASL WARNINGS-P FAILURE-P) (LET ((*COMPILE-FILE-PARALLEL* NIL)) (COMPILE-FILE FILE)) (DECLARE (IGNORE WARNINGS-P FAILURE-P)) (WHEN FASL (LOAD FASL))) (ERROR (E) (NOTE-COMPILE-ERROR (LIST FILE E)) (FORMAT T Regression: compile-file of ~a failed with ~a~% FILE E))))
T
````
with the pr
```lisp
COMMON-LISP-USER> (load "sys:regression-tests;framework.lisp" :print t)
;; -read- (DEFPACKAGE #:CLASP-TESTS (:USE :CL :CORE) (:EXPORT #:TEST #:TEST-EXPECT-ERROR))
;; -read- (IN-PACKAGE #:CLASP-TESTS)
;; -read- (DEFPARAMETER *PASSES* 0)
;; -read- (DEFPARAMETER *FAILS* 0)
;; -read- (DEFPARAMETER *FAILED-TESTS* NIL)
;; -read- (DEFPARAMETER *EXPECTED-FAILURES* NIL)
;; -read- (DEFPARAMETER *FILES-FAILED-TO-COMPILE* NIL)
;; -read- (DEFPARAMETER *TEST-MARKER-TABLE* (MAKE-HASH-TABLE))
;; -read- (DEFUN RESET-CLASP-TESTS NIL (SETQ *PASSES* 0 *FAILS* 0 *FAILED-TESTS* NIL *FILES-FAILED-TO-COMPILE* NIL *TEST-MARKER-TABLE* (MAKE-HASH-TABLE) *DUPLICATE-TESTS* NIL))
; caught WARNING:
;   Undefined variable *DUPLICATE-TESTS*
; 
; compilation unit finished
;   caught 1 WARNING condition
;; -read- (DEFUN NOTE-TEST (NAME) (COND ((GETHASH NAME *TEST-MARKER-TABLE*) (PUSH NAME *DUPLICATE-TESTS*) (WARN ~%Duplicate test ~a~% NAME)) (T (SETF (GETHASH NAME *TEST-MARKER-TABLE*) T))))
; caught WARNING:
;   Undefined variable *DUPLICATE-TESTS*
; caught WARNING:
;   Undefined variable *DUPLICATE-TESTS*
; 
; compilation unit finished
;   caught 2 WARNING conditions
;; -read- (DEFUN NOTE-TEST-FINISHED NIL (SETQ *FAILED-TESTS* (NREVERSE *FAILED-TESTS*)))
;; -read- (DEFUN NOTE-COMPILE-ERROR (FILE&ERROR) (PUSH FILE&ERROR *FILES-FAILED-TO-COMPILE*))
;; -read- (DEFUN SHOW-FAILED-TESTS NIL (COND (*FAILED-TESTS* (FORMAT T ~%Failed tests ~a~% *FAILED-TESTS*) (SHOW-UNEXPECTED-FAILURES)) (T (FORMAT T ~%No tests failed~%))) (WHEN *FILES-FAILED-TO-COMPILE* (DOLIST (FILE&ERROR *FILES-FAILED-TO-COMPILE*) (FORMAT T Compilation error for file ~a with error  ~a~% (FIRST FILE&ERROR) (SECOND FILE&ERROR)))) (WHEN *DUPLICATE-TESTS* (DOLIST (TEST *DUPLICATE-TESTS*) (FORMAT T Duplicate test ~a~% TEST))))
; caught WARNING:
;   Undefined variable *DUPLICATE-TESTS*
; caught WARNING:
;   Undefined variable *DUPLICATE-TESTS*
; caught STYLE-WARNING:
;   Undefined function SHOW-UNEXPECTED-FAILURES
;     at /Users/karstenpoeck/lisp/compiler/clasp-karsten/src/lisp/regression-tests/framework.lisp 34:0
; 
; 
; compilation unit finished
;   caught 2 WARNING conditions
;   caught 1 STYLE-WARNING condition
;; -read- (DEFUN SHOW-UNEXPECTED-FAILURES NIL (LET ((UNEXPECTED-FAILURES NIL)) (DOLIST (FAIL *FAILED-TESTS*) (UNLESS (MEMBER FAIL *EXPECTED-FAILURES*) (PUSH FAIL UNEXPECTED-FAILURES))) (WHEN UNEXPECTED-FAILURES (FORMAT T ~%unexpected failures ~a~% (NREVERSE UNEXPECTED-FAILURES))) (LET ((UNEXPECTED-SUCCESSES NIL)) (DOLIST (FAIL *EXPECTED-FAILURES*) (UNLESS (MEMBER FAIL *FAILED-TESTS*) (PUSH FAIL UNEXPECTED-SUCCESSES))) (WHEN UNEXPECTED-SUCCESSES (FORMAT T ~%unexpected success ~a~% (NREVERSE UNEXPECTED-SUCCESSES))))))
;; -read- (DEFMACRO TEST (NAME FORM &KEY DESCRIPTION) (QUASIQUOTE (IF (PROGN (NOTE-TEST (QUOTE (UNQUOTE NAME))) (IGNORE-ERRORS (UNQUOTE FORM))) (PROGN (FORMAT T Passed ~s~% (QUOTE (UNQUOTE NAME))) (INCF *PASSES*)) (PROGN (INCF *FAILS*) (PUSH (QUOTE (UNQUOTE NAME)) *FAILED-TESTS*) (FORMAT T Failed ~s~% (QUOTE (UNQUOTE NAME))) (WHEN (UNQUOTE DESCRIPTION) (FORMAT T ~s~% (UNQUOTE DESCRIPTION)))))))
;; -read- (DEFMACRO TEST-TYPE= (T1 T2) (QUASIQUOTE (TEST (AND (SUBTYPEP (UNQUOTE T1) (UNQUOTE T2)) (SUBTYPEP (UNQUOTE T2) (UNQUOTE T1))))))
;; -read- (DEFUN EXPAND-TEST-EXPECT-ERROR (FN) (HANDLER-CASE (PROGN (FUNCALL FN) NIL) (ERROR (ERR) T)))
;; -read- (DEFMACRO TEST-EXPECT-ERROR (NAME FORM &KEY (TYPE (QUOTE ERROR)) DESCRIPTION) (QUASIQUOTE (TEST (UNQUOTE NAME) (HANDLER-CASE (PROGN (UNQUOTE FORM) NIL) ((UNQUOTE TYPE) (ERR) T)) :DESCRIPTION (UNQUOTE DESCRIPTION))))
;; -read- (DEFUN LOAD-IF-COMPILED-CORRECTLY (FILE) (HANDLER-CASE (MULTIPLE-VALUE-BIND (FASL WARNINGS-P FAILURE-P) (LET ((*COMPILE-FILE-PARALLEL* NIL)) (COMPILE-FILE FILE)) (DECLARE (IGNORE WARNINGS-P FAILURE-P)) (WHEN FASL (LOAD FASL))) (ERROR (E) (NOTE-COMPILE-ERROR (LIST FILE E)) (FORMAT T Regression: compile-file of ~a failed with ~a~% FILE E))))
T

````