### PR TITLE
Initial for for float-bits conversion functions for issue 583

### DIFF
--- a/src/core/numbers.cc
+++ b/src/core/numbers.cc
@@ -3406,8 +3406,68 @@ LongFloat clasp_to_long_double(Number_sp x)
 
   // --- END OF TRANSLATORS ---
 
+CL_LAMBDA(singleFloat);
+CL_DECLARE();
+CL_DOCSTRING("Return the bit representation of a single float in a lisp Fixnum");
+CL_DEFUN Fixnum_sp core__single_float_bits(SingleFloat_sp singleFloat) {
+  union SingleFloatConversion {
+        float input;
+        long  output;
+  };
+  SingleFloatConversion converter;
+  converter.input = unbox_single_float(singleFloat);
+  return clasp_make_fixnum((gc::Fixnum) converter.output);
+}
+
+CL_LAMBDA(bit-representation);
+CL_DECLARE();
+CL_DOCSTRING("Convert a bit representation in a lisp Fixnum to a single float");
+CL_DEFUN SingleFloat_sp core__single_float_from_unsigned_byte_32(Fixnum_sp fixnum) {
+  union SingleFloatConversion {
+        float input;
+        long  output;
+    };
+  SingleFloatConversion converter;
+  converter.output = unbox_fixnum(fixnum);
+  return make_single_float(converter.input);
 };
 
+CL_LAMBDA(doubleFloat);
+CL_DECLARE();
+CL_DOCSTRING("Return the bit representation of a double float in a lisp Integer if possible a Fixnum");
+CL_DEFUN Integer_sp core__double_float_bits(DoubleFloat_sp doubleFloat) {
+  union DoubleFloatConversion {
+        double input;
+        long   output;
+  };
+  DoubleFloatConversion converter;
+  converter.input = doubleFloat->get();
+  long temp = converter.output;
+  if ((temp >= gc::most_negative_fixnum) && (temp <= gc::most_positive_fixnum))
+    return clasp_make_fixnum((gc::Fixnum) temp);
+  else return Bignum_O::create((gc::Fixnum) temp); // (int64_t)?
+}
+
+CL_LAMBDA(bit-representation);
+CL_DECLARE();
+CL_DOCSTRING("Convert a bit representation in a lisp Integer to a double float");
+CL_DEFUN DoubleFloat_sp core__double_float_from_bits(Integer_sp integer) {
+  union DoubleFloatConversion {
+        double input;
+        long   output;
+    };
+  DoubleFloatConversion converter;
+  if (integer.fixnump()) {
+    converter.output = unbox_fixnum(integer);
+    return clasp_make_double_float(converter.input);
+  } else
+  {
+    converter.output = integer->as_long();
+    return clasp_make_double_float(converter.input);
+  }
+};
+
+}
 
 namespace core {
 

--- a/src/lisp/regression-tests/numbers-core.lisp
+++ b/src/lisp/regression-tests/numbers-core.lisp
@@ -1,0 +1,34 @@
+(in-package #:clasp-tests)
+
+(test single-float-bit-positive-cases
+      (let ((args
+             (list most-negative-single-float -3.0 0.0 3.0 most-positive-single-float)))
+        (dolist (arg args t)
+          (let ((bits (core::single-float-bits arg)))
+            (unless
+                (= arg (core::single-float-from-unsigned-byte-32 bits))
+              (return nil))))))
+
+(test-expect-error single-float-bit-negative-1 (core::single-float-bits 0))
+(test-expect-error single-float-bit-negative-2 (core::single-float-bits 3))
+(test-expect-error single-float-bit-negative-3 (core::single-float-bits 3.d0))
+(test-expect-error single-float-bit-negative-4 (core::single-float-bits (1+ most-positive-fixnum)))
+(test-expect-error single-float-bit-negative-5 (core::single-float-bits (1- most-negative-fixnum)))
+
+(test double-float-bit-positive-cases
+      (let ((args
+             (list most-negative-double-float -3.0d0 0.0d0 3.0d0 most-positive-double-float)))
+        (dolist (arg args t)
+          (let ((bits (core::double-float-bits arg)))
+            (unless
+                (= arg (core::double-float-from-bits bits))
+              (return nil))))))
+
+(test-expect-error double-float-bit-negative-1 (core::double-float-bits 0))
+(test-expect-error double-float-bit-negative-2 (core::double-float-bits 3))
+(test-expect-error double-float-bit-negative-3 (core::double-float-bits 3.0))
+(test-expect-error double-float-bit-negative-4 (core::double-float-bits (1+ most-positive-fixnum)))
+(test-expect-error double-float-bit-negative-5 (core::double-float-bits (1- most-negative-fixnum)))
+
+
+

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -36,6 +36,7 @@
 (load-if-compiled-correctly "sys:regression-tests;types01.lisp")
 (load-if-compiled-correctly "sys:regression-tests;control01.lisp")
 (load-if-compiled-correctly "sys:regression-tests;loop.lisp")
+(load-if-compiled-correctly "sys:regression-tests;numbers-core.lisp")
 
 (progn
   (note-test-finished)


### PR DESCRIPTION
provide missing functions for float-features as requested in issue 583 by shinmera:
- core::single-float-bits (single-float to bits)
- core::single-float-from-unsigned-byte-32 (bits to single float)
- core::double-float-bits (double floats to bits)
- core::double-float-from-bits (bits to double floats)
- tests for all of the above