### PR TITLE
Feature enable disable signals

### DIFF
--- a/src/gctools/interrupt.cc
+++ b/src/gctools/interrupt.cc
@@ -53,7 +53,10 @@ core::T_sp safe_signal_handler(int sig) {
   return key;
 }
 
-core::T_mv gctools__signal_info(int sig) {
+CL_LAMBDA(signal);
+CL_DECLARE();
+CL_DOCSTRING("return Current handler for signal");
+CL_DEFUN core::T_mv gctools__signal_info(int sig) {
   return Values(safe_signal_name(sig),safe_signal_handler(sig));
 }
 
@@ -281,7 +284,7 @@ CL_DEFUN void core__disable_all_fpe_masks() {
 
 CL_LAMBDA(&key underflow overflow inexact invalid divide-by-zero denormalized-operand);
 CL_DECLARE();
-CL_DOCSTRING("zerop");
+CL_DOCSTRING("core::enable-fpe-masks");
 CL_DEFUN void core__enable_fpe_masks(core::T_sp underflow, core::T_sp overflow, core::T_sp inexact, core::T_sp invalid, core::T_sp divide_by_zero, core::T_sp denormalized_operand) {
   // See https://doc.rust-lang.org/stable/core/arch/x86_64/fn._mm_setcsr.html
   // mask all -> no fpe-exceptions
@@ -402,7 +405,7 @@ void initialize_signals(int clasp_signal) {
     INIT_SIGNALI(SIGBUS, (SA_NODEFER | SA_RESTART), handle_bus);
   }
   INIT_SIGNALI(SIGFPE, (SA_NODEFER | SA_RESTART), handle_fpe);
-  // HAndle all signals that would terminate clasp (and can be caught)
+  // Handle all signals that would terminate clasp (and can be caught)
   INIT_SIGNAL(SIGILL, (SA_NODEFER | SA_RESTART), handle_signal_now);
   INIT_SIGNAL(SIGPIPE, (SA_NODEFER | SA_RESTART), handle_signal_now);
   INIT_SIGNAL(SIGALRM, (SA_NODEFER | SA_RESTART), handle_signal_now);
@@ -435,7 +438,10 @@ void initialize_signals(int clasp_signal) {
     ADD_SIGNAL_SYMBOL(sig,sigsym,handler); \
   }
 
-void gctools__push_unix_signal_handler(int signal, core::Symbol_sp name, core::Function_sp handler) {
+CL_LAMBDA(signal symbol function);
+CL_DECLARE();
+CL_DOCSTRING("Set current handler for signal");
+CL_DEFUN void gctools__push_unix_signal_handler(int signal, core::Symbol_sp name, core::Function_sp handler) {
   WITH_READ_WRITE_LOCK(_lisp->_Roots._UnixSignalHandlersMutex);
   ADD_SIGNAL_SYMBOL(signal,name,handler);
 }

--- a/src/gctools/interrupt.cc
+++ b/src/gctools/interrupt.cc
@@ -56,7 +56,7 @@ core::T_sp safe_signal_handler(int sig) {
 CL_LAMBDA(signal);
 CL_DECLARE();
 CL_DOCSTRING("return Current handler for signal");
-CL_DEFUN core::T_mv gctools__signal_info(int sig) {
+CL_DEFUN core::T_mv core__signal_info(int sig) {
   return Values(safe_signal_name(sig),safe_signal_handler(sig));
 }
 
@@ -441,9 +441,119 @@ void initialize_signals(int clasp_signal) {
 CL_LAMBDA(signal symbol function);
 CL_DECLARE();
 CL_DOCSTRING("Set current handler for signal");
-CL_DEFUN void gctools__push_unix_signal_handler(int signal, core::Symbol_sp name, core::Symbol_sp handler) {
+CL_DEFUN void core__push_unix_signal_handler(int signal, core::Symbol_sp name, core::Symbol_sp handler) {
   WITH_READ_WRITE_LOCK(_lisp->_Roots._UnixSignalHandlersMutex);
   ADD_SIGNAL_SYMBOL(signal,name,handler);
+}
+
+CL_LAMBDA();
+CL_DOCSTRING("Get alist of Signal-name . Signal-code alist of known signal (Posix + extra)");
+CL_DEFUN core::List_sp core__signal_code_alist() {
+  core::List_sp alist = _Nil<core::T_O>();
+/* these are all posix signals */
+#ifdef SIGHUP
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGHUP",KeywordPkg), core::clasp_make_fixnum(SIGHUP)), alist);
+#endif
+#ifdef SIGINT
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGINT",KeywordPkg), core::clasp_make_fixnum(SIGINT)), alist);
+#endif
+#ifdef SIGQUIT
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGQUIT",KeywordPkg), core::clasp_make_fixnum(SIGQUIT)), alist);
+#endif
+#ifdef SIGILL
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGILL",KeywordPkg), core::clasp_make_fixnum(SIGILL)), alist);
+#endif
+#ifdef SIGTRAP
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGTRAP",KeywordPkg), core::clasp_make_fixnum(SIGTRAP)), alist);
+#endif
+#ifdef SIGABRT
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGABRT",KeywordPkg), core::clasp_make_fixnum(SIGABRT)), alist);
+#endif
+#ifdef SIGPOLL
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGPOLL",KeywordPkg), core::clasp_make_fixnum(SIGPOLL)), alist);
+#endif
+#ifdef SIGFPE
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGFPE",KeywordPkg), core::clasp_make_fixnum(SIGFPE)), alist);
+#endif
+#ifdef SIGKILL
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGKILL",KeywordPkg), core::clasp_make_fixnum(SIGKILL)), alist);      
+#endif
+#ifdef SIGBUS
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGBUS",KeywordPkg), core::clasp_make_fixnum(SIGBUS)), alist);
+#endif
+#ifdef SIGSEGV
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGSEGV",KeywordPkg), core::clasp_make_fixnum(SIGSEGV)), alist);
+#endif
+#ifdef SIGSYS
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGSYS",KeywordPkg), core::clasp_make_fixnum(SIGSYS)), alist);
+#endif
+#ifdef SIGPIPE
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGPIPE",KeywordPkg), core::clasp_make_fixnum(SIGPIPE)), alist);
+#endif
+#ifdef SIGALRM
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGALRM",KeywordPkg), core::clasp_make_fixnum(SIGALRM)), alist);
+#endif
+#ifdef SIGTERM
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGTERM",KeywordPkg), core::clasp_make_fixnum(SIGTERM)), alist);
+#endif
+#ifdef SIGURG
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGURG",KeywordPkg), core::clasp_make_fixnum(SIGURG)), alist);
+#endif
+#ifdef SIGSTOP
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGSTOP",KeywordPkg), core::clasp_make_fixnum(SIGSTOP)), alist);
+#endif
+#ifdef SIGTSTP
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGTSTP",KeywordPkg), core::clasp_make_fixnum(SIGTSTP)), alist);
+#endif
+#ifdef SIGCONT
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGCONT",KeywordPkg), core::clasp_make_fixnum(SIGCONT)), alist);
+#endif
+#ifdef SIGCHLD
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGCHLD",KeywordPkg), core::clasp_make_fixnum(SIGCHLD)), alist);
+#endif
+#ifdef SIGTTIN
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGTTIN",KeywordPkg), core::clasp_make_fixnum(SIGTTIN)), alist);
+#endif
+#ifdef SIGTTOU
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGTTOU",KeywordPkg), core::clasp_make_fixnum(SIGTTOU)), alist);
+#endif
+#ifdef SIGXCPU
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGXCPU",KeywordPkg), core::clasp_make_fixnum(SIGXCPU)), alist);
+#endif
+#ifdef SIGXFSZ
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGXFSZ",KeywordPkg), core::clasp_make_fixnum(SIGXFSZ)), alist);
+#endif
+#ifdef SIGVTALRM
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGVTALRM",KeywordPkg), core::clasp_make_fixnum(SIGVTALRM)), alist);
+#endif
+#ifdef SIGPROF
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGPROF",KeywordPkg), core::clasp_make_fixnum(SIGPROF)), alist);
+#endif
+#ifdef SIGUSR1
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGUSR1",KeywordPkg), core::clasp_make_fixnum(SIGUSR1)), alist);
+#endif
+#ifdef SIGUSR2
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGUSR2",KeywordPkg), core::clasp_make_fixnum(SIGUSR2)), alist);
+#endif
+
+/* Additional Signals */
+
+#ifdef SIGEMT
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGEMT",KeywordPkg), core::clasp_make_fixnum(SIGEMT)), alist);
+#endif
+#ifdef SIGIO
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGIO",KeywordPkg), core::clasp_make_fixnum(SIGIO)), alist);
+#endif
+#ifdef SIGWINCH
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGWINCH",KeywordPkg), core::clasp_make_fixnum(SIGWINCH)), alist);
+#endif
+#ifdef SIGINFO
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGINFO",KeywordPkg), core::clasp_make_fixnum(SIGINFO)), alist);
+#endif
+#ifdef SIGTHR
+  alist = core::Cons_O::create(core::Cons_O::create(_lisp->intern("SIGTHR",KeywordPkg), core::clasp_make_fixnum(SIGTHR)), alist);
+#endif
+  return alist;
 }
 
 void initialize_unix_signal_handlers() {

--- a/src/gctools/interrupt.cc
+++ b/src/gctools/interrupt.cc
@@ -441,7 +441,7 @@ void initialize_signals(int clasp_signal) {
 CL_LAMBDA(signal symbol function);
 CL_DECLARE();
 CL_DOCSTRING("Set current handler for signal");
-CL_DEFUN void gctools__push_unix_signal_handler(int signal, core::Symbol_sp name, core::Function_sp handler) {
+CL_DEFUN void gctools__push_unix_signal_handler(int signal, core::Symbol_sp name, core::Symbol_sp handler) {
   WITH_READ_WRITE_LOCK(_lisp->_Roots._UnixSignalHandlersMutex);
   ADD_SIGNAL_SYMBOL(signal,name,handler);
 }

--- a/src/lisp/kernel/init.lsp
+++ b/src/lisp/kernel/init.lsp
@@ -204,7 +204,9 @@
           quit
           btcl
           ihs-argument
-          with-float-traps-masked))
+          with-float-traps-masked
+          enable-interrupt default-interrupt ignore-interrupt
+          get-signal-handler set-signal-handler))
 (core:*make-special '*module-provider-functions*)
 (core:*make-special '*source-location*)
 (setq *source-location* nil)

--- a/src/lisp/kernel/lsp/posix.lsp
+++ b/src/lisp/kernel/lsp/posix.lsp
@@ -2,31 +2,39 @@
 
 (defun enable-interrupt (signal mode &optional lisp-handler)
   "Enable/disable signal, 
-   If mode = :ignore, ignore the signal
-   If mode = :default, set the default handler
-   If mode = :lisp, define lisp-handler"
+   If mode = :ignore, sets a handler that ignores the signal
+   If mode = :default, it sets the handler to the default handler.
+   If mode = :lisp, define lisp-handler for signal.
+   lisp-handler must only be provided, if mode = :lisp.
+   lisp-handler should be a function of one argument (the signal)
+   Returns :done if successfull,
+           :signal-not-found if the names signal was not found and
+           :error-defining-handler if there was an error defining the handler"
   (flet ((handle-lisp-handler (signal-as-int)
-             (core::note-signal-handler signal-as-int lisp-handler)
-             2)
+           (core::note-signal-handler signal-as-int lisp-handler)
+           2)
          (handle-non-lisp-handler (signal-as-int)
-             (core::forget-signal-handler signal-as-int)))
-      (let ((int-signal (core::external-to-int-signal signal)))
-        (cond (int-signal
-               (core:enable-disable-signals
-                int-signal
-                (ecase mode
-                  (:ignore  (handle-non-lisp-handler int-signal) 0)
-                  (:default (handle-non-lisp-handler int-signal) 1)
-                  (:lisp (handle-lisp-handler int-signal))))
-               :done)
-              (t :not-found)))))
+           (core::forget-signal-handler signal-as-int)))
+    (let ((int-signal (core::external-to-int-signal signal))
+          (result nil))
+      (cond (int-signal
+             (setq result (core:enable-disable-signals
+                           int-signal
+                           (ecase mode
+                             (:ignore  (handle-non-lisp-handler int-signal) 0)
+                             (:default (handle-non-lisp-handler int-signal) 1)
+                             (:lisp (handle-lisp-handler int-signal)))))
+             (if (zerop result)
+                 :done
+                 :error-defining-handler))
+            (t :signal-not-found)))))
 
 (defun default-interrupt (signal)
-  "Set the default handler for signal"
+  "Sets the handler to the default handler for signal"
   (enable-interrupt signal :default))
 
 (defun ignore-interrupt (signal)
-  "Ignore the interrupt for signal"
+  "Sets a handler that ignores the signal"
   (enable-interrupt signal :ignore))
 
 (defun get-signal-handler (signal)
@@ -40,20 +48,16 @@
   "Set a lisp handler handler for signal"
   (enable-interrupt signal :lisp handler))
 
-#|
-(defun karsten-handler(signal)(format t "~&Processed Signal ~a~%" signal))
-(ext:enable-interrupt :sigpipe :lisp #'karsten-handler)
-kill -s PIPE <clasp-pid>
-COMMON-LISP-USER> Processed Signal 13
-(ext:get-signal-handler :sigpipe)
-(ext:ignore-interrupt :sigpipe)
-(ext:default-interrupt :sigpipe)
-|#
-
 (in-package :core)
 
 (defparameter *signal-to-function* nil)
 
+
+;;; See https://pubs.opengroup.org/onlinepubs/009695399/basedefs/signal.h.html
+;;; Only include posix signals
+;;; Codes taken from https://gitlab.common-lisp.net/cmucl/cmucl/-/blob/master/src/code/signal.lisp
+;;; #+linux is only valid for linux on x86/ARM (http://man7.org/linux/man-pages/man7/signal.7.html)
+;;; bsd signals verified with https://www.freebsd.org/cgi/man.cgi?query=signal&sektion=3&manpath=freebsd-release-ports
 (defun external-to-int-signal (signal)
   (let* ((signal-alist
           '((:SIGHUP  1       :term "hangup ")
@@ -62,33 +66,33 @@ COMMON-LISP-USER> Processed Signal 13
             (:SIGILL  4       :core "illegal instruction (not reset when caught) ")
             (:SIGTRAP 5       :unknown "trace trap (not reset when caught) ")
             (:SIGABRT 6       :core "abort() ")
-            (:SIGPOLL 7       :unknown"pollable event ([XSR] generated, not supported) ")
-            (:SIGIOT  6       :core "compatibility ")
-            (:SIGEMT  7       :unknown "EMT instruction ")
+            #+(or) (:SIGPOLL 7       :unknown"pollable event ([XSR] generated, not supported) ")
+            #+(or)(:SIGIOT  6       :core "compatibility ")
+            #+(or) (:SIGEMT  7       :unknown "EMT instruction ")
             (:SIGFPE  8       :core "floating point exception ")
             (:SIGKILL 9       :term "kill (cannot be caught or ignored) ")
-            (:SIGBUS  10      :term "bus error ")
+            (:SIGBUS  #-linux 10 #+linux 7     :term "bus error ")
             (:SIGSEGV 11      :core "segmentation violation ")
-            (:SIGSYS  12      :unknown "bad argument to system call ")
+            (:SIGSYS  #-linux 12 #+linux 31     :unknown "bad argument to system call ")
             (:SIGPIPE 13      :term "write on a pipe with no one to read it ")
             (:SIGALRM 14      :term "alarm clock ")
             (:SIGTERM 15      :term "software termination signal from kill ")
-            (:SIGURG  16      :term "urgent condition on IO channel ")
-            (:SIGSTOP 17      :term "sendable stop signal not from tty ")
-            (:SIGTSTP 18      "stop signal from tty ")
-            (:SIGCONT 19      "continue a stopped process ")
-            (:SIGCHLD 20      "to parent on child stop or exit ")
+            (:SIGURG  #-linux 16 #+linux 23      :term "urgent condition on IO channel ")
+            (:SIGSTOP #-linux 17 #+linux 19      :term "sendable stop signal not from tty ")
+            (:SIGTSTP #-linux 18 #+linux 20     "stop signal from tty ")
+            (:SIGCONT #-linux 19 #+linux 18     "continue a stopped process ")
+            (:SIGCHLD #-linux 20 #+linux 17     "to parent on child stop or exit ")
             (:SIGTTIN 21      "to readers pgrp upon background tty read ")
             (:SIGTTOU 22      "like TTIN for output if (tp->t_local&LTOSTOP) ")
-            (:SIGIO   23      "input/output possible signal ")
+            #+(or) (:SIGIO   #-linux 23 #+linux 29     "input/output possible signal ")
             (:SIGXCPU 24      "exceeded CPU time limit ")
             (:SIGXFSZ 25      "exceeded file size limit ")
             (:SIGVTALRM 26    "virtual time alarm ")
             (:SIGPROF 27      "profiling time alarm ")
-            (:SIGWINCH 28     "window size changes ")
-            (:SIGINFO 29      "information request ")
-            (:SIGUSR1 30      "user defined signal 1 ")
-            (:SIGUSR2 31      "user defined signal 2 ")))
+            #+(or) (:SIGWINCH 28     "window size changes ")
+            #+(or) (:SIGINFO 29      "information request ")
+            (:SIGUSR1 #-linux 30 #+linux 10     "user defined signal 1 ")
+            (:SIGUSR2 #-linux 31 #+linux 12     "user defined signal 2 ")))
          (found (Assoc signal signal-alist)))
     (if found
         (second found)

--- a/src/lisp/kernel/lsp/posix.lsp
+++ b/src/lisp/kernel/lsp/posix.lsp
@@ -1,0 +1,107 @@
+(in-package :ext)
+
+(defun enable-interrupt (signal mode &optional lisp-handler)
+  "Enable/disable signal, 
+   If mode = :ignore, ignore the signal
+   If mode = :default, set the default handler
+   If mode = :lisp, define lisp-handler"
+  (flet ((handle-lisp-handler (signal-as-int)
+             (core::note-signal-handler signal-as-int lisp-handler)
+             2))
+      (let ((int-signal (core::external-to-int-signal signal)))
+        (cond (int-signal
+               (core:enable-disable-signals
+                int-signal
+                (ecase mode
+                  (:ignore 0)
+                  (:default 1)
+                  (:lisp (handle-lisp-handler int-signal))))
+               :done)
+              (t :not-found)))))
+
+(defun default-interrupt (signal)
+  "Set the default handler for signal"
+  (enable-interrupt signal :default))
+
+(defun ignore-interrupt (signal)
+  "Ignore the interrupt for signal"
+  (enable-interrupt signal :ignore))
+
+(defun get-signal-handler (signal)
+  "Get a lisp handler handler for signal, or nil if none defined"
+  (let ((internal-signal (core::external-to-int-signal signal)))
+    (if internal-signal
+        (core::get-signal-handler internal-signal)
+        nil)))
+
+(defun set-signal-handler (signal handler)
+  "Set a lisp handler handler for signal"
+  (enable-interrupt signal :lisp handler))
+
+#|
+(defun karsten-handler(signal)(format t "~&Processed Signal ~a~%" signal))
+(ext:enable-interrupt :sigpipe :lisp #'karsten-handler)
+kill -s PIPE <clasp-pid>
+COMMON-LISP-USER> Processed Signal 13
+(ext:get-signal-handler :sigpipe)
+(ext:ignore-interrupt :sigpipe)
+(ext:default-interrupt :sigpipe)
+|#
+
+(in-package :core)
+
+(defparameter *signal-to-function* nil)
+
+(defun external-to-int-signal (signal)
+  (let* ((signal-alist
+          '((:SIGHUP  1       :term "hangup ")
+            (:SIGINT  2       :term "interrupt ")
+            (:SIGQUIT 3       :core "quit ")
+            (:SIGILL  4       :core "illegal instruction (not reset when caught) ")
+            (:SIGTRAP 5       :unknown "trace trap (not reset when caught) ")
+            (:SIGABRT 6       :core "abort() ")
+            (:SIGPOLL 7       :unknown"pollable event ([XSR] generated, not supported) ")
+            (:SIGIOT  6       :core "compatibility ")
+            (:SIGEMT  7       :unknown "EMT instruction ")
+            (:SIGFPE  8       :core "floating point exception ")
+            (:SIGKILL 9       :term "kill (cannot be caught or ignored) ")
+            (:SIGBUS  10      :term "bus error ")
+            (:SIGSEGV 11      :core "segmentation violation ")
+            (:SIGSYS  12      :unknown "bad argument to system call ")
+            (:SIGPIPE 13      :term "write on a pipe with no one to read it ")
+            (:SIGALRM 14      :term "alarm clock ")
+            (:SIGTERM 15      :term "software termination signal from kill ")
+            (:SIGURG  16      :term "urgent condition on IO channel ")
+            (:SIGSTOP 17      :term "sendable stop signal not from tty ")
+            (:SIGTSTP 18      "stop signal from tty ")
+            (:SIGCONT 19      "continue a stopped process ")
+            (:SIGCHLD 20      "to parent on child stop or exit ")
+            (:SIGTTIN 21      "to readers pgrp upon background tty read ")
+            (:SIGTTOU 22      "like TTIN for output if (tp->t_local&LTOSTOP) ")
+            (:SIGIO   23      "input/output possible signal ")
+            (:SIGXCPU 24      "exceeded CPU time limit ")
+            (:SIGXFSZ 25      "exceeded file size limit ")
+            (:SIGVTALRM 26    "virtual time alarm ")
+            (:SIGPROF 27      "profiling time alarm ")
+            (:SIGWINCH 28     "window size changes ")
+            (:SIGINFO 29      "information request ")
+            (:SIGUSR1 30      "user defined signal 1 ")
+            (:SIGUSR2 31      "user defined signal 2 ")))
+         (found (Assoc signal signal-alist)))
+    (if found
+        (second found)
+        nil)))
+        
+(defun note-signal-handler (signal function)
+  (setf (getf *signal-to-function* signal) function))
+
+(defun get-signal-handler (signal)
+  (getf *signal-to-function* signal))
+
+(defun call-lisp-symbol-handler (signal-as-fixnum)
+  (let ((function (get-signal-handler signal-as-fixnum)))
+    (if function
+        (funcall function signal-as-fixnum)
+        (error 'ext:unix-signal-received :code signal-as-fixnum))))
+
+

--- a/tools-for-build/build_file_lists.py
+++ b/tools-for-build/build_file_lists.py
@@ -351,6 +351,7 @@ def collect_bclasp_lisp_files(**kwargs):
         "src/lisp/kernel/clos/inspect",
         "src/lisp/kernel/lsp/fli",
         "src/lisp/kernel/lsp/cas",
+        "src/lisp/kernel/lsp/posix",
         "src/lisp/modules/sockets/sockets",
         "src/lisp/kernel/lsp/top",
         "src/lisp/kernel/tag/pre-epilogue-bclasp",


### PR DESCRIPTION
Implements control of signal handling from lisp
* register a default-handler for sigpipe, so that clasp does not exit
* Implements `(ext:ignore-interrupt <signal>)` to ignore a signal, e.g. `(ext:ignore-interrupt :sigpipe)`
* Implements `(ext:default-interrupt <signal>)`to reset to the default signal handler, e.g. `(ext:default-interrupt :sigpipe)`
* Implements `(ext:enable-interrupt <signal> <mode> &optional <function>)`, e.g. `(ext:enable-interrupt :sigpipe :lisp #'karsten-handler)` to define a handler in lisp. Mode can be
  * :ignore as in `(ext:ignore-interrupt <signal>)`  
  * :default as in `(ext:default-interrupt <signal>)`
  * :lisp as in `(ext:enable-interrupt :sigpipe :lisp #'karsten-handler)`
* `(ext:get-signal-handler <signal>)`, e.g. `(ext:get-signal-handler :sigpipe)` to get a lisp-handler for signal, if defined
* `(ext:set-signal-handler <signal> <handler>)` as an alternative interface - like ecl - for `(ext:enable-interrupt <signal> :lisp <handler>`
* Defined signals:
  * :SIGHUP  1
  * :SIGINT  2 
  * :SIGQUIT  3 
  * :SIGILL  4 
  * :SIGTRAP  5
  * :SIGABRT  6 
  * :SIGPOLL  7 
  * :SIGIOT  6 
  * :SIGEMT  7 
  * :SIGFPE  8
  * :SIGKILL  9 
  * :SIGBUS  10
  * :SIGSEGV  11 
  * :SIGSYS  12
  * :SIGPIPE  13
  * :SIGALRM  14 
  * :SIGTERM  15 
  * :SIGURG  16 
  * :SIGSTOP  17 
  * :SIGTSTP  18
  * :SIGCONT  19 
  * :SIGCHLD  20 
  * :SIGTTIN  21 
  * :SIGTTOU  22 
  * :SIGIO  23
  * :SIGXCPU  24
  * :SIGXFSZ  25 
  * :SIGVTALRM  26 
  * :SIGPROF  27
  * :SIGWINCH  28
  * :SIGINFO  29 
  * :SIGUSR1  30 
  * :SIGUSR2  31
