### PR TITLE
Fix some format issues

### DIFF
--- a/src/lisp/kernel/lsp/format.lsp
+++ b/src/lisp/kernel/lsp/format.lsp
@@ -1737,27 +1737,29 @@
 ;;;; Tab and simple pretty-printing noise.
 
 (def-format-directive #\T (colonp atsignp params)
-  (check-output-layout-mode 1)
-  (if colonp
-      (expand-bind-defaults ((n 1) (m 1)) params
-	`(pprint-tab ,(if atsignp :section-relative :section)
-		     ,n ,m stream))
-      (if atsignp
-	  (expand-bind-defaults ((colrel 1) (colinc 1)) params
-	    `(format-relative-tab stream ,colrel ,colinc))
-	  (expand-bind-defaults ((colnum 1) (colinc 1)) params
-	    `(format-absolute-tab stream ,colnum ,colinc)))))
+  (cond (colonp
+         (check-output-layout-mode 1)
+         (expand-bind-defaults ((n 1) (m 1)) params
+                               `(pprint-tab ,(if atsignp :section-relative :section)
+                                            ,n ,m stream)))
+        (atsignp
+         (expand-bind-defaults ((colrel 1) (colinc 1)) params
+                               `(format-relative-tab stream ,colrel ,colinc)))
+        (t
+         (expand-bind-defaults ((colnum 1) (colinc 1)) params
+                               `(format-absolute-tab stream ,colnum ,colinc)))))
 
 (def-format-interpreter #\T (colonp atsignp params)
-  (check-output-layout-mode 1)
-  (if colonp
-      (interpret-bind-defaults ((n 1) (m 1)) params
-	(pprint-tab (if atsignp :section-relative :section) n m stream))
-      (if atsignp
-	  (interpret-bind-defaults ((colrel 1) (colinc 1)) params
-	    (format-relative-tab stream colrel colinc))
-	  (interpret-bind-defaults ((colnum 1) (colinc 1)) params
-	    (format-absolute-tab stream colnum colinc)))))
+  (cond (colonp
+         (check-output-layout-mode 1)
+         (interpret-bind-defaults ((n 1) (m 1)) params
+                                  (pprint-tab (if atsignp :section-relative :section) n m stream)))
+        (atsignp
+         (interpret-bind-defaults ((colrel 1) (colinc 1)) params
+                                  (format-relative-tab stream colrel colinc)))
+        (t
+         (interpret-bind-defaults ((colnum 1) (colinc 1)) params
+                                  (format-absolute-tab stream colnum colinc)))))
 
 (defun output-spaces (stream n)
   (let ((spaces #.(make-string 100 :initial-element #\space)))
@@ -2749,7 +2751,7 @@
 	 (block nil
 	   ,@(let ((*expander-next-arg-macro* 'expander-pprint-next-arg)
 		   (*only-simple-args* nil)
-		   (*orig-args-available* t))
+		   (*orig-args-available* (if atsignp *orig-args-available* t)))
 	       (expand-directive-list insides)))))))
 
 (defun interpret-format-logical-block

--- a/src/lisp/regression-tests/printer01.lisp
+++ b/src/lisp/regression-tests/printer01.lisp
@@ -379,4 +379,75 @@
 ;;; Test c++ cl:format chokes on ~2% and returns "Could not format ..."
 (test lisp-format-works (null (search "Could" (format nil "Bar ~2%"))))
 
+(defun print-symbol-with-prefix (stream symbol &optional colon at)
+  "For use with ~/: Write SYMBOL to STREAM as if it is not accessible from
+  the current package."
+  (declare (ignore colon at))
+  (let ((*package* (find-package :keyword)))
+    (write symbol :stream stream :escape t)))
+
+(test issue-911
+ (let ((count 42)
+       (function 'print))
+   (format t
+           "~@<~@(~D~) call~:P to ~
+               ~/clasp-tests::print-symbol-with-prefix/ ~
+               ~2:*~[~;was~:;were~] compiled before a compiler-macro ~
+               was defined for it. A declaration of NOTINLINE at the ~
+               call site~:P will eliminate this warning, as will ~
+               defining the compiler-macro before its first potential ~
+               use.~@:>"
+           count
+           function)
+   t))
+
+(test format.justify.37
+      ;; no padding, output fits
+      (string-equal
+       (format nil "AA~4T~8,,,'*<~%BBBB~,12:;CCCC~;DDDD~>")
+       "AA  CCCCDDDD"))
+
+(test format.justify.38
+      ;; no padding, output doesn't fit
+      (string-equal
+       (format nil "AA~4T~8,,,'*<~%BBBB~,11:;CCCC~;DDDD~>")
+       "AA  
+BBBBCCCCDDDD"))
+
+(test format.justify.39
+      ;; one padding character per segment, output fits
+      (string-equal
+       (format nil "AA~4T~10,,,'*<~%BBBB~,14:;CCCC~;DDDD~>")
+       "AA  CCCC**DDDD"))
+
+(test format.justify.40
+      ;; one padding character per segment, output doesn't fit
+      (string-equal
+       (format nil "AA~4T~10,,,'*<~%BBBB~,13:;CCCC~;DDDD~>")
+       "AA  
+BBBBCCCC**DDDD"))
+
+(test format.justify.41
+      ;; Same with ~@T
+      (string-equal
+       (format nil "AA~1,2@T~8,,,'*<~%BBBB~,12:;CCCC~;DDDD~>")
+       "AA  CCCCDDDD"))
+
+(test format.justify.42
+      (string-equal
+       (format nil "AA~1,2@T~8,,,'*<~%BBBB~,11:;CCCC~;DDDD~>")
+       "AA  
+BBBBCCCCDDDD"))
+
+(test format.justify.43
+      (string-equal
+       (format nil "AA~1,2@T~10,,,'*<~%BBBB~,14:;CCCC~;DDDD~>")
+       "AA  CCCC**DDDD"))
+
+(test format.justify.44
+      (string-equal
+       (format nil "AA~1,2@T~10,,,'*<~%BBBB~,13:;CCCC~;DDDD~>")
+       "AA  
+BBBBCCCC**DDDD"))
+
 


### PR DESCRIPTION
Fix issues detected by 
* crosscompiling sbcl (analysis and fix provided by Bike), test issue-911, fixes #911 
* ansi-test (fixes taken from ecl), tests format.justify.37 until format.justify.44
* Fixes tested with regression-tests and ansi-tests