### PR TITLE
Fix equalp for Str8Ns_O and StrWNs_O

### DIFF
--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -1319,6 +1319,7 @@ namespace core {
     virtual clasp_elttype elttype() const { return clasp_aet_bc; };
   public:
     virtual bool equal(T_sp other) const final;
+    virtual bool equalp(T_sp other) const final;
   public:
     iterator begin() { return &(*this)[0]; };
     iterator end() { return &(*this)[this->length()]; };
@@ -1376,6 +1377,7 @@ namespace core {
     virtual clasp_elttype elttype() const { return clasp_aet_ch; };
   public:
     virtual bool equal(T_sp other) const final;
+    virtual bool equalp(T_sp other) const final;
   public:
     iterator begin() { return &(*this)[0]; };
     iterator end() { return &(*this)[this->length()]; };

--- a/src/core/array.cc
+++ b/src/core/array.cc
@@ -2261,6 +2261,17 @@ bool Str8Ns_O::equal(T_sp other) const {
   return false;
 };
 
+bool Str8Ns_O::equalp(T_sp other) const {
+  if (&*other==this) return true;
+  if (!other.generalp()) return false;
+  if (cl__stringp(other)) {
+    String_sp sother = gc::As_unsafe<String_sp>(other);
+    TEMPLATE_HALF_STRING_DISPATCHER(this,sother,template_string_equalp_bool,0,this->length(),0,sother->length());
+  } else {
+    return this-> MDArray_O::equalp(other);
+  }
+}
+
 // Creators - depreciate these once the new array stuff is working better
 Str8Ns_sp Str8Ns_O::create(const string& nm) {
   auto ss = SimpleBaseString_O::make(nm.size(),'\0',true,nm.size(),(const claspChar*)nm.c_str());
@@ -2344,6 +2355,17 @@ bool StrWNs_O::equal(T_sp other) const {
   }
   return false;
 };
+
+bool StrWNs_O::equalp(T_sp other) const {
+  if (&*other==this) return true;
+  if (!other.generalp()) return false;
+  if (cl__stringp(other)) {
+    String_sp sother = gc::As_unsafe<String_sp>(other);
+    TEMPLATE_HALF_STRING_DISPATCHER(this,sother,template_string_equalp_bool,0,this->length(),0,sother->length());
+  } else {
+    return this->MDArray_O::equalp(other);
+  }
+}
 
 std::string StrWNs_O::get_std_string() const {
   std::string sout(this->length(),' ');

--- a/src/lisp/regression-tests/sequences01.lisp
+++ b/src/lisp/regression-tests/sequences01.lisp
@@ -297,11 +297,32 @@
 (test equalp-1
       (equalp "1234567890" (make-array 15 :element-type 'character :initial-contents "123456789012345" :fill-pointer 10)))
 
-;;; fails
+;;; fails no longer
 (test equalp-2
       (equalp
        (make-array 12 :element-type 'character :initial-contents "123456789012" :fill-pointer 10)
        (make-array 15 :element-type 'character :initial-contents "123456789012345" :fill-pointer 10)))
+
+(test equalp-2a
+      (equalp
+       (make-array 15 :element-type 'base-char :initial-contents "123456789012345" :fill-pointer 10)
+       (make-array 12 :element-type 'base-char :initial-contents "123456789012" :fill-pointer 10)))
+
+(test equalp-2b
+      (equalp
+       (make-array 3 :element-type 'base-char :initial-contents "abc" :fill-pointer 2)
+       (vector #\a #\B)))
+
+(test equalp-2c
+      (equalp
+       (make-array 3 :element-type 'character :initial-contents "abc" :fill-pointer 2)
+       (vector #\a #\B)))
+
+(test equalp-2d
+      (not (equalp
+            (make-array 3 :element-type 'character :initial-contents "abc" :fill-pointer 2)
+            23)))
+
 
 ;;; from clhs Fill-pointer in the second array seem to be respected
 (test equalp-clhs-1
@@ -312,11 +333,20 @@
                                 :fill-pointer 6)))
         (equalp array1 array2)))
 
-;;; from clhs Fill-pointer in the first array not, although I assume that (equalp a b) implies (equalp b a)
-(test equalp-clhs-2
+;;; from clhs 5.3.36 equalp
+;;; If two arrays have the same number of dimensions, the dimensions match, and the corresponding active elements are equalp.
+(test equalp-clhs-2a
       (Let ((array1 (make-array 6 :element-type 'integer
                                 :initial-contents '(1 1 1 3 5 7)))
             (array2 (make-array 8 :element-type 'integer
+                                :initial-contents '(1 1 1 3 5 7 2 6)
+                                :fill-pointer 6)))
+        (equalp array2 array1)))
+
+(test equalp-clhs-2b
+      (Let ((array2 (make-array 6 :element-type 'integer
+                                :initial-contents '(1 1 1 3 5 7)))
+            (array1 (make-array 8 :element-type 'integer
                                 :initial-contents '(1 1 1 3 5 7 2 6)
                                 :fill-pointer 6)))
         (equalp array2 array1)))

--- a/src/lisp/regression-tests/set-unexpected-failures.lisp
+++ b/src/lisp/regression-tests/set-unexpected-failures.lisp
@@ -2,9 +2,9 @@
 
 (setq *expected-failures*
       '(ANSI-PUSHNEW.14A 
-        EQUALP-2
+        ;;; EQUALP-2
         ;;; EQUALP-CLHS-2
-        EQUALP-3 EQUALP-4
+        ;;; EQUALP-3 EQUALP-4
         ;;; EQUALP-6 EQUALP-7
         ;;; NREVERSE-1
         ;;; REVERSE-1
@@ -31,12 +31,12 @@
         PRINT-READ-1
         ;;; GENTEMP-1 SPECIAL-OPERATOR-P-1
 
-        EQUALP-8 EQUALP-9
+        ;;; EQUALP-8 EQUALP-9
         TYPES-CLASSES-9 TYPES-CLASSES-10
         HASH-TABLE-SIZE-WEAK-KEY
         #-cst BABEL-SIMPLE-STRINGS-1
         LISTEN-3
-        ;;; what is correct syntax for a funcion name
+        ;;; what is correct syntax for a function name
         FBOUNDP.ERROR.3
         FBOUNDP.ERROR.4
         FBOUNDP.ERROR.5
@@ -114,7 +114,7 @@
 
         ;;; READ-FROM-STRING0
         READ-PRINT-CONSISTENCY-ARRAYS
-        EQUALP-HASH-TABLE-2
+        ;;; EQUALP-HASH-TABLE-2
 
         ;;; glsl-toolkit-grammar.lisp-1 errors while compiling in ast
         ;;; make-instance.error.5 the same


### PR DESCRIPTION
Fixes:
* equalp-2
* equalp-2a
* equalp-2b
* equalp-2c

By defining equalp for 
* Str8Ns_O
* StrWNs_O

Added tests for the change
Did run regression tests and complete ansi-tests with cst compiler
