### PR TITLE
Forgot to synch cl and eclector redtable for read-from-string

### DIFF
--- a/src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector.lisp
+++ b/src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector.lisp
@@ -97,7 +97,8 @@
                             &optional (eof-error-p t) eof-value
                             &key (start 0) (end (length string))
                               preserve-whitespace)
-  (let ((eclector.reader:*client* *clasp-normal-eclector-client*))
+  (let ((eclector.readtable:*readtable* cl:*readtable*)
+        (eclector.reader:*client* *clasp-normal-eclector-client*))
     (eclector.reader:read-from-string string eof-error-p eof-value
                                       :start start :end end :preserve-whitespace preserve-whitespace)))
 


### PR DESCRIPTION
* fixes regression test SET-SYNTAX-FROM-CHAR-TRAIT-X-1b that failed after my eclector integration pr
* brings down the errors in the ansi-tests to 197