### PR TITLE
define stat,fast (size,mtime.mode)

### DIFF
--- a/src/core/unixfsys.cc
+++ b/src/core/unixfsys.cc
@@ -2221,5 +2221,79 @@ CL_DEFUN FdSet_sp core__make_fd_set() {
   return fdset;
 }
 
+CL_LAMBDA(filedescriptor);
+CL_DECLARE();
+CL_DOCSTRING("Fstat-size for a file-descriptor, nil on error");
+CL_DEFUN T_sp core__fstat_size(int filedescriptor) {
+  struct stat sb;
+  if (fstat(filedescriptor, &sb) == -1)
+    return _Nil<T_O>();
+  else
+    return Integer_O::create(sb.st_size);
+};
 
+CL_LAMBDA(filedescriptor);
+CL_DECLARE();
+CL_DOCSTRING("Fstat-mtime for a file-descriptor, nil on error");
+CL_DEFUN T_sp core__fstat_mtime(int filedescriptor) {
+  struct stat sb;
+  if (fstat(filedescriptor, &sb) == -1)
+    return _Nil<T_O>();
+  else
+    return Integer_O::create((gctools::Fixnum) sb.st_mtime);
+};
+
+CL_LAMBDA(filedescriptor);
+CL_DECLARE();
+CL_DOCSTRING("fstat-mode for a filedescriptor, nil on error");
+CL_DEFUN T_sp core__fstat_mode(int filedescriptor) {
+  struct stat sb;
+  if (fstat(filedescriptor, &sb) == -1)
+    return _Nil<T_O>();
+  else
+    return Integer_O::create((gctools::Fixnum) sb.st_mode);
+};
+
+CL_LAMBDA(pathname);
+CL_DECLARE();
+CL_DOCSTRING("stat-size for a pathname, nil on error");
+CL_DEFUN T_sp core__stat_size(T_sp pathname) {
+  struct stat sb;
+  String_sp filename = gc::As<String_sp>(cl__namestring(pathname));
+  if (stat(filename->get_std_string().c_str(), &sb) == -1)
+    return _Nil<T_O>();
+  else
+    return Integer_O::create(sb.st_size);
+};
+
+CL_LAMBDA(pathname);
+CL_DECLARE();
+CL_DOCSTRING("stat-mtime for a pathname, nil on error");
+CL_DEFUN T_sp core__stat_mtime(T_sp pathname) {
+  struct stat sb;
+  String_sp filename = gc::As<String_sp>(cl__namestring(pathname));
+  if (stat(filename->get_std_string().c_str(), &sb) == -1)
+    return _Nil<T_O>();
+  else
+    return Integer_O::create((gctools::Fixnum) sb.st_mtime);
+};
+
+CL_LAMBDA(pathname);
+CL_DECLARE();
+CL_DOCSTRING("stat-mode for a pathname, nil on error");
+CL_DEFUN T_sp core__stat_mode(T_sp pathname) {
+  struct stat sb;
+  String_sp filename = gc::As<String_sp>(cl__namestring(pathname));
+  if (stat(filename->get_std_string().c_str(), &sb) == -1)
+    return _Nil<T_O>();
+  else
+    return Integer_O::create((gctools::Fixnum) sb.st_mode);
+};
+
+SYMBOL_EXPORT_SC_(CorePkg, fstat_size);
+SYMBOL_EXPORT_SC_(CorePkg, fstat_mtime);
+SYMBOL_EXPORT_SC_(CorePkg, fstat_mode);
+SYMBOL_EXPORT_SC_(CorePkg, stat_size);
+SYMBOL_EXPORT_SC_(CorePkg, stat_mtime);
+SYMBOL_EXPORT_SC_(CorePkg, stat_mode);
 }; // namespace core

