### PR TITLE
Undo some potentially wrong declarations that lead to segmentation faults

### DIFF
--- a/src/lisp/kernel/cmp/opt-cons.lsp
+++ b/src/lisp/kernel/cmp/opt-cons.lsp
@@ -33,7 +33,7 @@
 (defmacro do-in-list ((%elt %sublist list &rest output) &body body)
   `(do* ((,%sublist ,list (cdr ,%sublist)))
         ((null ,%sublist) ,@output)
-     (let ((,%elt (car (the cons ,%sublist))))
+     (let ((,%elt (car ,%sublist)))
        ,@body)))
 
 ;;; TODO: Avoid iteration for constant list (but watch out for growth)
@@ -97,7 +97,7 @@
                ,@init)
            (do-in-list (,%elt ,%sublist ,list)
              (when ,%elt
-               (let ((,%car (car (the cons ,%elt))))
+               (let ((,%car (car ,%elt)))
                  (when ,(funcall test-function %value
                                  (funcall key-function %car))
                    (return ,%elt))))))))))

--- a/src/lisp/kernel/lsp/seqlib.lsp
+++ b/src/lisp/kernel/lsp/seqlib.lsp
@@ -960,7 +960,9 @@ SEQUENCE.  See SORT."
       (list-merge-sort sequence predicate key)
       (if (or (stringp sequence) (bit-vector-p sequence))
           (sort sequence predicate :key key)
-          (vector-merge-sort sequence predicate key))))
+          (if (vectorp sequence)
+              (vector-merge-sort sequence predicate key)
+              (error 'type-error :datum sequence :expected-type 'sequence)))))
 
 
 (defun merge (result-type sequence1 sequence2 predicate &key key

--- a/src/lisp/regression-tests/cons01.lisp
+++ b/src/lisp/regression-tests/cons01.lisp
@@ -118,3 +118,7 @@
       (not
       (LET ((X (LIST 'A 'B 'C 'D)))
         (EQ (APPEND X NIL) X))))
+
+(test-expect-error  MEMBER-IF.ERROR.8 (MEMBER-IF #'IDENTITY 'A) :type type-error)
+(test-expect-error  ASSOC-IF.ERROR.12 (ASSOC-IF #'NULL '((A . B) :BAD (C . D))) :type type-error)
+(test-expect-error  ASSOC-IF-NOT.ERROR.12 (ASSOC-IF-NOT #'IDENTITY '((A . B) :BAD (C . D))) :type type-error)

--- a/src/lisp/regression-tests/sequences01.lisp
+++ b/src/lisp/regression-tests/sequences01.lisp
@@ -446,5 +446,10 @@
                           3
                           :ELEMENT-TYPE
                           (ARRAY-ELEMENT-TYPE S1))))
-        (POSITION #\c S2 :FROM-END T))))
+           (POSITION #\c S2 :FROM-END T))))
+
+
+(test-expect-error stable-sort.error.11
+                   (funcall #'(lambda (x) (stable-sort x #'<)) #'position)
+                   :type type-error)
       


### PR DESCRIPTION
Fixes #853 and #854 by dropping potentially wrong declarations and for vector-merge-sort actually test that the argument is a vector

Did full rebuild, run regression-test and ansi-tests to validate the changes and added tests to the regression tests.

With the changes ansi-tests do run again w/o segmentation violations.