### PR TITLE
Update regression tests after sequence changes

### DIFF
--- a/src/lisp/regression-tests/sequences01.lisp
+++ b/src/lisp/regression-tests/sequences01.lisp
@@ -506,3 +506,12 @@
        (nreverse 
         (MAKE-ARRAY 8 :ELEMENT-TYPE '(INTEGER -1 0) :INITIAL-CONTENTS #(0 0 -1 0 -1 -1 0 -1)))))
 
+(test-expect-error
+ every.error.14
+ (every #'identity '(1 2 3 . 4))
+ :type type-error)
+
+(test-expect-error
+ some.error.14
+ (some #'null '(a b . c))
+  :type type-error)

--- a/src/lisp/regression-tests/strings01.lisp
+++ b/src/lisp/regression-tests/strings01.lisp
@@ -103,8 +103,8 @@
       (equal (core:copy-to-simple-base-string #\C) "C"))
 
 
-(test closest-sequence-type0 (eq (core::closest-sequence-type 'simple-base-string) 'base-char))
-(test closest-sequence-type1 (eq (core::closest-sequence-type 'simple-string) 'character))
+(test closest-sequence-type0 (equal (core::sequence-type-maker-info 'simple-base-string) '(vector base-char)))
+(test closest-sequence-type1 (equal (core::sequence-type-maker-info 'simple-string) '(vector character)))
 
 ;;; These should not return t, but the first index, where it is different
 (test eql-1 (eql 0 (string/= "a" "b")))


### PR DESCRIPTION
* use sequence-type-maker-info instead of dropped closest-sequence-type
* added tests for forms that resulted in a segmentation violation (already fixed)