--- a/src/core/unixfsys.cc
+++ b/src/core/unixfsys.cc
@@ -2223,77 +2223,33 @@ CL_DEFUN FdSet_sp core__make_fd_set() {
 
 CL_LAMBDA(filedescriptor);
 CL_DECLARE();
-CL_DOCSTRING("Fstat-size for a file-descriptor, nil on error");
-CL_DEFUN T_sp core__fstat_size(int filedescriptor) {
+CL_DOCSTRING("Fstat values size mtime and mode for file-descriptor, nil on error");
+CL_DEFUN T_mv core__fstat(int filedescriptor) {
   struct stat sb;
   if (fstat(filedescriptor, &sb) == -1)
-    return _Nil<T_O>();
+    return Values(_Nil<T_O>());
   else
-    return Integer_O::create(sb.st_size);
-};
-
-CL_LAMBDA(filedescriptor);
-CL_DECLARE();
-CL_DOCSTRING("Fstat-mtime for a file-descriptor, nil on error");
-CL_DEFUN T_sp core__fstat_mtime(int filedescriptor) {
-  struct stat sb;
-  if (fstat(filedescriptor, &sb) == -1)
-    return _Nil<T_O>();
-  else
-    return Integer_O::create((gctools::Fixnum) sb.st_mtime);
-};
-
-CL_LAMBDA(filedescriptor);
-CL_DECLARE();
-CL_DOCSTRING("fstat-mode for a filedescriptor, nil on error");
-CL_DEFUN T_sp core__fstat_mode(int filedescriptor) {
-  struct stat sb;
-  if (fstat(filedescriptor, &sb) == -1)
-    return _Nil<T_O>();
-  else
-    return Integer_O::create((gctools::Fixnum) sb.st_mode);
+    return Values (Integer_O::create(sb.st_size),
+                   Integer_O::create((gctools::Fixnum) sb.st_mtime),
+                   Integer_O::create((gctools::Fixnum) sb.st_mode));
+                                     
 };
 
 CL_LAMBDA(pathname);
 CL_DECLARE();
-CL_DOCSTRING("stat-size for a pathname, nil on error");
-CL_DEFUN T_sp core__stat_size(T_sp pathname) {
+CL_DOCSTRING("stat values size mtime and mode for a pathname, nil on error");
+CL_DEFUN T_mv core__stat (T_sp pathname) {
   struct stat sb;
   String_sp filename = gc::As<String_sp>(cl__namestring(pathname));
   if (stat(filename->get_std_string().c_str(), &sb) == -1)
-    return _Nil<T_O>();
+    return Values (_Nil<T_O>());
   else
-    return Integer_O::create(sb.st_size);
+    return Values(Integer_O::create(sb.st_size),
+                  Integer_O::create((gctools::Fixnum) sb.st_mtime),
+                  Integer_O::create((gctools::Fixnum) sb.st_mode));
 };
 
-CL_LAMBDA(pathname);
-CL_DECLARE();
-CL_DOCSTRING("stat-mtime for a pathname, nil on error");
-CL_DEFUN T_sp core__stat_mtime(T_sp pathname) {
-  struct stat sb;
-  String_sp filename = gc::As<String_sp>(cl__namestring(pathname));
-  if (stat(filename->get_std_string().c_str(), &sb) == -1)
-    return _Nil<T_O>();
-  else
-    return Integer_O::create((gctools::Fixnum) sb.st_mtime);
-};
+SYMBOL_EXPORT_SC_(CorePkg, fstat);
+SYMBOL_EXPORT_SC_(CorePkg, stat);
 
-CL_LAMBDA(pathname);
-CL_DECLARE();
-CL_DOCSTRING("stat-mode for a pathname, nil on error");
-CL_DEFUN T_sp core__stat_mode(T_sp pathname) {
-  struct stat sb;
-  String_sp filename = gc::As<String_sp>(cl__namestring(pathname));
-  if (stat(filename->get_std_string().c_str(), &sb) == -1)
-    return _Nil<T_O>();
-  else
-    return Integer_O::create((gctools::Fixnum) sb.st_mode);
-};
-
-SYMBOL_EXPORT_SC_(CorePkg, fstat_size);
-SYMBOL_EXPORT_SC_(CorePkg, fstat_mtime);
-SYMBOL_EXPORT_SC_(CorePkg, fstat_mode);
-SYMBOL_EXPORT_SC_(CorePkg, stat_size);
-SYMBOL_EXPORT_SC_(CorePkg, stat_mtime);
-SYMBOL_EXPORT_SC_(CorePkg, stat_mode);
 }; // namespace core


### PR DESCRIPTION
to use, e.g.
```lisp
(let* ((file "~/quicklisp/setup.lisp"))
   (core:stat file))

5054
1464206628
33188
(let* ((file "~/quicklisp/setup.lisp")
       (fd nil))
  (with-open-file (stream file :direction :input)
    (setq fd (core::file-stream-fd stream))
  (core:fstat fd)))

5054
1464206628
33188
````