### PR TITLE
Fix message compiled-function-file expected a function as argument ..

### DIFF
--- a/src/lisp/kernel/lsp/top.lsp
+++ b/src/lisp/kernel/lsp/top.lsp
@@ -888,11 +888,13 @@ Use special code 0 to cancel this operation.")
   #+threads (format t " In: ~A.~%" mp:*current-process*)
   (let ((fun (ihs-fun *ihs-current*)))
     (when (and (symbolp fun) (fboundp fun))
-      (setf fun (fdefinition fun)))
-    (multiple-value-bind (file position)
-	(ext:compiled-function-file fun)
-      (when file
-	(format t " File: ~S (Position #~D)~%" file position))))
+      (setf fun (fdefinition fun))
+      ;;; to avoid ;;; Warning: compiled-function-file expected a function as argument
+      ;;; - but it got NIL - there may not be any backtrace available
+      (multiple-value-bind (file position)
+          (ext:compiled-function-file fun)
+        (when file
+          (format t " File: ~S (Position #~D)~%" file position)))))
   (values))
 
 (defun tpl-hide (fname)
@@ -931,7 +933,8 @@ Use special code 0 to cancel this operation.")
 
 (defun ihs-fname (i)
   (let ((function (ihs-fun i)))
-    (cond ((symbolp function) function)
+    (cond ((null function) "Unkown")
+          ((symbolp function) function)
           ((compiled-function-p function)
            (or (ext:compiled-function-name function) 'lambda))
 	  #+clos

--- a/src/lisp/kernel/lsp/top.lsp
+++ b/src/lisp/kernel/lsp/top.lsp
@@ -933,7 +933,7 @@ Use special code 0 to cancel this operation.")
 
 (defun ihs-fname (i)
   (let ((function (ihs-fun i)))
-    (cond ((null function) "Unkown")
+    (cond ((null function) '#:unknown)
           ((symbolp function) function)
           ((compiled-function-p function)
            (or (ext:compiled-function-name function) 'lambda))


### PR DESCRIPTION
Before an error in the repl would show 2 wrong messages:
* `;;; Warning: compiled-function-file expected a function as argument - but it got NIL - there may not be any backtrace available`
* Reference a frame 'nil' e.g. in `Broken at frame[0] NIL. In: #<PROCESS TOP-LEVEL @0x1104c3019>.``

Full example:
```lisp
COMMON-LISP-USER> (Defun test ()(nada))
; caught STYLE-WARNING:
;   Undefined function NADA
;     at -unknown-file- 0:0
; 
; 
; compilation unit finished
;   caught 1 STYLE-WARNING condition

TEST
COMMON-LISP-USER> (test)

Condition of type: UNDEFINED-FUNCTION
The function NADA is undefined.

Available restarts:
(use :r1 to invoke restart 1)

1. (RESTART-TOPLEVEL) Go back to Top-Level REPL.

search_jitted_stackmaps
Broken at frame[0] NIL. In: #<PROCESS TOP-LEVEL @0x1104c3019>.
;;; Warning: compiled-function-file expected a function as argument - but it got NIL - there may not be any backtrace available
````

With the pr applied:
```lisp
COMMON-LISP-USER> (Defun test ()(nada))
; caught STYLE-WARNING:
;   Undefined function NADA
;     at -unknown-file- 0:0
; 
; 
; compilation unit finished
;   caught 1 STYLE-WARNING condition

TEST
COMMON-LISP-USER> (test)

Condition of type: UNDEFINED-FUNCTION
The function NADA is undefined.

Available restarts:
(use :r1 to invoke restart 1)

1. (RESTART-TOPLEVEL) Go back to Top-Level REPL.

search_jitted_stackmaps
Broken at frame[0] "UNKOWN". In: #<PROCESS TOP-LEVEL @0x1198fc019>.
````