### PR TITLE
Remove useless T_mv

### DIFF
--- a/include/clasp/core/primitives.h
+++ b/include/clasp/core/primitives.h
@@ -42,7 +42,7 @@ extern Symbol_sp core__function_block_name(T_sp functionName);
 
 //extern void af_ensure_single_dispatch_generic_function(Symbol_sp gfname, LambdaListHandler_sp llh);
 
-extern T_mv cl__read_delimited_list(Character_sp chr, T_sp input_stream_designator, T_sp recursive_p);
+extern List_sp cl__read_delimited_list(Character_sp chr, T_sp input_stream_designator, T_sp recursive_p);
 
 T_sp cl__read(T_sp input_stream_designator, T_sp eof_error_p = _Nil<T_O>(), T_sp eof_value = _Nil<T_O>(), T_sp recursive_p = _Nil<T_O>());
 T_sp cl__read_preserving_whitespace(T_sp input_stream_designator, T_sp eof_error_p = _Nil<T_O>(), T_sp eof_value = _Nil<T_O>(), T_sp recursive_p = _Nil<T_O>());
@@ -148,20 +148,20 @@ namespace core {
 /*! Set the current core:*ihs-current* value.
       If the idx is out of bounds then return a valid value */
 void core__gdb(T_sp msg);
-  T_mv core__valid_function_name_p(T_sp arg);
+  T_sp core__valid_function_name_p(T_sp arg);
   int core__set_ihs_current_frame(int idx);
   void core__exception_stack_dump();
   T_sp core__create_tagged_immediate_value_or_nil(T_sp object);
   bool cl__constantp(T_sp obj, T_sp env = _Nil<T_O>());
   T_mv cl__values_list(List_sp list);
-  T_mv cl__compiler_macro_function(core::T_sp name, core::T_sp env);
+  T_sp cl__compiler_macro_function(core::T_sp name, core::T_sp env);
   bool cl__fboundp(T_sp functionName);
   T_sp core__get_global_inline_status(core::T_sp name, core::T_sp env);
   void core__setf_global_inline_statis(core::T_sp name, bool status, core::T_sp env);
   T_sp cl__fdefinition(T_sp functionName);
-  T_mv cl__special_operator_p(Symbol_sp sym);
+  T_sp cl__special_operator_p(Symbol_sp sym);
   T_sp cl__sleep(Real_sp oseconds);
-List_sp core__list_from_va_list(VaList_sp valist);
+  List_sp core__list_from_va_list(VaList_sp valist);
 
 T_sp core__next_number();
 };

--- a/src/core/array.cc
+++ b/src/core/array.cc
@@ -1541,7 +1541,7 @@ CL_DEFUN T_sp cl__string_EQ_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp 
 CL_LAMBDA(strdes1 strdes2 &key (start1 0) end1 (start2 0) end2);
 CL_DECLARE();
 CL_DOCSTRING("string_NE_");
-CL_DEFUN T_mv cl__string_NE_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
+CL_DEFUN T_sp cl__string_NE_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
   size_t istart1, iend1, istart2, iend2;
   String_sp string1;
   String_sp string2;
@@ -1552,7 +1552,7 @@ CL_DEFUN T_mv cl__string_NE_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp 
 CL_LAMBDA(strdes1 strdes2 &key (start1 0) end1 (start2 0) end2);
 CL_DECLARE();
 CL_DOCSTRING("string_LT_");
-CL_DEFUN T_mv cl__string_LT_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
+CL_DEFUN T_sp cl__string_LT_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
   size_t istart1, iend1, istart2, iend2;
   String_sp string1;
   String_sp string2;
@@ -1563,7 +1563,7 @@ CL_DEFUN T_mv cl__string_LT_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp 
 CL_LAMBDA(strdes1 strdes2 &key (start1 0) end1 (start2 0) end2);
 CL_DECLARE();
 CL_DOCSTRING("string_GT_");
-CL_DEFUN T_mv cl__string_GT_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
+CL_DEFUN T_sp cl__string_GT_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
   size_t istart1, iend1, istart2, iend2;
   String_sp string1;
   String_sp string2;
@@ -1574,7 +1574,7 @@ CL_DEFUN T_mv cl__string_GT_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp 
 CL_LAMBDA(strdes1 strdes2 &key (start1 0) end1 (start2 0) end2);
 CL_DECLARE();
 CL_DOCSTRING("string_LE_");
-CL_DEFUN T_mv cl__string_LE_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
+CL_DEFUN T_sp cl__string_LE_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
   size_t istart1, iend1, istart2, iend2;
   String_sp string1;
   String_sp string2;
