### PR TITLE
Feature small defstruct fixes

### DIFF
--- a/src/lisp/kernel/lsp/defstruct.lsp
+++ b/src/lisp/kernel/lsp/defstruct.lsp
@@ -136,7 +136,8 @@
                        (if seen-read-only
                            (error-defstruct-slot-syntax slot-description)
                            (setq seen-read-only t
-                                 read-only t)))
+                                 ;;; treat :read-only nil correctly
+                                 read-only (cadr os))))
                       (otherwise
                        (error-defstruct-slot-syntax slot-description)))))
                  (t (error-defstruct-slot-syntax slot-description))))
@@ -184,8 +185,9 @@
     (let ((old-reader (getf old-plist :reader))
           (old-accessor (getf old-plist :accessor)))
       (when (and accessor old-reader)
-        (error "Mutable slot ~a cannot override read-only included slot."
-               slot-name))
+        #+(or)(error "Mutable slot ~a cannot override read-only included slot."
+                     slot-name)
+        (setq reader accessor accessor nil))
       `(,slot-name
         ;; We always have an initarg for any non-:NAMED slot.
         :initarg ,initarg
@@ -255,9 +257,11 @@
           (error "Cannot override nonexistent slot ~a" slot-name))))
     ;; Signal an error for any duplicate slot.
     (dolist (new-slotd new-slotds)
-      (let ((slot-name (first new-slotd)))
-        (when (member slot-name old-slotds :key #'first)
-          (error "Duplicate slot ~a" slot-name))))
+      ;;; check for "dummy" slotdescriptions coming from :initial-offset
+      (unless (null new-slotd)
+        (let ((slot-name (first new-slotd)))
+          (when (member slot-name old-slotds :key #'first)
+            (error "Duplicate slot ~a" slot-name)))))
     ;; Done.
     (append old-slotds new-slotds)))
 
@@ -512,6 +516,13 @@
        `(set-documentation ',structure-name 'structure
                            ',(second option))))))
 
+(defun named-slot-description-p (structure-name slot-description)
+  (let* ((nsd (named-slot-description structure-name))
+         (sym1 (first slot-description))
+         (sym2 (first nsd)))
+    (and (symbolp sym1)(symbolp sym2)(string= (symbol-name sym1)(symbol-name sym2))
+         (equalp (rest nsd) (rest slot-description)))))
+                                 
 (defun defstruct-list-option-expander
     (structure-name included-size slot-descriptions)
   (lambda (option)
@@ -527,12 +538,16 @@
        `(defun ,(second option) (object)
           (and
            (consp object)
-           ,@(let (forms)
-               (dotimes (i (length slot-descriptions) forms)
-                 (push '(consp (setf object (cdr object))) forms)))
+           ;; need to test before object is changed with setf below
            ;; FIXME: inefficient
            (eq (nth ,(+ (third option) included-size) object)
-               ',structure-name))))
+               ',structure-name)
+           ,@(let (forms)
+               (dolist (sd slot-descriptions forms)
+                 ;;; if the structure is :named, the first slot-decription is for the name and should not enter the following list
+                 ;;; need to recognize a named-slot-description
+                 (unless (named-slot-description-p structure-name sd)
+                   (push '(consp (setf object (cdr object))) forms)))))))
       ((:copier)
        `(defun ,(second option) (instance) (copy-list instance)))
       ((:documentation)
@@ -772,7 +787,7 @@
                   ((:conc-name)
                    (if seen-conc-name
                        (error "Specified ~a more than once" :conc-name)
-                       (setq conc-name nil)))
+                       (setq conc-name nil seen-conc-name t)))
                   ((:copier)
                    (if seen-copier
                        (error-defstruct-option-duplicated :copier)
@@ -808,7 +823,12 @@
           (when predicate
             (error "Cannot specify :TYPE and a PREDICATE but not :NAMED, in structure definition for ~a"
                    name))
-          (unless predicate
+          ;;; This option takes one argument, which specifies the name of the type predicate. 
+          ;;; If the argument is provided and is nil, no predicate is defined.
+          ;;; If the argument is not supplied or if the option itself is not supplied,
+          ;;; the name of the predicate is made by concatenating the name of the structure to the string "-P",
+          ;;; interning the name in whatever package is current at the time defstruct is expanded. 
+          (unless (or predicate seen-predicate)
             (setq predicate (default-predicate-name name))))
       ;; default conc-name
       (unless seen-conc-name

--- a/src/lisp/regression-tests/structures.lisp
+++ b/src/lisp/regression-tests/structures.lisp
@@ -1,3 +1,5 @@
+(in-package #:clasp-tests)
+
 ;; Bug 444
 (defstruct defstruct-predicate.a)
 (defstruct (defstruct-predicate.b (:include defstruct-predicate.a)))
@@ -67,4 +69,99 @@
           (and (eql a 1)(eql b 2)(eql c 3)))))
 
 (setf (find-class 'otto3) nil)
+
+;;; defstruct used to ignore in slot-descriptions the value after :read-only assuming t
+(defstruct foo-0a (bar 42 :read-only nil))
+(defstruct foo-0b (bar 42 :read-only t))
+(defstruct foo-0c (bar 42))
+(test structure-use-readonly-value-positive
+      (let ((object (make-foo-0a)))
+        (setf (foo-0a-bar object) 42)))
+
+(test-expect-error structure-use-readonly-value-negative
+      (let ((object (make-foo-0b)))
+        (setf (foo-0b-bar object) 42)))
+
+(test structure-use-readonly-value-implicit
+      (let ((object (make-foo-0c)))
+        (setf (foo-0c-bar object) 42)))
+
+;;; (DEFSTRUCT (STRUCT-TEST-07 :CONC-NAME) A07 B07) should result in accessors a07, b07
+
+(DEFSTRUCT (STRUCT-TEST-07 :CONC-NAME) A07 B07)
+
+(test struct-test-07-5.simplified
+      (let ((obj (make-STRUCT-TEST-07 :a07 23 :b07 42)))
+        (and (a07 obj)(b07 obj))))
+
+(DEFSTRUCT (STRUCT-TEST-15 (:PREDICATE NIL)) A15 B15)
+(test STRUCT-TEST-15/10 (null (FBOUNDP 'STRUCT-TEST-15-P)))
+
+(DEFSTRUCT (STRUCT-TEST-15a (:PREDICATE)) A15 B15)
+(test STRUCT-TEST-15/10a (FBOUNDP 'STRUCT-TEST-15A-P))
+(DEFSTRUCT (STRUCT-TEST-15b :PREDICATE) A15 B15)
+(test STRUCT-TEST-15/10b (FBOUNDP 'STRUCT-TEST-15B-P))
+(DEFSTRUCT (STRUCT-TEST-38 (:TYPE LIST) :NAMED) A38 B38 C38)
+(test STRUCT-TEST-38-2
+      (LET ((S (MAKE-STRUCT-TEST-38)))
+        (AND (FBOUNDP 'STRUCT-TEST-38-P)
+             (FUNCTIONP #'STRUCT-TEST-38-P)
+             (SYMBOL-FUNCTION 'STRUCT-TEST-38-P)
+             (NOT (NOT (FUNCALL #'STRUCT-TEST-38-P S)))
+             (NOT (NOT (STRUCT-TEST-38-P S))))))
+
+(DEFSTRUCT (STRUCT-TEST-45 (:TYPE LIST) (:INITIAL-OFFSET 2)) A45 B45)
+;;; used to error with duplicate slot nil
+(test STRUCT-TEST-45
+      (eval '(DEFSTRUCT
+              (STRUCT-TEST-47 (:TYPE LIST) (:INITIAL-OFFSET 3)
+               (:INCLUDE STRUCT-TEST-45))
+              C47
+              D47)))
+
+(defstruct node tail-p)
+(defstruct (valued-node (:conc-name node-)
+                        (:include node)))
+(defstruct (combination (:include valued-node)))
+;;; must not define node-tail-p in valued-node, but how to test?
+(test include-level-2
+      (find-if #'(lambda(form)
+                   (and (listp form)
+                        (eql (first form) 'cl:defun)
+                        (eql (second form) 'node-tail-p)))
+               (macroexpand '(defstruct (combination-1 (:conc-name node-)(:include valued-node))))))
+
+;;; Did error when a conc-name is used in the chain, that would repeat an accessor
+(test sbcl-cross-compile-1
+      (fboundp 'combination-tail-p))
+
+(defstruct foo-2 (bar 42 :read-only t))
+
+;;; if read-only is not repeated, assume it is set (don't require it explicitely)
+(test sbcl-cross-compile-2
+      (eval '(progn
+              (defstruct (ifoo-1 (:include foo-2 (bar 43))))
+              t)))
+
+(test sbcl-cross-compile-3
+      (eval '(progn
+              (defstruct (ifoo-2 (:include foo-2 (bar 43 :read-only t))))
+              t)))
+
+(test-expect-error sbcl-cross-compile-4
+                   (eval '(progn
+                           (defstruct (ifoo-3 (:include foo-2 (bar 43 :read-only nil))))
+                           t)))
+      
+(defstruct bar0 a)
+(defstruct (bar1 (:include bar0)) b)
+;;; must not generate accessor bar0-a
+;;; so it is not enough to look at the immediate parent
+(test include-level-3
+      (find-if #'(lambda(form)
+                   (and (listp form)
+                        (eql (first form) 'cl:defun)
+                        (eql (second form) 'BAR0-A)))
+               (macroexpand '(defstruct (bar2 (:include bar1)(:conc-name bar0-)) c))))
+ 
 

--- a/src/lisp/regression-tests/structures.lisp
+++ b/src/lisp/regression-tests/structures.lisp
@@ -119,22 +119,6 @@
               C47
               D47)))
 
-(defstruct node tail-p)
-(defstruct (valued-node (:conc-name node-)
-                        (:include node)))
-(defstruct (combination (:include valued-node)))
-;;; must not define node-tail-p in valued-node, but how to test?
-(test include-level-2
-      (find-if #'(lambda(form)
-                   (and (listp form)
-                        (eql (first form) 'cl:defun)
-                        (eql (second form) 'node-tail-p)))
-               (macroexpand '(defstruct (combination-1 (:conc-name node-)(:include valued-node))))))
-
-;;; Did error when a conc-name is used in the chain, that would repeat an accessor
-(test sbcl-cross-compile-1
-      (fboundp 'combination-tail-p))
-
 (defstruct foo-2 (bar 42 :read-only t))
 
 ;;; if read-only is not repeated, assume it is set (don't require it explicitely)
@@ -148,20 +132,85 @@
               (defstruct (ifoo-2 (:include foo-2 (bar 43 :read-only t))))
               t)))
 
+;;; Should error with something like this (from sbcl)
+;;; The slot BAR is :READ-ONLY in superclass, and so must be :READ-ONLY in subclass.
+;;; This does not error, but at least we don't generate (setf bar)
+;;; To be fixed in override-slotd
 (test-expect-error sbcl-cross-compile-4
                    (eval '(progn
                            (defstruct (ifoo-3 (:include foo-2 (bar 43 :read-only nil))))
                            t)))
-      
-(defstruct bar0 a)
-(defstruct (bar1 (:include bar0)) b)
-;;; must not generate accessor bar0-a
-;;; so it is not enough to look at the immediate parent
-(test include-level-3
+
+;;; tests with include
+(defstruct node tail-p)
+;;; must not define node-tail-p in valued-node, since it would override the function from the parent
+(test include-level-2
+      (not (find-if #'(lambda(form)
+                   (and (listp form)
+                        (eql (first form) 'cl:defun)
+                        (eql (second form) 'node-tail-p)))
+                    (macroexpand '(defstruct (valued-node (:conc-name node-) (:include node)))))))
+
+;;; Should find it , if conc-name leads to different accessor name
+(test include-level-2a
       (find-if #'(lambda(form)
                    (and (listp form)
                         (eql (first form) 'cl:defun)
-                        (eql (second form) 'BAR0-A)))
+                        (eql (second form) 'nodea-tail-p)))
+                    (macroexpand '(defstruct (valued-nodea (:conc-name nodea-) (:include node))))))
+
+(defstruct (valued-node (:conc-name node-) (:include node)))
+
+(defstruct (combination (:include valued-node)))
+;;; should generate combination-tailp, but doesn't
+;;; That breaks cross-compiling sbcl
+;;; Might be wrong in fix-old-slotd
+(test include-level-2b
+      (fboundp 'combination-tail-p))
+
+(defstruct bar0 a)
+(defstruct (bar1 (:include bar0)) b)
+
+;;; must not re-generate accessor bar0-a, but must generate bar0-b & bar0-c
+;;; so it is not enough to look at the immediate parent
+;;; ccl check in sd-refname-in-included-struct-p all the chain up
+(test include-level-3
+      (not (find-if #'(lambda(form)
+                   (and (listp form)
+                        (or (eql (first form) 'cl:defun) #+sbcl (eql (first form) 'SB-C:XDEFUN))
+                        (eql (second form) 'bar0-a)))
+                    (macroexpand '(defstruct (bar2 (:include bar1)(:conc-name bar0-)) c)))))
+
+(test include-level-3a
+      (find-if #'(lambda(form)
+                   (and (listp form)
+                        (or (eql (first form) 'cl:defun) #+sbcl (eql (first form) 'SB-C:XDEFUN))
+                        (eql (second form) 'bar0-b)))
                (macroexpand '(defstruct (bar2 (:include bar1)(:conc-name bar0-)) c))))
  
+(defstruct blah a)
+(defstruct (sub-blah (:include blah)) b)
+(defstruct (sub-sub-blah (:include sub-blah (a 23 :read-only t))) c)
 
+(test-expect-error include-level-4
+                   (let ((object (make-sub-sub-blah)))
+                     (setf (sub-sub-blah-a object) 15)
+                     object))
+;;;sub-blah1-a is not generated, but sub-blah1-b
+(defstruct (sub-blah1 (:include blah)(:conc-name blah-)) b)
+(defstruct (sub-sub-blah1 (:include sub-blah1 (a 23 :read-only t))) c)
+
+(test-expect-error include-level-5
+                   (let ((object (make-sub-sub-blah1)))
+                     (setf (sub-sub-blah1-a object) 15)
+                     object))
+
+(test include-level-5a
+      (let ((object (make-sub-sub-blah1 :a 1 :b 2 :c 3)))
+        (values
+         (sub-sub-blah1-a object)
+         (sub-sub-blah1-b object)
+         (sub-sub-blah1-c object)
+         (setf (sub-sub-blah1-b object) 23)
+         (setf (sub-sub-blah1-b object) 42)
+         object)))


### PR DESCRIPTION
Some fixes from ansi-test and sbcl crosscompiling and assorted tests.
* (defstruct foo-0a (bar 42 :read-only nil)) ignored the nil after read-only
* Fix for "Mutable slot ~a cannot override read-only included slot." contributed By Bike in irc
* `(DEFSTRUCT (STRUCT-TEST-45 (:TYPE LIST) (:INITIAL-OFFSET 2)) A45 B45)` and `(DEFSTRUCT
              (STRUCT-TEST-47 (:TYPE LIST) (:INITIAL-OFFSET 3)
               (:INCLUDE STRUCT-TEST-45))
              C47
              D47)`gave an incorrect error about slot nil repeating
* defstruct ..... (:TYPE LIST) :NAMED) generated wrong predicate function (test for 1 slot too much)
* some errors by the tests are still open, I believe it is not enough to look at the direct include, but need to look up the whole chain of includes
  * INCLUDE-LEVEL-2 
  * SBCL-CROSS-COMPILE-1
  * SBCL-CROSS-COMPILE-4
