### PR TITLE
Avoid doble quotes for pathnames

### DIFF
--- a/src/core/pathname.cc
+++ b/src/core/pathname.cc
@@ -2138,7 +2138,7 @@ string Pathname_O::__repr__() const {
   if (str.nilp()) {
     ss << "#P" << '"' << '"';
   } else {
-    ss << "#P" << '"' << _rep_(str) << '"';
+    ss << "#P" << _rep_(str);
   }
   return ss.str();
 }


### PR DESCRIPTION
* Before they would print like `Loading #P""/Users/karstenpoeck/lisp/compiler/clasp-karsten/build/boehm/fasl/aclasp-boehm-bitcode/src/lisp/kernel/lsp/defstruct.faso""`
* Reason is the change in __repr__ for strings