### PR TITLE
enable shinmeras float features

### DIFF
--- a/src/lisp/kernel/init.lsp
+++ b/src/lisp/kernel/init.lsp
@@ -205,7 +205,8 @@
           generate-encoding-hashtable
           quit
           btcl
-          ihs-argument))
+          ihs-argument
+          with-float-traps-masked))
 (core:*make-special '*module-provider-functions*)
 (core:*make-special '*source-location*)
 (setq *source-location* nil)

--- a/src/lisp/regression-tests/float-features.lisp
+++ b/src/lisp/regression-tests/float-features.lisp
@@ -1,0 +1,81 @@
+(in-package #:clasp-tests)
+
+(test float-features-1
+      (ext:float-infinity-p
+       (flet ((foo () (if (> 10 (random 20)) 0.0 0.0))
+              (bar () (if (> 10 (random 20)) 23 24)))
+         (ext:with-float-traps-masked (:divide-by-zero)
+           (/ (bar) (foo))))))
+(test float-features-1
+      (handler-case
+          (flet ((foo () (if (> 10 (random 20)) 0.0 0.0))
+                 (bar () (if (> 10 (random 20)) 23 24)))
+            (ext:with-float-traps-masked ()
+              (/ (bar) (foo))
+              ))
+        (division-by-zero (error)
+          (values t error))))
+
+(defun foo-ext-1 (n)
+  (if (> n (random 20)) most-positive-long-float most-positive-long-float))
+
+(defun bar-ext-1 (n)
+  (if (> n (random 20)) most-positive-long-float most-positive-long-float))
+
+(test float-features-3
+      (ext:float-infinity-p
+       (ext:with-float-traps-masked (:overflow :inexact)
+         (let ((n (random 100)))
+           (+ (foo-ext-1 n) (bar-ext-1 n))))))
+
+(test float-features-4
+      (handler-case
+          (let ((n (random 100)))
+            (ext:with-float-traps-masked ()
+              (+ (foo-ext-1 n) (bar-ext-1 n))))
+        (FLOATING-POINT-OVERFLOW (error)
+          (values t error))))
+
+(defun foo-ext-2 (n)
+  (if (> n (random 20)) (- most-positive-long-float 3) (- most-positive-long-float 3)))
+
+(defun bar-ext-2 (n)
+  (if (> n (random 20)) (- most-positive-long-float 3) (- most-positive-long-float 3)))
+
+(test float-features-5
+      (ext:float-infinity-p
+       (ext:with-float-traps-masked (:overflow :inexact)
+         (let ((n (random 100)))
+           (+ (foo-ext-2 n) (bar-ext-2 n))))))
+
+(test float-features-6
+      (handler-case
+          (let ((n (random 100)))
+            (ext:with-float-traps-masked ()
+              (+ (foo-ext-2 n) (bar-ext-2 n))))
+        (FLOATING-POINT-INEXACT (error)
+          (values t error))
+        (FLOATING-POINT-OVERFLOW (error)
+          (values t error))))
+
+(defun foo-ext-3 (n)
+  (if (> n (random 20)) 0.0 0.0))
+
+(defun bar-ext-3 (n)
+  (if (> n (random 20)) 0.0 0.0))
+
+(test float-features-7
+      (ext:float-nan-p
+       (ext:with-float-traps-masked (:invalid)
+         (let ((n (random 100)))
+           (/ (foo-ext-3 n) (bar-ext-3 n))))))
+
+(test float-features-8
+      (handler-case
+          (ext:with-float-traps-masked ()
+            (let ((n (random 100)))
+              (/ (foo-ext-3 n) (bar-ext-3 n))))
+        (FLOATING-POINT-INEXACT (error)
+          (values t error))
+        (FLOATING-POINT-INVALID-OPERATION (error)
+          (values t error))))

--- a/src/lisp/regression-tests/float-features.lisp
+++ b/src/lisp/regression-tests/float-features.lisp
@@ -1,12 +1,13 @@
 (in-package #:clasp-tests)
 
-(test float-features-1
+(test float-features-1a
       (ext:float-infinity-p
        (flet ((foo () (if (> 10 (random 20)) 0.0 0.0))
               (bar () (if (> 10 (random 20)) 23 24)))
          (ext:with-float-traps-masked (:divide-by-zero)
            (/ (bar) (foo))))))
-(test float-features-1
+
+(test float-features-1b
       (handler-case
           (flet ((foo () (if (> 10 (random 20)) 0.0 0.0))
                  (bar () (if (> 10 (random 20)) 23 24)))

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -45,6 +45,7 @@
 (load-if-compiled-correctly "sys:regression-tests;encodings.lisp")
 (load-if-compiled-correctly "sys:regression-tests;system-construction.lisp")
 (load-if-compiled-correctly "sys:regression-tests;environment.lisp")
+(load-if-compiled-correctly "sys:regression-tests;float-features.lisp")
 
 (progn
   (note-test-finished)


### PR DESCRIPTION
* implementation of float-features
* Shinmera float-features can be integrated with
```
(defmacro with-float-traps-masked (traps &body body)
...
    #+clasp
     `(ext:with-float-traps-masked ,traps
       ,@body)
...
```

* Added tests, since I coudn't find them in float-features
* retested the tests with sbcl and ccl. The only deviation in behaviour are the last 2 tests, where I had to add `(FLOATING-POINT-INEXACT (error)
          (values t error))`for clasp
* Still need to test on linux
* This code will be sse-only, so no clue about arm
 