### PR TITLE
Complete eclector integration into clasp

### DIFF
--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -1032,6 +1032,8 @@ CL_DEFUN List_sp cl__read_delimited_list(Character_sp chr, T_sp input_stream_des
   return result;
 }
 
+SYMBOL_EXPORT_SC_(CorePkg, STARread_hookSTAR);
+
 CL_LAMBDA(&optional input-stream-designator (eof-error-p t) eof-value recursive-p);
 CL_DECLARE();
 CL_DOCSTRING("read an object from a stream - see CLHS");
@@ -1044,9 +1046,14 @@ CL_DEFUN T_sp cl__read(T_sp input_stream_designator, T_sp eof_error_p, T_sp eof_
   }
   DynamicScopeManager scope(_sym_STARpreserve_whitespace_pSTAR, _lisp->_boolean(preserve_whitespace));
   T_sp sin = coerce::inputStreamDesignator(input_stream_designator);
-  return read_lisp_object(sin, eof_error_p.isTrue(), eof_value, recursive_p.notnilp());
+  if (_sym_STARread_hookSTAR->boundP() &&
+      _sym_STARread_hookSTAR->symbolValue().notnilp())
+    return eval::funcall(_sym_STARread_hookSTAR->symbolValue(), sin ,eof_error_p, eof_value, recursive_p);
+  else
+    return read_lisp_object(sin, eof_error_p.isTrue(), eof_value, recursive_p.notnilp());
 }
 
+SYMBOL_EXPORT_SC_(CorePkg, STARread_preserving_whitespace_hookSTAR);
 CL_LAMBDA(&optional input-stream-designator (eof-error-p t) eof-value recursive-p);
 CL_DECLARE();
 CL_DOCSTRING("read an object from a stream while preserving whitespace - see CLHS");
@@ -1059,7 +1066,11 @@ CL_DEFUN T_sp cl__read_preserving_whitespace(T_sp input_stream_designator, T_sp 
   }
   DynamicScopeManager scope(_sym_STARpreserve_whitespace_pSTAR, _lisp->_boolean(preserve_whitespace));
   T_sp sin = coerce::inputStreamDesignator(input_stream_designator);
-  return read_lisp_object(sin, eof_error_p.isTrue(), eof_value, recursive_p.isTrue());
+  if (_sym_STARread_preserving_whitespace_hookSTAR->boundP() &&
+      _sym_STARread_preserving_whitespace_hookSTAR->symbolValue().notnilp())
+    return eval::funcall(_sym_STARread_preserving_whitespace_hookSTAR->symbolValue(), sin ,eof_error_p, eof_value, recursive_p);
+  else
+    return read_lisp_object(sin, eof_error_p.isTrue(), eof_value, recursive_p.isTrue());
 }
 
 /* -------------------------------------------------------- */

--- a/src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector.lisp
+++ b/src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector.lisp
@@ -57,13 +57,26 @@
       (gethash name clasp-cleavir::*additional-clasp-character-names*)
       (clasp-cleavir::simple-unicode-name name)))
 
+;;; From eclector macro functions:
+;;; So we need a way for readers for lists and vectors to explicitly
+;;; allow for backquote and comma, whereas BY DEFAULT, they should not
+;;; be allowed.  We solve this by introducing two variables:
+;;; *BACKQUOTE-ALLOWED-P* and *BACKQUOTE-IN-SUBFORMS-ALLOWED-P*.
+;;; Initially the two are TRUE.  Whenever READ is called, it binds the
+;;; variable *BACKQUOTE-ALLOWED-P* to the value of
+;;; *BACKQUOTE-IN-SUBFORMS-ALLOWED-P*, and it binds
+;;; *BACKQUOTE-IN-SUBFORMS-ALLOWED-P* to FALSE.  If no special action
+;;; is taken, when READ is called recursively from a reader macro,
+;;; the value of *BACKQUOTE-ALLOWED-P* will be FALSE.
+
 (defun read-with-readtable-synced (&optional
                                       (input-stream *standard-input*)
                                       (eof-error-p t)
                                       (eof-value nil)
                                       (recursive-p nil))
   (let ((eclector.readtable:*readtable* cl:*readtable*)
-        (eclector.reader:*client* *clasp-normal-eclector-client*))
+        (eclector.reader:*client* *clasp-normal-eclector-client*)
+        (eclector.reader::*backquote-in-subforms-allowed-p* t))
     (eclector.reader:read input-stream eof-error-p eof-value recursive-p)))
 
 ;;; to avoid th cl:*readtable* and eclector.readtable:*readtable* get out of sync
