### PR TITLE
Add core:package-add-nickname and ext:package-remove-nickname  as a safer way than rename-package to change nicknames

### DIFF
--- a/include/clasp/core/lispList.h
+++ b/include/clasp/core/lispList.h
@@ -45,6 +45,7 @@ namespace core {
 
   T_sp cl__last(List_sp list, Integer_sp in);
   List_sp cl__nbutlast(List_sp list, Integer_sp n);
+  List_sp remove_equal(T_sp element, List_sp alist);
 
 };
 

--- a/src/core/lispList.cc
+++ b/src/core/lispList.cc
@@ -442,6 +442,15 @@ CL_DEFUN T_sp cl__nreconc(List_sp list, T_sp tail) {
   return list.asCons()->nreconc(tail);
 };
 
+List_sp remove_equal(T_sp element, List_sp alist) {
+  ql::list new_list;
+  for (List_sp cur = alist; cur.notnilp(); cur = oCdr(cur)) {
+    if (!cl__equal(element, oCar(cur)))
+      new_list << oCar(cur);
+  }   
+  return new_list.cons();
+};
+
   SYMBOL_EXPORT_SC_(ClPkg, revappend);
   SYMBOL_EXPORT_SC_(ClPkg, nreconc);
   SYMBOL_EXPORT_SC_(ClPkg, list);

--- a/src/core/package.cc
+++ b/src/core/package.cc
@@ -46,7 +46,7 @@ THE SOFTWARE.
 #include <clasp/core/multipleValues.h>
 #include <clasp/core/evaluator.h> // for eval::funcall
 #include <clasp/core/cons.h>
-
+#include <clasp/core/lispList.h>
 // last include is wrappers.h
 #include <clasp/core/wrappers.h>
 
