### PR TITLE
Fix datatype for loop for ...

### DIFF
--- a/src/lisp/kernel/lsp/loop2.lsp
+++ b/src/lisp/kernel/lsp/loop2.lsp
@@ -1912,7 +1912,7 @@ collected result will be returned as the value of the LOOP."
   (unless var
     (setf var (gensym)))
   (loop-sequencer
-    var (loop-check-data-type data-type 'real) t
+    var (loop-check-data-type data-type 'number) t
     nil nil nil nil nil nil
     (loop-collect-prepositional-phrases
       '((:from :upfrom :downfrom) (:to :upto :downto :above :below) (:by))


### PR DESCRIPTION
* Fix is authored by Bike
* Sbcl has the same Fix in https://github.com/sbcl/sbcl/blob/master/src/code/loop.lisp#L1753
* Fix should go to ecl too
* Fixes regression tests `(LOOP-COLLECT-1 LOOP-COLLECT-2 LOOP-COLLECT-3 LOOP-COLLECT-4
                    LOOP-COLLECT-5 LOOP-COLLECT-6)`
* fixes ansi-test `LOOP.1.44, LOOP.1.45, LOOP.1.46, LOOP.1.47, LOOP.1.48, LOOP.1.49`