### PR TITLE
Run regression-tests with safety set to high, adapt expected errors!

### DIFF
--- a/src/lisp/regression-tests/cons01.lisp
+++ b/src/lisp/regression-tests/cons01.lisp
@@ -118,3 +118,7 @@
       (not
       (LET ((X (LIST 'A 'B 'C 'D)))
         (EQ (APPEND X NIL) X))))
+
+(test-expect-error  MEMBER-IF.ERROR.8 (MEMBER-IF #'IDENTITY 'A) :type type-error)
+(test-expect-error  ASSOC-IF.ERROR.12 (ASSOC-IF #'NULL '((A . B) :BAD (C . D))) :type type-error)
+(test-expect-error  ASSOC-IF-NOT.ERROR.12 (ASSOC-IF-NOT #'IDENTITY '((A . B) :BAD (C . D))) :type type-error)

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -1,3 +1,7 @@
+(in-package :cl-user)
+
+(declaim (optimize (safety 3)))
+
 (load (compile-file "sys:regression-tests;framework.lisp"))
 (load "sys:regression-tests;set-unexpected-failures.lisp")
 

--- a/src/lisp/regression-tests/sequences01.lisp
+++ b/src/lisp/regression-tests/sequences01.lisp
@@ -297,11 +297,32 @@
 (test equalp-1
       (equalp "1234567890" (make-array 15 :element-type 'character :initial-contents "123456789012345" :fill-pointer 10)))
 
-;;; fails
+;;; fails no longer
 (test equalp-2
       (equalp
        (make-array 12 :element-type 'character :initial-contents "123456789012" :fill-pointer 10)
        (make-array 15 :element-type 'character :initial-contents "123456789012345" :fill-pointer 10)))
+
+(test equalp-2a
+      (equalp
+       (make-array 15 :element-type 'base-char :initial-contents "123456789012345" :fill-pointer 10)
+       (make-array 12 :element-type 'base-char :initial-contents "123456789012" :fill-pointer 10)))
+
+(test equalp-2b
+      (equalp
+       (make-array 3 :element-type 'base-char :initial-contents "abc" :fill-pointer 2)
+       (vector #\a #\B)))
+
+(test equalp-2c
+      (equalp
+       (make-array 3 :element-type 'character :initial-contents "abc" :fill-pointer 2)
+       (vector #\a #\B)))
+
+(test equalp-2d
+      (not (equalp
+            (make-array 3 :element-type 'character :initial-contents "abc" :fill-pointer 2)
+            23)))
+
 
 ;;; from clhs Fill-pointer in the second array seem to be respected
 (test equalp-clhs-1
@@ -312,11 +333,20 @@
                                 :fill-pointer 6)))
         (equalp array1 array2)))
 
-;;; from clhs Fill-pointer in the first array not, although I assume that (equalp a b) implies (equalp b a)
-(test equalp-clhs-2
+;;; from clhs 5.3.36 equalp
+;;; If two arrays have the same number of dimensions, the dimensions match, and the corresponding active elements are equalp.
+(test equalp-clhs-2a
       (Let ((array1 (make-array 6 :element-type 'integer
                                 :initial-contents '(1 1 1 3 5 7)))
             (array2 (make-array 8 :element-type 'integer
+                                :initial-contents '(1 1 1 3 5 7 2 6)
+                                :fill-pointer 6)))
+        (equalp array2 array1)))
+
+(test equalp-clhs-2b
+      (Let ((array2 (make-array 6 :element-type 'integer
+                                :initial-contents '(1 1 1 3 5 7)))
+            (array1 (make-array 8 :element-type 'integer
                                 :initial-contents '(1 1 1 3 5 7 2 6)
                                 :fill-pointer 6)))
         (equalp array2 array1)))
@@ -438,13 +468,18 @@
 (test position-2
       (= 6
          (LET* ((S1 (COPY-SEQ "xxxabcdabcdyyyyyyyy"))
-             (S2
-              (MAKE-ARRAY '(8)
-                          :DISPLACED-TO
-                          S1
-                          :DISPLACED-INDEX-OFFSET
-                          3
-                          :ELEMENT-TYPE
-                          (ARRAY-ELEMENT-TYPE S1))))
-        (POSITION #\c S2 :FROM-END T))))
+                (S2
+                 (MAKE-ARRAY '(8)
+                             :DISPLACED-TO
+                             S1
+                             :DISPLACED-INDEX-OFFSET
+                             3
+                             :ELEMENT-TYPE
+                             (ARRAY-ELEMENT-TYPE S1))))
+           (POSITION #\c S2 :FROM-END T))))
+
+
+(test-expect-error stable-sort.error.11
+                   (funcall #'(lambda (x) (stable-sort x #'<)) #'position)
+                   :type type-error)
       

--- a/src/lisp/regression-tests/set-unexpected-failures.lisp
+++ b/src/lisp/regression-tests/set-unexpected-failures.lisp
@@ -2,7 +2,7 @@
 
 (setq *expected-failures*
       '(ANSI-PUSHNEW.14A 
-        EQUALP-2
+        ;;; EQUALP-2
         ;;; EQUALP-CLHS-2
         ;;; EQUALP-3 EQUALP-4
         ;;; EQUALP-6 EQUALP-7
@@ -31,12 +31,12 @@
         PRINT-READ-1
         ;;; GENTEMP-1 SPECIAL-OPERATOR-P-1
 
-        ;;;EQUALP-8 EQUALP-9
+        ;;; EQUALP-8 EQUALP-9
         TYPES-CLASSES-9 TYPES-CLASSES-10
         HASH-TABLE-SIZE-WEAK-KEY
         #-cst BABEL-SIMPLE-STRINGS-1
         LISTEN-3
-        ;;; what is correct syntax for a funcion name
+        ;;; what is correct syntax for a function name
         FBOUNDP.ERROR.3
         FBOUNDP.ERROR.4
         FBOUNDP.ERROR.5
@@ -108,7 +108,7 @@
         NUMBER-COMPARISON-NUMBER-12A
         NUMBER-COMPARISON-NUMBER-13A
         NUMBER-COMPARISON-NUMBER-14A
-        ;;; NUMBER-UNARY-OPERATIONS-1-INLINE
+        NUMBER-UNARY-OPERATIONS-1-INLINE
         TEST-CHAR-0A
         TEST-CHAR-1A
 

--- a/src/lisp/regression-tests/set-unexpected-failures.lisp
+++ b/src/lisp/regression-tests/set-unexpected-failures.lisp
@@ -4,7 +4,7 @@
       '(ANSI-PUSHNEW.14A 
         EQUALP-2
         ;;; EQUALP-CLHS-2
-        EQUALP-3 EQUALP-4
+        ;;; EQUALP-3 EQUALP-4
         ;;; EQUALP-6 EQUALP-7
         ;;; NREVERSE-1
         ;;; REVERSE-1
@@ -31,7 +31,7 @@
         PRINT-READ-1
         ;;; GENTEMP-1 SPECIAL-OPERATOR-P-1
 
-        EQUALP-8 EQUALP-9
+        ;;;EQUALP-8 EQUALP-9
         TYPES-CLASSES-9 TYPES-CLASSES-10
         HASH-TABLE-SIZE-WEAK-KEY
         #-cst BABEL-SIMPLE-STRINGS-1
@@ -108,13 +108,13 @@
         NUMBER-COMPARISON-NUMBER-12A
         NUMBER-COMPARISON-NUMBER-13A
         NUMBER-COMPARISON-NUMBER-14A
-        NUMBER-UNARY-OPERATIONS-1-INLINE
+        ;;; NUMBER-UNARY-OPERATIONS-1-INLINE
         TEST-CHAR-0A
         TEST-CHAR-1A
 
         ;;; READ-FROM-STRING0
         READ-PRINT-CONSISTENCY-ARRAYS
-        EQUALP-HASH-TABLE-2
+        ;;; EQUALP-HASH-TABLE-2
 
         ;;; glsl-toolkit-grammar.lisp-1 errors while compiling in ast
         ;;; make-instance.error.5 the same


### PR DESCRIPTION
* w/o (safety 3) some tests segfault on incorrect arguments instead of raising an type error (see #853)