@@ -89,12 +89,25 @@ CL_DEFUN T_sp cl__package_nicknames(T_sp pkg) {
 
 CL_LAMBDA(pkg nickname);
 CL_DECLARE();
-CL_DOCSTRING("packageNicknames");
-CL_DEFUN T_sp core__package_add_nickname(T_sp pkg, T_sp nick) {
+CL_DOCSTRING("adds the nickname <nickname> to package");
+CL_DEFUN T_sp ext__package_add_nickname(T_sp pkg, T_sp nick) {
   Package_sp package = coerce::packageDesignator(pkg);
   String_sp nickname  = coerce::stringDesignator(nick);
   _lisp->mapNameToPackage(nickname->get_std_string(), package);
   package->setNicknames(Cons_O::create(nickname, package->getNicknames()));
+  return package->getNicknames();
+};
+
+CL_LAMBDA(pkg nickname);
+CL_DECLARE();
+CL_DOCSTRING("removes the nickname <nickname> from package");
+CL_DEFUN T_sp ext__package_remove_nickname(T_sp pkg, T_sp nick) {
+  Package_sp package = coerce::packageDesignator(pkg);
+  unlikely_if (package->getNicknames().nilp())
+    return _Nil<T_O>();
+  String_sp nickname  = coerce::stringDesignator(nick);
+  _lisp->unmapNameToPackage(nickname->get_std_string());
+  package->setNicknames(remove_equal(nickname, package->getNicknames()));
   return package->getNicknames();
 };
 

--- a/src/core/package.cc
+++ b/src/core/package.cc
@@ -89,26 +89,45 @@ CL_DEFUN T_sp cl__package_nicknames(T_sp pkg) {
 
 CL_LAMBDA(pkg nickname);
 CL_DECLARE();
-CL_DOCSTRING("adds the nickname <nickname> to package");
+CL_DOCSTRING("Adds the nickname <nickname> to package. "
+             "Returns new nicknames. A package error is signalled,"
+             " if package does not exist, or nickname is already in use");
 CL_DEFUN T_sp ext__package_add_nickname(T_sp pkg, T_sp nick) {
   Package_sp package = coerce::packageDesignator(pkg);
   String_sp nickname  = coerce::stringDesignator(nick);
-  _lisp->mapNameToPackage(nickname->get_std_string(), package);
-  package->setNicknames(Cons_O::create(nickname, package->getNicknames()));
-  return package->getNicknames();
+  T_sp packageUsingNickName = _lisp->findPackage(nickname->get_std_string());
+  if (packageUsingNickName.notnilp()) {
+    if (Package_sp pkg = packageUsingNickName.asOrNull<Package_O>())
+      SIMPLE_PACKAGE_ERROR_2_args("Package nickname[~a] is already being used by package[~a]" ,
+                                  nickname->get_std_string() , pkg->getName());
+    else
+      SIMPLE_PACKAGE_ERROR("Package nickname[~a] is already being used" ,
+                                  nickname->get_std_string());
+      }
+  else {
+    _lisp->mapNameToPackage(nickname->get_std_string(), package);
+    package->setNicknames(Cons_O::create(nickname, package->getNicknames()));
+    return package->getNicknames();
+  }
 };
 
 CL_LAMBDA(pkg nickname);
 CL_DECLARE();
-CL_DOCSTRING("removes the nickname <nickname> from package");
+CL_DOCSTRING("Removes the nickname <nickname> from package."
+             "Returns nil, if nickname does not belong to package."
+             "A package error is signalled, if package does not exist");
 CL_DEFUN T_sp ext__package_remove_nickname(T_sp pkg, T_sp nick) {
   Package_sp package = coerce::packageDesignator(pkg);
   unlikely_if (package->getNicknames().nilp())
     return _Nil<T_O>();
   String_sp nickname  = coerce::stringDesignator(nick);
-  _lisp->unmapNameToPackage(nickname->get_std_string());
-  package->setNicknames(remove_equal(nickname, package->getNicknames()));
-  return package->getNicknames();
+  // verify if nickname is really nicknames of this package
+  if (_lisp->findPackage(nickname->get_std_string()) == package) {
+    _lisp->unmapNameToPackage(nickname->get_std_string());
+    package->setNicknames(remove_equal(nickname, package->getNicknames()));
+    return package->getNicknames();
+  }
+  else return _Nil<T_O>();
 };
 
 CL_LAMBDA(pkg);

--- a/src/core/package.cc
+++ b/src/core/package.cc
@@ -45,6 +45,7 @@ THE SOFTWARE.
 #include <clasp/core/debugger.h>
 #include <clasp/core/multipleValues.h>
 #include <clasp/core/evaluator.h> // for eval::funcall
+#include <clasp/core/cons.h>
 
 // last include is wrappers.h
 #include <clasp/core/wrappers.h>
@@ -83,6 +84,17 @@ CL_DECLARE();
 CL_DOCSTRING("packageNicknames");
 CL_DEFUN T_sp cl__package_nicknames(T_sp pkg) {
   Package_sp package = coerce::packageDesignator(pkg);
+  return package->getNicknames();
+};
+
+CL_LAMBDA(pkg nickname);
+CL_DECLARE();
+CL_DOCSTRING("packageNicknames");
+CL_DEFUN T_sp core__package_add_nickname(T_sp pkg, T_sp nick) {
+  Package_sp package = coerce::packageDesignator(pkg);
+  String_sp nickname  = coerce::stringDesignator(nick);
+  _lisp->mapNameToPackage(nickname->get_std_string(), package);
+  package->setNicknames(Cons_O::create(nickname, package->getNicknames()));
   return package->getNicknames();
 };
 

--- a/src/lisp/regression-tests/package.lisp
+++ b/src/lisp/regression-tests/package.lisp
@@ -87,3 +87,26 @@
                           nil)))
              (list-all-packages)))
 
+(defpackage :%test% (:use))
+
+(test add-nickname
+      (let ((package (find-package :%test%)))
+        (and (null (package-nicknames package))
+             (let ()
+               (ext:package-add-nickname package :future-common-lisp)
+               (and (package-nicknames package)
+                    (find-package :future-common-lisp))))))
+
+(defpackage :%test-foo% (:use))
+(test remove-nickname
+      (let ((package (find-package :%test-foo%)))
+        (and (null (package-nicknames package))
+             (let ()
+               (ext:package-add-nickname package :very-future-common-lisp)
+               (and (package-nicknames package)
+                    (find-package :very-future-common-lisp)))
+             (let ()
+               (ext:package-remove-nickname package :very-future-common-lisp)
+               (null (package-nicknames package))
+               (null (find-package :very-future-common-lisp))))))
+