@@ -73,7 +86,8 @@
                                                            (eof-value nil)
                                                            (recursive-p nil))
   (let ((eclector.readtable:*readtable* cl:*readtable*)
-        (eclector.reader:*client* *clasp-normal-eclector-client*))
+        (eclector.reader:*client* *clasp-normal-eclector-client*)
+        (eclector.reader::*backquote-in-subforms-allowed-p* t))
     (eclector.reader:read-preserving-whitespace input-stream eof-error-p eof-value recursive-p)))
 
 ;;; need also sync in clasp-cleavir::cclasp-loop-read-and-compile-file-forms

--- a/src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector.lisp
+++ b/src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector.lisp
@@ -1,0 +1,104 @@
+(in-package :eclector.readtable)
+
+(defmethod eclector.readtable:syntax-type  ((readtable cl:readtable) char)
+  (core:syntax-type readtable char))
+
+(defmethod eclector.readtable:get-macro-character ((readtable cl:readtable) char)
+  (cl:get-macro-character char readtable))
+
+(defmethod eclector.readtable:set-macro-character
+    ((readtable cl:readtable) char function &optional non-terminating-p)
+  (cl:set-macro-character char function non-terminating-p readtable))
+ 
+(defmethod eclector.readtable:get-dispatch-macro-character ((readtable cl:readtable) disp sub)
+  (cl:get-dispatch-macro-character disp sub readtable))
+ 
+(defmethod eclector.readtable:set-dispatch-macro-character
+    ((readtable cl:readtable) disp sub function)
+  (cl:set-dispatch-macro-character disp sub function readtable))
+ 
+(defmethod eclector.readtable:copy-readtable ((readtable cl:readtable))
+  (cl:copy-readtable readtable))
+
+(defmethod eclector.readtable:copy-readtable-into ((from cl:readtable) (to cl:readtable))
+  (cl:copy-readtable from to))
+ 
+(defmethod eclector.readtable:make-dispatch-macro-character
+    ((readtable cl:readtable) char &optional non-terminating-p)
+  (cl:make-dispatch-macro-character char non-terminating-p readtable))
+
+(defmethod eclector.readtable:readtable-case (readtable)
+  (error 'type-error :datum readtable :EXPECTED-TYPE 'cl:readtable))
+
+(defmethod eclector.readtable:readtable-case ((readtable cl:readtable))
+  (cl:readtable-case readtable))
+ 
+(defmethod (setf eclector.readtable:readtable-case) (mode (readtable cl:readtable))
+  (setf (cl:readtable-case readtable) mode))
+
+(defmethod (setf eclector.readtable:readtable-case) (mode readtable)
+  (error 'type-error :datum readtable :EXPECTED-TYPE 'cl:readtable))
+ 
+(defmethod eclector.readtable:readtablep ((object cl:readtable)) t)
+
+(defvar core:*read-hook*)
+(defvar core:*read-preserving-whitespace-hook*)
+
+
+;;; to avoid that cl:*readtable* and eclector.readtable:*readtable* get out of sync
+;;; to avoid eclector.parse-result::*stack* being unbound, when *client* is bound to a parse-result-client
+;;; Not sure whether this a a fortunate design in eclector
+
+(defun read-with-readtable-synced (&optional
+                                      (input-stream *standard-input*)
+                                      (eof-error-p t)
+                                      (eof-value nil)
+                                      (recursive-p nil))
+  (let ((eclector.readtable:*readtable* cl:*readtable*)
+        (ECLECTOR.READER:*CLIENT* nil))
+    #+(or)(format t "stream ~a eof-p ~a eofv ~a recur ~a~%" input-stream eof-error-p eof-value recursive-p)
+    (eclector.reader:read input-stream eof-error-p eof-value recursive-p)))
+
+;;; to avoid th cl:*readtable* and eclector.readtable:*readtable* get out of sync
+(defun read-preserving-whitespace-with-readtable-synced (&optional
+                                                           (input-stream *standard-input*)
+                                                           (eof-error-p t)
+                                                           (eof-value nil)
+                                                           (recursive-p nil))
+  (let ((eclector.readtable:*readtable* cl:*readtable*)
+        (ECLECTOR.READER:*CLIENT* nil))
+    (eclector.reader:read-preserving-whitespace input-stream eof-error-p eof-value recursive-p)))
+
+;;; need also sync in clasp-cleavir::cclasp-loop-read-and-compile-file-forms
+
+
+(defun cl:read-from-string (string
+                            &optional (eof-error-p t) eof-value
+                            &key (start 0) (end (length string))
+                              preserve-whitespace)
+  (let ((ECLECTOR.READER:*CLIENT* nil))
+    (ECLECTOR.READER:READ-FROM-STRING string eof-error-p eof-value
+                                      :start start :end end :preserve-whitespace preserve-whitespace)))
+
+(defun init-clasp-as-eclector-reader ()
+  (setq eclector.readtable:*readtable* cl:*readtable*)
+  (eclector.reader::set-standard-macro-characters cl:*readtable*)
+  (eclector.reader::set-standard-dispatch-macro-characters cl:*readtable*)
+  (cl:set-dispatch-macro-character #\# #\a 'core:sharp-a-reader cl:*readtable*)
+  (cl:set-dispatch-macro-character #\# #\A 'core:sharp-a-reader cl:*readtable*)
+  (cl:set-dispatch-macro-character #\# #\I #'core::read-cxx-object cl:*readtable*)
+  (cl:set-dispatch-macro-character #\# #\! 'core::sharp-!-reader cl:*readtable*)
+  ;;; Crosscompile sbcl fails w/o that
+  (cl:set-dispatch-macro-character #\# #\s 'core:sharp-s-reader cl:*readtable*)
+  (cl:set-dispatch-macro-character #\# #\S 'core:sharp-s-reader cl:*readtable*)
+
+  ;;; also change read 
+  (setq core:*read-hook* 'read-with-readtable-synced)
+  (setq core:*read-preserving-whitespace-hook* 'read-preserving-whitespace-with-readtable-synced)
+  ;;; read-from-string calls read or read-preserving-whitespace
+  )
+
+(eclector.readtable::init-clasp-as-eclector-reader)  
+
+
+

--- a/src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector.lisp
+++ b/src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector.lisp
@@ -49,14 +49,21 @@
 ;;; to avoid eclector.parse-result::*stack* being unbound, when *client* is bound to a parse-result-client
 ;;; Not sure whether this a a fortunate design in eclector
 
+(defclass clasp-non-cst-elector-client () ())
+(defvar *clasp-normal-eclector-client* (make-instance 'clasp-non-cst-elector-client))
+
+(defmethod eclector.reader:find-character ((client clasp-non-cst-elector-client) name)
+  (or (call-next-method)
+      (gethash name clasp-cleavir::*additional-clasp-character-names*)
+      (clasp-cleavir::simple-unicode-name name)))
+
 (defun read-with-readtable-synced (&optional
                                       (input-stream *standard-input*)
                                       (eof-error-p t)
                                       (eof-value nil)
                                       (recursive-p nil))
   (let ((eclector.readtable:*readtable* cl:*readtable*)
-        (ECLECTOR.READER:*CLIENT* nil))
-    #+(or)(format t "stream ~a eof-p ~a eofv ~a recur ~a~%" input-stream eof-error-p eof-value recursive-p)
+        (eclector.reader:*client* *clasp-normal-eclector-client*))
     (eclector.reader:read input-stream eof-error-p eof-value recursive-p)))
 
 ;;; to avoid th cl:*readtable* and eclector.readtable:*readtable* get out of sync
@@ -66,7 +73,7 @@
                                                            (eof-value nil)
                                                            (recursive-p nil))
   (let ((eclector.readtable:*readtable* cl:*readtable*)
-        (ECLECTOR.READER:*CLIENT* nil))
+        (eclector.reader:*client* *clasp-normal-eclector-client*))
     (eclector.reader:read-preserving-whitespace input-stream eof-error-p eof-value recursive-p)))
 
 ;;; need also sync in clasp-cleavir::cclasp-loop-read-and-compile-file-forms
@@ -76,8 +83,8 @@
                             &optional (eof-error-p t) eof-value
                             &key (start 0) (end (length string))
                               preserve-whitespace)
-  (let ((ECLECTOR.READER:*CLIENT* nil))
-    (ECLECTOR.READER:READ-FROM-STRING string eof-error-p eof-value
+  (let ((eclector.reader:*client* *clasp-normal-eclector-client*))
+    (eclector.reader:read-from-string string eof-error-p eof-value
                                       :start start :end end :preserve-whitespace preserve-whitespace)))
 
 (defun init-clasp-as-eclector-reader ()

--- a/src/lisp/kernel/cleavir/clasp-cleavir.asd
+++ b/src/lisp/kernel/cleavir/clasp-cleavir.asd
@@ -49,6 +49,8 @@
                (:file "translate")
                (:file "translate-instruction")
                (:file "satiation")
+               (:file "fixup-eclector-readtables")
+               (:file "activate-clasp-readtables-for-eclector")
                (:file "inline-prep")
                ;;                 (:file "auto-compile")
                ;;                 (:file "inline")

--- a/src/lisp/kernel/cleavir/clasp-cleavir.asd
+++ b/src/lisp/kernel/cleavir/clasp-cleavir.asd
@@ -48,7 +48,7 @@
                (:file "closure-optimize")
                (:file "translate")
                (:file "translate-instruction")
-               (:file "satiation")
+               ;;                (:file "satiation")
                (:file "fixup-eclector-readtables")
                (:file "activate-clasp-readtables-for-eclector")
                (:file "inline-prep")

--- a/src/lisp/kernel/cleavir/fixup-eclector-readtables.lisp
+++ b/src/lisp/kernel/cleavir/fixup-eclector-readtables.lisp
@@ -1,0 +1,86 @@
+(cl:in-package #:eclector.readtable.simple)
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,readtable_case);
+(defmethod eclector.readtable:readtable-case ((readtable t))
+  (error 'type-error :datum readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,setf_readtable_case);
+;;; need to dispach to (setf)
+(defun ECLECTOR.READTABLE::SETF-READTABLE-CASE (mode readtable)
+  ;;; Check that the readtable is of a type understood by eclector
+  ;;; mode can be :upcase :downcase :invert :preserve
+  (unless (member mode '(:upcase :downcase :invert :preserve))
+    (error 'type-error :datum mode :EXPECTED-TYPE '(member :upcase :downcase :invert :preserve)))
+  (unless (typep readtable 'ECLECTOR.READTABLE.SIMPLE:READTABLE)
+    (error 'type-error :datum readtable :EXPECTED-TYPE 'ECLECTOR.READTABLE.SIMPLE:READTABLE))
+  (setf (eclector.readtable:readtable-case readtable) mode))
+
+#+(or)
+(defmethod (setf eclector.readtable:readtable-case) (mode (readtable t))
+  (error 'type-error :datum readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,make_dispatch_macro_character);
+(defmethod eclector.readtable:make-dispatch-macro-character
+    ((readtable t) char &optional non-terminating-p)
+  (error 'type-error :datum readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,get_macro_character);
+
+(defmethod eclector.readtable:get-macro-character ((readtable t) char)
+  (if (null readtable)
+      ;;; to avoid breaking (get-macro-character #\{ nil)
+      (cl:get-macro-character char cl:*readtable*)
+      (error 'type-error :datum readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable)))
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,set_macro_character);
+(defmethod eclector.readtable:set-macro-character
+    ((readtable t) char function &optional non-terminating-p)
+  (error 'type-error :datum readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,get_dispatch_macro_character);
+(defmethod eclector.readtable:get-dispatch-macro-character
+    ((readtable t) disp-char sub-char)
+  (error 'type-error :datum readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,set_dispatch_macro_character);
+(defmethod eclector.readtable:set-dispatch-macro-character
+    ((readtable t) disp-char sub-char function)
+  (error 'type-error :datum readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,syntax_type);
+(defmethod eclector.readtable:syntax-type ((readtable t) char)
+  (error 'type-error :datum readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,setf_syntax_type);
+(defmethod (setf eclector.readtable:syntax-type)
+    (syntax-type (readtable t) char)
+  (error 'type-error :datum readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,copy_readtable_into);
+(defmethod eclector.readtable:copy-readtable-into
+    ((from-readtable t) (to-readtable readtable))
+  (error 'type-error :datum from-readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+(defmethod eclector.readtable:copy-readtable-into
+    ((from-readtable readtable) (to-readtable t))
+  (error 'type-error :datum to-readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+(defmethod eclector.readtable:copy-readtable-into
+    ((from-readtable t) (to-readtable t))
+  (error 'type-error :datum from-readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,copy_readtable);
+(defmethod eclector.readtable:copy-readtable ((readtable t))
+  (error 'type-error :datum readtable :EXPECTED-TYPE 'eclector.readtable.simple:readtable))
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,readtablep);
+(defmethod eclector.readtable:readtablep ((readtable t))
+  nil)
+
+;;; was forgotten in Eclector, fixed in de134e75ddee442a1811f5f9561133836e36fcf8
+(defmethod eclector.readtable:readtablep ((readtable ECLECTOR.READTABLE.SIMPLE:READTABLE))
+  t)
+
+;;; SYMBOL_EXPORT_SC_(EclectorReadtablePkg,set_syntax_from_char);
+;;; ECLECTOR.READTABLE:SET-SYNTAX-FROM-CHAR is a defun
+

--- a/src/lisp/kernel/cleavir/translate.lisp
+++ b/src/lisp/kernel/cleavir/translate.lisp
@@ -887,6 +887,7 @@ This works like compile-lambda-function in bclasp."
 (defun cclasp-loop-read-and-compile-file-forms (source-sin environment)
   (let ((eof-value (gensym))
         (eclector.reader:*client* *cst-client*)
+        (eclector.readtable:*readtable* cl:*readtable*)
         (cleavir-generate-ast:*compiler* 'cl:compile-file)
         (core:*use-cleavir-compiler* t))
     (loop

--- a/tools-for-build/cleavir-file-list.lisp
+++ b/tools-for-build/cleavir-file-list.lisp
@@ -310,9 +310,10 @@
  "src/lisp/kernel/cleavir/mir" "src/lisp/kernel/cleavir/hir-to-mir"
  "src/lisp/kernel/cleavir/ir" "src/lisp/kernel/cleavir/gml-drawing"
  "src/lisp/kernel/cleavir/landing-pad"
- "src/lisp/kernel/cleavir/closure-optimize"
- "src/lisp/kernel/cleavir/translate"
+ "src/lisp/kernel/cleavir/closure-optimize" "src/lisp/kernel/cleavir/translate"
  "src/lisp/kernel/cleavir/translate-instruction"
  "src/lisp/kernel/cleavir/satiation"
+ "src/lisp/kernel/cleavir/fixup-eclector-readtables"
+ "src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector"
  "src/lisp/kernel/cleavir/inline-prep" "src/lisp/kernel/cleavir/auto-compile"
- "src/lisp/kernel/cleavir/inline" "src/lisp/kernel/cleavir/transform")
+ "src/lisp/kernel/cleavir/inline")

--- a/tools-for-build/cleavir-file-list.lisp
+++ b/tools-for-build/cleavir-file-list.lisp
@@ -312,7 +312,6 @@
  "src/lisp/kernel/cleavir/landing-pad"
  "src/lisp/kernel/cleavir/closure-optimize" "src/lisp/kernel/cleavir/translate"
  "src/lisp/kernel/cleavir/translate-instruction"
- "src/lisp/kernel/cleavir/satiation"
  "src/lisp/kernel/cleavir/fixup-eclector-readtables"
  "src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector"
  "src/lisp/kernel/cleavir/inline-prep" "src/lisp/kernel/cleavir/auto-compile"

--- a/tools-for-build/cleavir-file-list.lisp
+++ b/tools-for-build/cleavir-file-list.lisp
@@ -316,4 +316,4 @@
  "src/lisp/kernel/cleavir/fixup-eclector-readtables"
  "src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector"
  "src/lisp/kernel/cleavir/inline-prep" "src/lisp/kernel/cleavir/auto-compile"
- "src/lisp/kernel/cleavir/inline")
+ "src/lisp/kernel/cleavir/inline" "src/lisp/kernel/cleavir/transform")

--- a/tools-for-build/cleavir_file_list.py
+++ b/tools-for-build/cleavir_file_list.py
@@ -326,5 +326,6 @@ cleavir_file_list = [
     "src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector",
     "src/lisp/kernel/cleavir/inline-prep",
     "src/lisp/kernel/cleavir/auto-compile",
-    "src/lisp/kernel/cleavir/inline"
+    "src/lisp/kernel/cleavir/inline",
+    "src/lisp/kernel/cleavir/transform"
 ]

--- a/tools-for-build/cleavir_file_list.py
+++ b/tools-for-build/cleavir_file_list.py
@@ -321,9 +321,10 @@ cleavir_file_list = [
     "src/lisp/kernel/cleavir/closure-optimize",
     "src/lisp/kernel/cleavir/translate",
     "src/lisp/kernel/cleavir/translate-instruction",
-#    "src/lisp/kernel/cleavir/satiation",
+    "src/lisp/kernel/cleavir/satiation",
+    "src/lisp/kernel/cleavir/fixup-eclector-readtables",
+    "src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector",
     "src/lisp/kernel/cleavir/inline-prep",
     "src/lisp/kernel/cleavir/auto-compile",
-    "src/lisp/kernel/cleavir/inline",
-    "src/lisp/kernel/cleavir/transform"
+    "src/lisp/kernel/cleavir/inline"
 ]

--- a/tools-for-build/cleavir_file_list.py
+++ b/tools-for-build/cleavir_file_list.py
@@ -321,7 +321,6 @@ cleavir_file_list = [
     "src/lisp/kernel/cleavir/closure-optimize",
     "src/lisp/kernel/cleavir/translate",
     "src/lisp/kernel/cleavir/translate-instruction",
-    "src/lisp/kernel/cleavir/satiation",
     "src/lisp/kernel/cleavir/fixup-eclector-readtables",
     "src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector",
     "src/lisp/kernel/cleavir/inline-prep",

--- a/tools-for-build/regenerate-cleavir-file-list.lisp
+++ b/tools-for-build/regenerate-cleavir-file-list.lisp
@@ -56,7 +56,8 @@
     ;; replace CL functions like CONSP, CAR, CDR, RPLACA etc
     ;;#P"src/lisp/kernel/tags/pre-auto"
     "src/lisp/kernel/cleavir/auto-compile"
-    "src/lisp/kernel/cleavir/inline")))
+    "src/lisp/kernel/cleavir/inline"
+    "src/lisp/kernel/cleavir/transform")))
 
 (save-file-list-as-python
  (merge-pathnames #P"cleavir_file_list.py"

--- a/tools-for-build/regenerate-cleavir-file-list.lisp
+++ b/tools-for-build/regenerate-cleavir-file-list.lisp
@@ -10,7 +10,9 @@
 (in-package :cl-user)
 
 (format t "Loading asdf~%")
-(load "sys:modules;asdf;build;asdf.lisp")
+#+(or) (load "sys:modules;asdf;build;asdf.lisp")
+(require :asdf)
+
 
 (defun save-file-list-as-python (filename file-list)
   "Save the list of files in FILE-LIST to FILENAME as a python file."


### PR DESCRIPTION
Features
* until now eclector, was just used in compile-file. Also use it for
   * load (via read)
   * read (can be configured via global variable calls out from c++)
   * read-preserving-whitespace (can be configured via global variable calls out from c++)
   * read-from-string
   * read-delimited-list is not yet covered by eclector, so still calls the c++ reader
* recent changes in the c++ side allowed for use of eclector readtables in clasp, but the integration changed the semantics, restored by fixup-eclector-readtables.lisp 
* I finally believe that it is best to use the clasp-readtables in eclector, but using the macro-character-code form eclector (activate-clasp-readtables-for-eclector.lisp)
* It is hell to have cl:*readtable* in sync with eclector.readtable:*readtable* , so in the end I opted for the brute force approach to sync before every call to eclector
* if e.g. a macro calls the reader during compilation - sea opticl-core - the wrong eclector-client (parse-result-client) was used, so set the client to nil in calls via read and friends
* added the new files to src/lisp/kernel/cleavir/clasp-cleavir.asd 
* regenerated cleavir-file-list.lisp and cleavir-file-list.py
* fixed regenerate-cleavir-file-list.lisp to use the already compiled asdf

* I see that transform.lisp is now missing, this is not intentional, perhaps this is missing in https://github.com/clasp-developers/clasp/blob/master/tools-for-build/regenerate-cleavir-file-list.lisp#L57 , will add again. Is it possible that the file-list was edited manually?

Did test with
* the regression-test
* the ansi-test-suite (there a now a lot of errrors fixed but other new. The new errors have probably to be fixed in eclector
* compiled mcclim (only problem was iterate)
* compiled all systems for cando (from https://github.com/clasp-developers/clasp/blob/master/lib.sh#L109-#L134)


```lisp
79 unexpected failures: DEFMACRO.21, DEFTYPE.11, FORMAT.C.5A, READ-SYMBOL.16, READ-SYMBOL.17, 
   READ-SYMBOL.18, READ-SYMBOL.25, READTABLE-CASE.CASE-DOWNCASE, 
   READTABLE-CASE.CASE-PRESERVE, READTABLE-CASE.CASE-INVERT, 
   SET-MACRO-CHARACTER.1, SET-MACRO-CHARACTER.2, SET-MACRO-CHARACTER.3, 
   READ-SUPPRESS.SHARP-R.10, READ-SUPPRESS.SHARP-EQUAL.4, 
   READ-SUPPRESS.SHARP-SHARP.1, READ-SUPPRESS.SHARP-SHARP.2, 
   READ-SUPPRESS.SHARP-SHARP.3, READ-SUPPRESS.SHARP-SHARP.4, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-REVERSE_SOLIDUS, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-VERTICAL_LINE, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-QUOTATION_MARK, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-NUMBER_SIGN, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-APOSTROPHE, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LEFT_PARENTHESIS, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-RIGHT_PARENTHESIS, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-COMMA, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-SEMICOLON, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-GRAVE_ACCENT, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_A, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_B, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_C, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_D, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_E, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_F, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_G, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_H, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_I, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_J, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_K, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_L, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_M, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_N, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_O, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_P, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_Q, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_R, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_S, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_T, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_U, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_V, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_W, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_X, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_Y, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-LATIN_SMALL_LETTER_Z, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-TAB, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-NEWLINE, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-PAGE, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-RETURN, 
   SET-SYNTAX-FROM-CHAR-TRAIT-X-SPACE, 
   SET-SYNTAX-FROM-CHAR.SINGLE-ESCAPE.1, 
   SET-SYNTAX-FROM-CHAR.MULTIPLE-ESCAPE, SET-SYNTAX-FROM-CHAR.SEMICOLON, 
   SET-SYNTAX-FROM-CHAR.LEFT-PAREN, SET-SYNTAX-FROM-CHAR.RIGHT-PAREN, 
   SET-SYNTAX-FROM-CHAR.SINGLE-QUOTE, SET-SYNTAX-FROM-CHAR.BACKQUOTE, 
   SET-SYNTAX-FROM-CHAR.COMMA, SET-SYNTAX-FROM-CHAR.SHARP.2, 
   MAKE-DISPATCH-MACRO-CHARACTER.1, MAKE-DISPATCH-MACRO-CHARACTER.3, 
   SYNTAX.DIGITS.ALPHABETIC.1, SYNTAX.SHARP-BACKSLASH.5, 
   SYNTAX.SHARP-BACKSLASH.6, SYNTAX.SHARP-BACKSLASH.7, 
   SYNTAX.SINGLE-ESCAPE-EOF.2, SYNTAX.MULTIPLE-ESCAPE-EOF.2, 
   SYNTAX.NUMBER-TOKEN.3, SYNTAX.NUMBER-TOKEN.4.

55 unexpected successes: SUBSEQ-VECTOR.9, READ-SYMBOL.11, READ-SYMBOL.12, READ-SYMBOL.13, 
   READ-SUPPRESS.SHARP-ASTERISK.1, READ-SUPPRESS.SHARP-ASTERISK.2, 
   READ-SUPPRESS.SHARP-ASTERISK.10, READ-SUPPRESS.SHARP-ASTERISK.11, 
   READ-SUPPRESS.SHARP-ASTERISK.12, READ-SUPPRESS.SHARP-ASTERISK.14, 
   SYNTAX.ESCAPED.1, SYNTAX.ESCAPED.2, SYNTAX.SHARP-BACKSLASH.2, 
   SYNTAX.SHARP-BACKSLASH.3, SYNTAX.SHARP-ASTERISK.11, 
   SYNTAX.DOT-TOKEN.2, SYNTAX.DOT-TOKEN.4, SYNTAX.DOT-TOKEN.5, 
   SYNTAX.DOT-TOKEN.7, PRINT.SYMBOL.RANDOM.3, PRINT.SYMBOL.RANDOM.4, 
   SYNTAX.SHARP-COLON.ERROR.1, PRINT.SHORT-FLOAT.RANDOM, 
   PRINT.SINGLE-FLOAT.RANDOM, PRINT.CONS.RANDOM.1, PRINT.ARRAY.2.26, 
   READ-SYMBOL.23, READ.16, READ.ERROR.1, 
   READ-PRESERVING-WHITESPACE.ERROR.1, READ-FROM-STRING.2, 
   READ-FROM-STRING.6, READ-FROM-STRING.11, READ-FROM-STRING.14, 
   READ-FROM-STRING.15, READ-FROM-STRING.16, READ-FROM-STRING.17, 
   SYNTAX.SHARP-QUOTE.ERROR.1, SYNTAX.SHARP-QUOTE.ERROR.2, 
   SYNTAX.SHARP-DOT.ERROR.1, SYNTAX.SHARP-DOT.ERROR.2, SYNTAX.SHARP-B.5, 
   SYNTAX.SHARP-B.7, SYNTAX.SHARP-B.10, SYNTAX.SHARP-O.7, 
   SYNTAX.SHARP-O.8, SYNTAX.SHARP-O.10, SYNTAX.SHARP-X.15, 
   SYNTAX.SHARP-T.7, SYNTAX.SHARP-T.8, SYNTAX.DOT-TOKEN.1, 
   SYNTAX.DOT-TOKEN.3, SYNTAX.DOT-TOKEN.6, SYNTAX.DOT-ERROR.4, 
   SYNTAX.DOT-ERROR.7.
````