### PR TITLE
Correctly define datatype of argument as number for cl__zerop

### DIFF
--- a/src/core/numbers.cc
+++ b/src/core/numbers.cc
@@ -155,8 +155,8 @@ Number_sp clasp_make_complex (Real_sp r, Real_sp i) {
 CL_LAMBDA(num);
 CL_DECLARE();
 CL_DOCSTRING("zerop");
-CL_DEFUN bool cl__zerop(T_sp num) {
-  return clasp_zerop(gc::As<Number_sp>(num));
+CL_DEFUN bool cl__zerop(Number_sp num) {
+  return clasp_zerop(num);
 }
 
 CL_LAMBDA(z);


### PR DESCRIPTION
* cl__zerop is defined to work on numbers, not need to pass a T_sp num and later do gc::As<Number_sp>(num). Don't even want to know what happens currently if you do `(zerop "23")`

* Did verify change with regression and ansi tests.