### PR DESCRIPTION
* adds `core:package-add-nickname`
* check here
```lisp
(core:package-add-nickname (find-package :cl) :future-common-lisp)

("FUTURE-COMMON-LISP" "CL")
COMMON-LISP-USER> (find-package :future-common-lisp)

#<PACKAGE COMMON-LISP>
COMMON-LISP-USER> (package-nicknames (find-package :cl))               

("FUTURE-COMMON-LISP" "CL")
COMMON-LISP-USER> (find-package :common-lisp)

#<PACKAGE COMMON-LISP>
COMMON-LISP-USER> (describe (find-package :common-lisp))

#<PACKAGE COMMON-LISP> - package
 nicknames:  ("FUTURE-COMMON-LISP" "CL")
 used-by list:  (#<PACKAGE PRIMOP> #<PACKAGE INTERPRET-AST>
                 #<PACKAGE LISP-EXECUTABLE.CREATION> #<PACKAGE CLEAVIR-IR-GML>
                 #<PACKAGE CC-MIR> #<PACKAGE CC-HIR-TO-MIR>
                 #<PACKAGE CC-GENERATE-AST> #<PACKAGE CLASP-CLEAVIR-AST-TO-HIR>
                 #<PACKAGE CLASP-CLEAVIR-HIR> #<PACKAGE CLASP-CLEAVIR-AST>
                 #<PACKAGE CLASP-CLEAVIR> #<PACKAGE CCLASP-BUILD>
                 #<PACKAGE SICL-ADDITIONAL-CONDITIONS>
                 #<PACKAGE SICL-ADDITIONAL-TYPES>
                 #<PACKAGE CLEAVIR-BASIC-BLOCKS> #<PACKAGE CLEAVIR-UTILITIES>
                 #<PACKAGE CLEAVIR-HIR-TO-MIR>
                 #<PACKAGE CLEAVIR-PARTIAL-INLINING>
                 #<PACKAGE CLEAVIR-REMOVE-USELESS-INSTRUCTIONS>
                 #<PACKAGE CLEAVIR-HIR-TRANSFORMATIONS>
                 #<PACKAGE CLEAVIR-ESCAPE> #<PACKAGE CLEAVIR-TYPE-DESCRIPTORS>
                 #<PACKAGE CLEAVIR-KILDALL-TYPE-INFERENCE>
                 #<PACKAGE CLEAVIR-LIVENESS>
                 #<PACKAGE CLEAVIR-KILDALL-GRAPHVIZ> #<PACKAGE CLEAVIR-KILDALL>
                 #<PACKAGE CLEAVIR-AST-TO-HIR> #<PACKAGE CLEAVIR-IR-GRAPHVIZ>
                 #<PACKAGE CLEAVIR-IR> #<PACKAGE CLEAVIR-CST-TO-AST>
                 #<PACKAGE CLEAVIR-GENERATE-AST>
                 #<PACKAGE CLEAVIR-COMPILATION-POLICY>
                 #<PACKAGE CLEAVIR-ENVIRONMENT>
                 #<PACKAGE CLEAVIR-CODE-UTILITIES>
                 #<PACKAGE CLEAVIR-AST-TRANSFORMATIONS>
                 #<PACKAGE CLEAVIR-AST-GRAPHVIZ> #<PACKAGE CLEAVIR-AST>
                 #<PACKAGE CLEAVIR-METER> #<PACKAGE CLEAVIR-IO>
                 #<PACKAGE ECLECTOR.CONCRETE-SYNTAX-TREE>
                 #<PACKAGE ECLECTOR.PARSE-RESULT> #<PACKAGE ECLECTOR.READER>
                 #<PACKAGE ECLECTOR.READTABLE.SIMPLE>
                 #<PACKAGE ECLECTOR.READTABLE> #<PACKAGE ECLECTOR.BASE>
                 #<PACKAGE CLOSER-MOP> #<PACKAGE ALEXANDRIA.0.DEV>
                 #<PACKAGE CONCRETE-SYNTAX-TREE> #<PACKAGE ACCLIMATION>
                 #<PACKAGE STATIC-GFS> #<PACKAGE MP> #<PACKAGE LITERAL>
                 #<PACKAGE C> #<PACKAGE SB-BSD-SOCKETS> #<PACKAGE CLBIND-TEST>
                 #<PACKAGE SB-BSD-CLBIND> #<PACKAGE CORE> #<PACKAGE EXT>
                 #<PACKAGE COMPILER> #<PACKAGE CLOS> #<PACKAGE GRAY>
                 #<PACKAGE GCTOOLS> #<PACKAGE LLVM-SYS> #<PACKAGE CLBIND>
                 #<PACKAGE CLASP-FFI> #<PACKAGE SERVE-EVENT-INTERNAL>
                 #<PACKAGE SOCKETS-INTERNAL> #<PACKAGE MPI>
                 #<PACKAGE AST-TOOLING> #<PACKAGE CLANG-AST>
                 #<PACKAGE CLANG-COMPILE> #<PACKAGE COMMON-LISP-USER>)
````