### PR TITLE
[WIP] Further Fixes to include handling in defstruct

### DIFF
--- a/src/lisp/regression-tests/structures.lisp
+++ b/src/lisp/regression-tests/structures.lisp
@@ -155,14 +155,13 @@
 (test include-level-2a
       (fboundp 'nodea-tail-p))
 
-(defstruct (valued-node (:conc-name node-) (:include node)))
-
-(defstruct (combination (:include valued-node)))
 ;;; should generate combination-tailp, but doesn't
 ;;; That breaks cross-compiling sbcl
 ;;; Might be wrong in fix-old-slotd
 (test include-level-2b
-      (fboundp 'combination-tail-p))
+      (progn
+        (eval '(defstruct (combination (:include valued-node))))
+        (fboundp 'combination-tail-p)))
 
 (defstruct bar0 a)
 (defstruct (bar1 (:include bar0)) b)
@@ -206,3 +205,24 @@
          (setf (sub-sub-blah1-b object) 23)
          (setf (sub-sub-blah1-b object) 42)
          object)))
+
+;;; include slots with :named
+(defstruct  (struct-test-55 (:type list)
+                            (:initial-offset 2)
+                            :named)
+  a55 b55 c55)
+
+(defstruct (struct-test-56 (:type list)
+                           (:initial-offset 3)
+                           (:include struct-test-55)
+                           :named)
+  d56 e56)
+
+(test struct-test-56
+      (let ((s (make-struct-test-56 :a55 1 :b55 2 :c55 3 :d56 4 :e56 5)))
+        (and (struct-test-56-p s)
+             (= (struct-test-56-a55 s) 1)
+             (= (struct-test-56-b55 s) 2)
+             (= (struct-test-56-c55 s) 3)
+             (= (struct-test-56-d56 s) 4)
+             (= (struct-test-56-e56 s) 5))))


### PR DESCRIPTION
* fix the remaining problems with include defstruct definitions from sbcl cross-compiling
   * generated accessor/readers even if the immediate include has now accessor/readers (include-level-2b)
   * check for duplicate definitions along the whole include chain, not only in the parent (include-level-3)
* new test struct-test-56 to check for regression introduced in a previous vesrion of the fix
* only known problem test  sbcl-cross-compile-4, since we don't detect an implicit read-only (code generated is ok, but error is silently corrected)