### PR TITLE
Fix (stream-element-type 0) to return a type error instead of aborting + test

### DIFF
--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -4418,12 +4418,6 @@ stream_dispatch_table(T_sp strm) {
   if (gc::IsA<Instance_sp>(strm)) {
     return clos_stream_ops;
   }
-  #if 0
-  // drmeister says that just for debugging hashtables in MPS
-  if (!strm) {
-    return startup_stream_ops;
-  }
-  #endif
   ERROR_WRONG_TYPE_ONLY_ARG(core::_sym_dispatchTable, strm, cl::_sym_Stream_O);
 }
 

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -4418,9 +4418,12 @@ stream_dispatch_table(T_sp strm) {
   if (gc::IsA<Instance_sp>(strm)) {
     return clos_stream_ops;
   }
+  #if 0
+  // drmeister says that just for debugging hashtables in MPS
   if (!strm) {
     return startup_stream_ops;
   }
+  #endif
   ERROR_WRONG_TYPE_ONLY_ARG(core::_sym_dispatchTable, strm, cl::_sym_Stream_O);
 }
 

--- a/src/lisp/regression-tests/streams01.lisp
+++ b/src/lisp/regression-tests/streams01.lisp
@@ -185,4 +185,10 @@
                  (file-string-length broadcast "jd")
                  (file-string-length last-stream "jd")))))))
 
+;;; did trap ../../src/core/lispStream.cc:1541 Illegal op Abort trap: 6
+(test stream-element-type.error.3.simplified
+      (handler-case
+          (stream-element-type 0)
+        (error (e) e)))
+
 


### PR DESCRIPTION
Fixes various ansi errors (that all trap, so test in ended)