### PR TITLE
Fix remf where the keys are not symbols, e.g. numbers

### DIFF
--- a/include/clasp/core/cons.h
+++ b/include/clasp/core/cons.h
@@ -487,7 +487,7 @@ List_sp coerce_to_list(T_sp o);
 
 T_sp cl__getf(List_sp plist, T_sp indicator, T_sp default_value);
 List_sp core__put_f(List_sp plist, T_sp value, T_sp indicator);
-T_mv core__rem_f(List_sp plist, Symbol_sp indicator);
+T_mv core__rem_f(List_sp plist, T_sp indicator);
  List_sp cl__make_list(Fixnum_sp osize, T_sp initial_element);
 
  void not_alist_error(T_sp l);

--- a/src/core/cons.cc
+++ b/src/core/cons.cc
@@ -91,7 +91,7 @@ CL_DEFUN T_sp cl__getf(List_sp plist, T_sp indicator, T_sp default_value) {
 CL_LAMBDA(plist indicator);
 CL_DECLARE();
 CL_DOCSTRING("Removes the property with the indicator from the property list in place if present and returns MultipleValues with the new property list and T if the property was found");
-CL_DEFUN T_mv core__rem_f(List_sp plist, Symbol_sp indicator) {
+CL_DEFUN T_mv core__rem_f(List_sp plist, T_sp indicator) {
   if (oCar(plist) == indicator) {
     plist = oCddr(plist);
     T_sp tplist = plist;

--- a/src/lisp/regression-tests/cons01.lisp
+++ b/src/lisp/regression-tests/cons01.lisp
@@ -122,3 +122,5 @@
 (test-expect-error  MEMBER-IF.ERROR.8 (MEMBER-IF #'IDENTITY 'A) :type type-error)
 (test-expect-error  ASSOC-IF.ERROR.12 (ASSOC-IF #'NULL '((A . B) :BAD (C . D))) :type type-error)
 (test-expect-error  ASSOC-IF-NOT.ERROR.12 (ASSOC-IF-NOT #'IDENTITY '((A . B) :BAD (C . D))) :type type-error)
+
+(test remf-failure-cl-http (let ((place (list 9000 23)))(remf place 9000)))


### PR DESCRIPTION
* `(let ((place (list 9000 23)))(remf place 9000))` complaining that 9000 is not a symbol (true, but not required)
* added regression test