### PR TITLE
Also sync the readtables for parallel compile as with sequential compile

### DIFF
--- a/src/lisp/kernel/cmp/compile-file-parallel.lsp
+++ b/src/lisp/kernel/cmp/compile-file-parallel.lsp
@@ -167,6 +167,7 @@ multithreaded performance that we should explore."
         #+cclasp(cleavir-generate-ast:*compiler* 'cl:compile-file)
         #+cclasp(core:*use-cleavir-compiler* t)
         #+cclasp(eclector.reader:*client* clasp-cleavir::*cst-client*)
+        #+cclasp(eclector.readtable:*readtable* cl:*readtable*)
         ast-jobs)
     (cfp-log "Starting the pool of threads~%")
     (finish-output)


### PR DESCRIPTION
* now passes while cross-compiling sbcl make-host-1.sh in 
`real	35m43.360s
user	115m30.230s
sys	2m55.174s`
* and w/o the patch fails reading the float-constants since readtables are not in sync
* used to be 60 min
* make-host-2 is not in parallel, so old speed