### PR TITLE
ansi-tests: (setf (slot-value ..)) should ignore values of slot-missing

### DIFF
--- a/src/lisp/kernel/clos/std-slot-value.lsp
+++ b/src/lisp/kernel/clos/std-slot-value.lsp
@@ -263,9 +263,7 @@
 	  (let ((location (gethash slot-name location-table nil)))
 	    (if location
                 (setf (standard-instance-access self location) value)
-                (progn
-                  (slot-missing class self slot-name 'SETF value)
-                  value)))
+                (slot-missing class self slot-name 'SETF value)))
 	  (let ((slotd
                  #+(or) (find slot-name (class-slots class) :key #'slot-definition-name)
                  (loop for prospect in (class-slots class)
@@ -274,9 +272,8 @@
                     return prospect)))
 	    (if slotd
 		(setf (slot-value-using-class class self slotd) value)
-		(progn
-                  (slot-missing class self slot-name 'SETF value)
-                  value)))))))
+		(slot-missing class self slot-name 'SETF value))))))
+  value)
 
 
 ;;;

--- a/src/lisp/regression-tests/clos.lisp
+++ b/src/lisp/regression-tests/clos.lisp
@@ -22,4 +22,17 @@
 
 (test issue-698
       (vectorp (foo-bar (make-array 23 :adjustable T))))
+
 #+cst (test-expect-error make-instance.error.5 (let ()(make-instance)) :type program-error)
+
+(defclass slot-missing-class-01 () (a))
+
+(defmethod slot-missing ((class t) (obj slot-missing-class-01)
+                         (slot-name t) (operation t)
+                         &optional (new-value nil new-value-p))
+  42)
+
+(test slot-missing-2-simplified
+      (eq 'bar
+          (let ((obj (make-instance 'slot-missing-class-01)))
+            (setf (slot-value obj 'foo) 'bar))))


### PR DESCRIPTION
Fixes test slot-missing-2-simplified and the corresponding ansi-test