### PR TITLE
Export btcl and ihs-argument from ext

### DIFF
--- a/src/lisp/kernel/init.lsp
+++ b/src/lisp/kernel/init.lsp
@@ -162,6 +162,8 @@
 
 ;;; Imports
 (import 'core:quit :ext)
+(import 'core:btcl :ext)
+(import 'core:ihs-argument :ext)
 ;;; EXT exports
 (eval-when (:execute :compile-toplevel :load-toplevel)
   (select-package :ext))
@@ -201,7 +203,9 @@
           stream-encoding-error
           stream-decoding-error
           generate-encoding-hashtable
-          quit))
+          quit
+          btcl
+          ihs-argument))
 (core:*make-special '*module-provider-functions*)
 (core:*make-special '*source-location*)
 (setq *source-location* nil)


### PR DESCRIPTION
export
* `(ext:btcl)`
* `(ext:ihs-argument arg_index &optional (frame_index *ihs-current*))`

as the official debugger interface