### PR TITLE
Silence compile-file verbose messages when verbose = nil

### DIFF
--- a/src/lisp/kernel/cmp/compile-file-parallel.lsp
+++ b/src/lisp/kernel/cmp/compile-file-parallel.lsp
@@ -434,7 +434,8 @@ Each bitcode filename will contain the form-index.")
                     (t (output-cfp-result result ast-jobs output-path output-type)))
               output-path)))))))
 
-(defun cl:compile-file (input-file &rest args &key (output-type :fasl output-type-p) output-file  &allow-other-keys)
+(defun cl:compile-file (input-file &rest args &key (output-type :fasl output-type-p)
+                                                output-file (verbose *compile-verbose*) &allow-other-keys)
   (when *generate-faso*
     (remf args :output-type)
     (setq output-type (case output-type
@@ -449,9 +450,8 @@ Each bitcode filename will contain the form-index.")
                  (t (if *compile-file-parallel*
                         (apply #'compile-file-parallel input-file args)
                         (apply #'compile-file-serial input-file args))))))
-    (if (or (getf args :print) *compile-print*)
-        (let ((*trace-output* *standard-output*))
-          (time (do-compile-file)))
+    (if verbose
+        (time (do-compile-file))
         (do-compile-file))))
 
 (eval-when (:load-toplevel)


### PR DESCRIPTION
* General messages about compilation should be controlled by verbose not by print. Print is supposed to give information for every compiled form.
* When :verbose nil is passed, it should not be overwritten by  *compile-verbose*. *compile-verbose* should be the default value for verbose
* Test already exists in the regression-test `COMPILE-FILE.1.simplified`