@@ -1585,7 +1585,7 @@ CL_DEFUN T_mv cl__string_LE_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp 
 CL_LAMBDA(strdes1 strdes2 &key (start1 0) end1 (start2 0) end2);
 CL_DECLARE();
 CL_DOCSTRING("string_GE_");
-CL_DEFUN T_mv cl__string_GE_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
+CL_DEFUN T_sp cl__string_GE_(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
   size_t istart1, iend1, istart2, iend2;
   String_sp string1;
   String_sp string2;
@@ -1607,7 +1607,7 @@ CL_DEFUN T_sp cl__string_equal(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_s
 CL_LAMBDA(strdes1 strdes2 &key (start1 0) end1 (start2 0) end2);
 CL_DECLARE();
 CL_DOCSTRING("string_not_equal");
-CL_DEFUN T_mv cl__string_not_equal(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
+CL_DEFUN T_sp cl__string_not_equal(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
   size_t istart1, iend1, istart2, iend2;
   String_sp string1;
   String_sp string2;
@@ -1617,7 +1617,7 @@ CL_DEFUN T_mv cl__string_not_equal(T_sp strdes1, T_sp strdes2, Fixnum_sp start1,
 CL_LAMBDA(strdes1 strdes2 &key (start1 0) end1 (start2 0) end2);
 CL_DECLARE();
 CL_DOCSTRING("string_lessp");
-CL_DEFUN T_mv cl__string_lessp(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
+CL_DEFUN T_sp cl__string_lessp(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
   size_t istart1, iend1, istart2, iend2;
   String_sp string1;
   String_sp string2;
@@ -1627,7 +1627,7 @@ CL_DEFUN T_mv cl__string_lessp(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_s
 CL_LAMBDA(strdes1 strdes2 &key (start1 0) end1 (start2 0) end2);
 CL_DECLARE();
 CL_DOCSTRING("string_greaterp");
-CL_DEFUN T_mv cl__string_greaterp(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
+CL_DEFUN T_sp cl__string_greaterp(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
   size_t istart1, iend1, istart2, iend2;
   String_sp string1;
   String_sp string2;
@@ -1637,7 +1637,7 @@ CL_DEFUN T_mv cl__string_greaterp(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, 
 CL_LAMBDA(strdes1 strdes2 &key (start1 0) end1 (start2 0) end2);
 CL_DECLARE();
 CL_DOCSTRING("string_not_greaterp");
-CL_DEFUN T_mv cl__string_not_greaterp(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
+CL_DEFUN T_sp cl__string_not_greaterp(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
   size_t istart1, iend1, istart2, iend2;
   String_sp string1;
   String_sp string2;
@@ -1647,7 +1647,7 @@ CL_DEFUN T_mv cl__string_not_greaterp(T_sp strdes1, T_sp strdes2, Fixnum_sp star
 CL_LAMBDA(strdes1 strdes2 &key (start1 0) end1 (start2 0) end2);
 CL_DECLARE();
 CL_DOCSTRING("string_not_lessp");
-CL_DEFUN T_mv cl__string_not_lessp(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
+CL_DEFUN T_sp cl__string_not_lessp(T_sp strdes1, T_sp strdes2, Fixnum_sp start1, T_sp end1, Fixnum_sp start2, T_sp end2) {
   size_t istart1, iend1, istart2, iend2;
   String_sp string1;
   String_sp string2;

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -1677,9 +1677,9 @@ CL_DEFUN void core__stack_monitor(T_sp fn) {
 
 CL_LAMBDA();
 CL_DECLARE();
-CL_DOCSTRING("Return the soft and hard limits of the stack");
-CL_DEFUN T_mv core__stack_limit() {
-  return Values(clasp_make_fixnum(_lisp->_StackWarnSize));
+CL_DOCSTRING("Return the stack warn size");
+CL_DEFUN T_sp core__stack_limit() {
+  return clasp_make_fixnum(_lisp->_StackWarnSize);
 };
 
 CL_LAMBDA(&key warn-size sample-size);
@@ -1786,14 +1786,14 @@ CL_DEFUN List_sp core__member1(T_sp item, List_sp list, T_sp test, T_sp test_not
 CL_LAMBDA("&optional (prompt \"\")");
 CL_DECLARE();
 CL_DOCSTRING("getline");
-CL_DEFUN T_mv core__getline(String_sp prompt) {
+CL_DEFUN T_sp core__getline(String_sp prompt) {
   ASSERT(cl__stringp(prompt));
   string res;
   string sprompt(prompt->get());
   bool end_of_transmission;
   res = myReadLine(sprompt.c_str(), end_of_transmission);
   SimpleBaseString_sp result = SimpleBaseString_O::make(res);
-  return (Values(result));
+  return result;
 }
 
 CL_DOCSTRING("lookup-class-with-stamp");
@@ -1939,8 +1939,8 @@ CL_DEFUN void core__select_package(T_sp package_designator) {
 CL_LAMBDA();
 CL_DECLARE();
 CL_DOCSTRING("mpi_enabled");
-CL_DEFUN T_mv core__mpi_enabled() {
-  return (Values(_lisp->_boolean(_lisp->mpiEnabled())));
+CL_DEFUN T_sp core__mpi_enabled() {
+  return _lisp->_boolean(_lisp->mpiEnabled());
 }
 
 /*
@@ -1953,8 +1953,8 @@ CL_DEFUN T_mv core__mpi_enabled() {
 CL_LAMBDA();
 CL_DECLARE();
 CL_DOCSTRING("Return the mpi_rank or 0 if mpi is disabled");
-CL_DEFUN T_mv core__mpi_rank() {
-  return (Values(make_fixnum(_lisp->mpiRank())));
+CL_DEFUN T_sp core__mpi_rank() {
+  return make_fixnum(_lisp->mpiRank());
 }
 
 /*
@@ -1968,8 +1968,8 @@ CL_DEFUN T_mv core__mpi_rank() {
 CL_LAMBDA();
 CL_DECLARE();
 CL_DOCSTRING("Return mpi_size or 0 if mpi is not enabled");
-CL_DEFUN T_mv core__mpi_size() {
-  return (Values(make_fixnum(_lisp->mpiSize())));
+CL_DEFUN T_sp core__mpi_size() {
+  return make_fixnum(_lisp->mpiSize());
 }
 
 CL_LAMBDA(form &optional env);
@@ -2346,16 +2346,16 @@ CL_DEFUN void cl__cerror(T_sp cformat, T_sp eformat, List_sp arguments) {
 CL_LAMBDA(arg);
 CL_DECLARE();
 CL_DOCSTRING("Return a string representation of the object");
-CL_DEFUN T_mv core__repr(T_sp obj) {
+CL_DEFUN T_sp core__repr(T_sp obj) {
   SimpleBaseString_sp res = SimpleBaseString_O::make(_rep_(obj));
-  return (Values(res));
+  return res;
 }
 
 CL_LAMBDA(arg);
 CL_DECLARE();
 CL_DOCSTRING("not");
-CL_DEFUN T_mv cl__not(T_sp x) {
-  return (Values(_lisp->_boolean(!x.isTrue())));
+CL_DEFUN T_sp cl__not(T_sp x) {
+  return _lisp->_boolean(!x.isTrue());
 };
 
 Instance_sp Lisp_O::boot_setf_findClass(Symbol_sp className, Instance_sp mc) {

--- a/src/core/numbers.cc
+++ b/src/core/numbers.cc
@@ -706,53 +706,53 @@ CL_DEFUN Number_sp contagen_div(Number_sp na, Number_sp nb) {
 }
 
 CL_LAMBDA(&rest numbers);
-CL_DEFUN T_mv cl___PLUS_(List_sp numbers) {
+CL_DEFUN Number_sp cl___PLUS_(List_sp numbers) {
   if (numbers.nilp())
-    return (Values(make_fixnum(0)));
+    return make_fixnum(0);
   Number_sp result = gc::As<Number_sp>(oCar(numbers));
   for (auto cur : (List_sp)oCdr(numbers)) {
     result = contagen_add(result, gc::As<Number_sp>(oCar(cur)));
   }
-  return (Values(result));
+  return result;
 }
 
 CL_LAMBDA(&rest numbers);
 CL_DECLARE();
 CL_DOCSTRING("See CLHS: *");
-CL_DEFUN T_mv cl___TIMES_(List_sp numbers) {
+CL_DEFUN Number_sp cl___TIMES_(List_sp numbers) {
   if (numbers.nilp())
-    return (Values(make_fixnum(1)));
+    return make_fixnum(1);
   Number_sp result = gc::As<Number_sp>(oCar(numbers));
   for (auto cur : (List_sp)oCdr(numbers)) {
     result = contagen_mul(result, gc::As<Number_sp>(oCar(cur)));
   }
-  return (Values(result));
+  return result;
 }
 
 CL_LAMBDA(num &rest numbers);
 CL_DECLARE();
 CL_DOCSTRING("See CLHS: +");
-CL_DEFUN T_mv cl___MINUS_(Number_sp num, List_sp numbers) {
+CL_DEFUN Number_sp cl___MINUS_(Number_sp num, List_sp numbers) {
   if (numbers.nilp()) {
-    return (Values(clasp_negate(num)));
+    return clasp_negate(num);
   }
   Number_sp result = num;
   for (auto cur : (List_sp)(numbers)) {
     result = contagen_sub(result, gc::As<Number_sp>(oCar(cur)));
   }
-  return (Values(result));
+  return result;
 }
 
 CL_LAMBDA(num &rest numbers);
-CL_DEFUN T_sp cl___DIVIDE_(Number_sp num, List_sp numbers) {
+CL_DEFUN Number_sp cl___DIVIDE_(Number_sp num, List_sp numbers) {
   if (numbers.nilp()) {
-    return (clasp_reciprocal(num));
+    return clasp_reciprocal(num);
   }
   Number_sp result = num;
   for (auto cur : (List_sp)(numbers)) {
     result = contagen_div(result, gc::As<Number_sp>(oCar(cur)));
   }
-  return ((result));
+  return result;
 }
 
 /* ----------------------------------------------------------------------
@@ -2649,7 +2649,7 @@ Number_sp clasp_atan1(Number_sp y) {
 CL_LAMBDA(x &optional y);
 CL_DECLARE();
 CL_DOCSTRING("atan");
-CL_DEFUN T_sp cl__atan(Number_sp x, T_sp y) {
+CL_DEFUN Number_sp cl__atan(Number_sp x, T_sp y) {
   /* INV: type check in clasp_atan() & clasp_atan2() */
   /* FIXME clasp_atan() and clasp_atan2() produce generic errors
 	   without recovery and function information. */
@@ -3471,14 +3471,14 @@ CL_DEFUN DoubleFloat_sp core__double_float_from_bits(Integer_sp integer) {
 
 namespace core {
 
-CL_DEFUN T_sp cl__rational(T_sp num) {
+CL_DEFUN Number_sp cl__rational(Real_sp num) {
   if (num.fixnump()) return num;
   if (num.single_floatp()) return DoubleFloat_O::rational(num.unsafe_single_float());
   if (gc::IsA<Number_sp>(num)) return gc::As_unsafe<Number_sp>(num)->rational_();
-  TYPE_ERROR(num,cl::_sym_Number_O);
+  TYPE_ERROR(num,cl::_sym_Real_O);
 };
 
-CL_DEFUN T_sp cl__rationalize(T_sp num) {
+CL_DEFUN Number_sp cl__rationalize(Real_sp num) {
   return cl__rational(num);
 };
 

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -543,11 +543,11 @@ CL_DEFUN Symbol_sp core__function_block_name(T_sp functionName) {
 CL_LAMBDA(arg);
 CL_DECLARE();
 CL_DOCSTRING("validFunctionNameP");
-CL_DEFUN T_mv core__valid_function_name_p(T_sp arg) {
+CL_DEFUN T_sp core__valid_function_name_p(T_sp arg) {
   T_sp name = functionBlockName(arg);
   if (name.nilp())
-    return (Values(_Nil<T_O>()));
-  return (Values(_lisp->_true()));
+    return _Nil<T_O>();
+  return _lisp->_true();
 };
 
 CL_LAMBDA(listOfPairs);
@@ -650,7 +650,7 @@ CL_DEFUN_SETF T_sp setf_macro_function(Function_sp function, Symbol_sp symbol, T
 CL_LAMBDA(symbol);
 CL_DECLARE();
 CL_DOCSTRING("See CLHS: special-operator-p");
-CL_DEFUN T_mv cl__special_operator_p(Symbol_sp sym) {
+CL_DEFUN T_sp cl__special_operator_p(Symbol_sp sym) {
   // should signal type-error if its argument is not a symbol.
   SYMBOL_EXPORT_SC_(ClPkg, let);
   SYMBOL_EXPORT_SC_(ClPkg, letSTAR);
@@ -697,7 +697,7 @@ CL_DEFUN T_mv cl__special_operator_p(Symbol_sp sym) {
       (sym == cl::_sym_throw) ||
       (sym == cl::_sym_progv) ||
       (sym == cl::_sym_quote)) {
-    return (Values(_lisp->_true()));
+    return _lisp->_true();
   }
   // Now check the special operators hash table because
   // there may be a few more there.
@@ -841,17 +841,17 @@ CL_DEFUN bool cl__constantp(T_sp obj, T_sp env) {
 CL_LAMBDA(arg);
 CL_DECLARE();
 CL_DOCSTRING("identity");
-CL_DEFUN T_mv cl__identity(T_sp arg) {
-  return (Values(arg));
+CL_DEFUN T_sp cl__identity(T_sp arg) {
+  return arg;
 };
 
 CL_LAMBDA(obj);
 CL_DECLARE();
 CL_DOCSTRING("null test - return true if the object is the empty list otherwise return nil");
-CL_DEFUN T_mv cl__null(T_sp obj) {
+CL_DEFUN T_sp cl__null(T_sp obj) {
   if (obj.nilp())
-    return (Values(_lisp->_true()));
-  return (Values(_Nil<T_O>()));
+    return _lisp->_true();
+  return _Nil<T_O>();
 };
 
 CL_LAMBDA(obj);
@@ -992,19 +992,19 @@ CL_DEFUN bool cl__fboundp(T_sp functionName) {
 CL_LAMBDA(function-name);
 CL_DECLARE();
 CL_DOCSTRING("fmakunbound");
-CL_DEFUN T_mv cl__fmakunbound(T_sp functionName) {
+CL_DEFUN T_sp cl__fmakunbound(T_sp functionName) {
   if ((functionName).consp()) {
     List_sp cname = functionName;
     if (oCar(cname) == cl::_sym_setf) {
       Symbol_sp name = gc::As<Symbol_sp>(oCadr(cname));
       if (name.notnilp()) {
         name->fmakunbound_setf();
-        return (Values(functionName));
+        return functionName;
       }
     }
   } else if (Symbol_sp sym = functionName.asOrNull<Symbol_O>() ) {
     sym->fmakunbound();
-    return (Values(sym));
+    return sym;
   }
   TYPE_ERROR(functionName, // type of function names
              Cons_O::createList(cl::_sym_or, cl::_sym_symbol,
@@ -1015,7 +1015,7 @@ CL_DEFUN T_mv cl__fmakunbound(T_sp functionName) {
 CL_LAMBDA(char &optional input-stream-designator recursive-p);
 CL_DECLARE();
 CL_DOCSTRING("read a list up to a specific character - see CLHS");
-CL_DEFUN T_mv cl__read_delimited_list(Character_sp chr, T_sp input_stream_designator, T_sp recursive_p) {
+CL_DEFUN List_sp cl__read_delimited_list(Character_sp chr, T_sp input_stream_designator, T_sp recursive_p) {
   T_sp sin = coerce::inputStreamDesignator(input_stream_designator);
 #if 0
 	// I think it is safe to ignore recursive_p
@@ -1024,11 +1024,11 @@ CL_DEFUN T_mv cl__read_delimited_list(Character_sp chr, T_sp input_stream_design
     SIMPLE_ERROR(BF("Currently I don't handle recursive-p[true] for read_delimited_list"));
   }
 #endif
-  T_sp result = read_list(sin, clasp_as_claspCharacter(chr), true);
+  List_sp result = read_list(sin, clasp_as_claspCharacter(chr), true);
   if (cl::_sym_STARread_suppressSTAR->symbolValue().isTrue()) {
-    return (Values(_Nil<T_O>()));
+    return _Nil<T_O>();
   }
-  return (Values(result));
+  return result;
 }
 
 CL_LAMBDA(&optional input-stream-designator (eof-error-p t) eof-value recursive-p);
@@ -1260,19 +1260,19 @@ CL_DEFUN T_sp cl__mapl(T_sp func_desig, List_sp lists) {
 CL_LAMBDA(op &rest lists);
 CL_DECLARE();
 CL_DOCSTRING("mapcon");
-CL_DEFUN T_mv cl__mapcon(T_sp op, List_sp lists) {
+CL_DEFUN T_sp cl__mapcon(T_sp op, List_sp lists) {
   List_sp parts = cl__maplist(op, lists);
   T_sp result = cl__nconc(parts);
-  return Values(result);
+  return result;
 };
 
 CL_LAMBDA(op &rest lists);
 CL_DECLARE();
 CL_DOCSTRING("mapcan");
-CL_DEFUN T_mv cl__mapcan(T_sp op, List_sp lists) {
+CL_DEFUN T_sp cl__mapcan(T_sp op, List_sp lists) {
   List_sp parts = cl__mapcar(op, lists);
   T_sp result = cl__nconc(parts);
-  return Values(result);
+  return result;
 };
 
 


### PR DESCRIPTION
* dropped T_mv where only 1 value was returned and clhs does not ask for multiple values
* tighten the type for cl___PLUS_
* tighten the type for cl___TIMES_
* tighten the type for cl___MINUS_
* tighten the type for cl___TIMES_
* tighten the type for cl___DIVIDE_
* tighten the type for cl__atan
* tighten the type for cl__rational
* tighten the type for cl__read_delimited_list

Did run regression and ansi-tests to validate (with sucess)