### PR TITLE
[Wip] Return sensible error in integer-decode-float when called with a infinity value

### DIFF
--- a/src/core/num_co.cc
+++ b/src/core/num_co.cc
@@ -1109,6 +1109,8 @@ CL_LAMBDA(x);
 CL_DECLARE();
 CL_DOCSTRING("integer_decode_float");
 CL_DEFUN Real_mv cl__integer_decode_float(Float_sp x) {
+  unlikely_if (clasp_float_infinity_p(x))
+    ARITHMETIC_ERROR(cl::_sym_integer_decode_float, core::lisp_createList(x));
   int e = 0, s = 1;
   Real_sp rx(_Nil<Real_O>());
   switch (clasp_t_of(x)) {

--- a/src/lisp/regression-tests/numbers.lisp
+++ b/src/lisp/regression-tests/numbers.lisp
@@ -600,3 +600,43 @@
       (labels ((factorial (n)(if (<= n 1) 1 (* n (factorial (1- n))))))
         (loop for x from 1 to 500 collect
              (log (factorial x)))))
+
+(test-expect-error
+ integer_decode_float_infinity_short_positive
+ (integer-decode-float #.ext:short-float-positive-infinity)
+ :type arithmetic-error)
+
+(test-expect-error
+ integer_decode_float_infinity_single_positive
+ (integer-decode-float #.ext:single-float-positive-infinity)
+ :type arithmetic-error)
+
+(test-expect-error
+ integer_decode_float_infinity_double_positive
+ (integer-decode-float #.ext:double-float-positive-infinity)
+ :type arithmetic-error)
+
+(test-expect-error
+ integer_decode_float_infinity_long_positive
+ (integer-decode-float #.ext:long-float-positive-infinity)
+ :type arithmetic-error)
+
+(test-expect-error
+ integer_decode_float_infinity_short_negative
+ (integer-decode-float #.ext:short-float-negative-infinity)
+ :type arithmetic-error)
+
+(test-expect-error
+ integer_decode_float_infinity_single_negative
+ (integer-decode-float #.ext:single-float-negative-infinity)
+ :type arithmetic-error)
+
+(test-expect-error
+ integer_decode_float_infinity_double_negative
+ (integer-decode-float #.ext:double-float-negative-infinity)
+ :type arithmetic-error)
+
+(test-expect-error
+ integer_decode_float_infinity_long_negative
+ (integer-decode-float #.ext:long-float-negative-infinity)
+ :type arithmetic-error)


### PR DESCRIPTION
* issue encountered while cross-compiling sbcl (and the origin is still to be clarified)
* return sensible error instead of sigfpe as before
* added test to regression-suite