### PR TITLE
Actually use handle_bus

### DIFF
--- a/src/gctools/interrupt.cc
+++ b/src/gctools/interrupt.cc
@@ -255,15 +255,22 @@ int global_pollTicksGC = INITIAL_GLOBAL_POLL_TICKS_PER_CLEANUP;
 
 void handle_fpe(int signo, siginfo_t* info, void* context) {
   (void)context; // unused
-  init_float_traps(); // WHY
+  // printf("Enter handle_fpe Signo: %d Errno:%d Code:%d\n", (info->si_signo), (info->si_errno), (info->si_code));
+  // init_float_traps(); // WHY
   // TODO: Get operation and operands when possible.
   // Probably off the call stack.
   switch (info->si_code) {
+    #ifdef _TARGET_OS_DARWIN
+  case FPE_NOOP:   NO_INITIALIZERS_ERROR(cl::_sym_arithmeticError);
+    #endif
+  case FPE_INTDIV: NO_INITIALIZERS_ERROR(cl::_sym_divisionByZero);
+  case FPE_INTOVF: NO_INITIALIZERS_ERROR(cl::_sym_arithmeticError);
   case FPE_FLTDIV: NO_INITIALIZERS_ERROR(cl::_sym_divisionByZero);
   case FPE_FLTOVF: NO_INITIALIZERS_ERROR(cl::_sym_floatingPointOverflow);
   case FPE_FLTUND: NO_INITIALIZERS_ERROR(cl::_sym_floatingPointUnderflow);
   case FPE_FLTRES: NO_INITIALIZERS_ERROR(cl::_sym_floatingPointInexact);
   case FPE_FLTINV: NO_INITIALIZERS_ERROR(cl::_sym_floatingPointInvalidOperation);
+  case FPE_FLTSUB: NO_INITIALIZERS_ERROR(cl::_sym_arithmeticError);
   default: // FIXME: signal a better error.
       // Can end up here with e.g. SI_USER if it originated from kill
       handle_signal_now(signo);
@@ -380,18 +387,25 @@ void initialize_unix_signal_handlers() {
 #ifdef SIGEMT
         ADD_SIGNAL( SIGEMT, "SIGEMT", _Nil<core::T_O>());
 #endif
+/*
+// We do install a sigfpe handler in initialize_signals
 #ifdef SIGFPE
         ADD_SIGNAL( SIGFPE, "SIGFPE", _Nil<core::T_O>());
 #endif
+*/
 #ifdef SIGKILL
         ADD_SIGNAL( SIGKILL, "SIGKILL", _Nil<core::T_O>());
 #endif
+/*
+// These take a parameter, so will fail if called here, since handle_signal_now call with no parameters
+// We do install correct handlers in initialize_signals
 #ifdef SIGBUS
         ADD_SIGNAL( SIGBUS, "SIGBUS", ext::_sym_bus_error);
 #endif
 #ifdef SIGSEGV
         ADD_SIGNAL( SIGSEGV, "SIGSEGV", ext::_sym_segmentation_violation);
 #endif
+*/
 #ifdef SIGSYS
         ADD_SIGNAL( SIGSYS, "SIGSYS", _Nil<core::T_O>());
 #endif
@@ -416,9 +430,12 @@ void initialize_unix_signal_handlers() {
 #ifdef SIGCONT
         ADD_SIGNAL( SIGCONT, "SIGCONT", _Nil<core::T_O>());
 #endif
+/*
+// core::_sym_wait_for_all_processes is undefined
 #ifdef SIGCHLD
         ADD_SIGNAL( SIGCHLD, "SIGCHLD", core::_sym_wait_for_all_processes);
 #endif
+*/
 #ifdef SIGTTIN
         ADD_SIGNAL( SIGTTIN, "SIGTTIN", _Nil<core::T_O>());
 #endif

--- a/src/gctools/interrupt.cc
+++ b/src/gctools/interrupt.cc
@@ -335,7 +335,7 @@ void initialize_signals(int clasp_signal) {
   if (!getenv("CLASP_DONT_HANDLE_CRASH_SIGNALS")) {
     INIT_SIGNAL(SIGABRT, (SA_NODEFER | SA_RESTART), handle_or_queue_signal);
     INIT_SIGNALI(SIGSEGV, (SA_NODEFER | SA_RESTART | SA_ONSTACK), handle_segv);
-    INIT_SIGNAL(SIGBUS, (SA_NODEFER | SA_RESTART), handle_signal_now);
+    INIT_SIGNALI(SIGBUS, (SA_NODEFER | SA_RESTART), handle_bus);
   }
   INIT_SIGNALI(SIGFPE, (SA_NODEFER | SA_RESTART), handle_fpe);
   INIT_SIGNAL(SIGILL, (SA_NODEFER | SA_RESTART), handle_signal_now);


### PR DESCRIPTION
* if handle_signal_now is called -as it was before- , than ext::_sym_bus_error will be called with no arguments, which will crash, since ext:bus-error expects one argument
* Same with SIGSEGV in `ADD_SIGNAL( SIGSEGV, "SIGSEGV", ext::_sym_segmentation_violation);`
* `core::_sym_wait_for_all_processes` is not defined
* fix that `handle_fpe`is really called
* in `handle_fpe` handle all values for `info->si_code`, `FPE_NOOP`only on darwin