### PR TITLE
Fix compile file serial faso

### DIFF
--- a/src/lisp/kernel/cmp/compile-file.lsp
+++ b/src/lisp/kernel/cmp/compile-file.lsp
@@ -88,12 +88,17 @@
     ((eq output-type :bitcode) (if *use-human-readable-bitcode* "ll" "bc"))
     ((and *generate-faso* (or (eq output-type :object))) "faso")
     ((and *generate-faso* (or (eq output-type :fasl))) "fasp")
+    #+no ((and (eq core:*clasp-build-mode* :faso) (or (eq output-type :object)))"faso")
+    #+no ((and (eq core:*clasp-build-mode* :faso) (or (eq output-type :fasl))) "fasp")
     ((eq output-type :object) "o")
     ((eq output-type :fasl) "fasl")
     ((eq output-type :faso) "faso")
     ((eq output-type :fasp) "fasp")
     ((eq output-type :executable) #-windows "" #+windows "exe")
     (t (error "unsupported output-type ~a" output-type))))
+
+(if (or *generate-faso* (eq *clasp-build-mode* :faso))
+                                               :fasp :fasl)
 
 (defun cfp-output-file-default (input-file output-type &key target-backend)
   (let* ((defaults (merge-pathnames input-file *default-pathname-defaults*)))
@@ -295,8 +300,8 @@ Compile a lisp source file into an LLVM module."
                               (source-debug-lineno 0)
                               (source-debug-offset 0)
                               ;; output-type can be (or :fasl :bitcode :object)
-                              (output-type (if (or *generate-faso* (eq *clasp-build-mode* :faso))
-                                               :fasp :fasl) output-type-p)
+                              ;; logic needs to be consistent with compile-file-serial and cfp-output-extension
+                              (output-type :fasl output-type-p)
                               ;; type can be either :kernel or :user
                               (type :user)
                               ;; A unique prefix for symbols of compile-file'd files that
@@ -422,7 +427,7 @@ Compile a lisp source file into an LLVM module."
            (let ((stream (generate-obj-asm-stream module :simple-vector-byte8
                                                   'llvm-sys:code-gen-file-type-object-file
                                                   (reloc-model))))
-             (core:write-faso (make-pathname :type "fasp" :defaults output-file) (list stream) :start-object-id position))))
+             (core:write-faso output-file (list stream) :start-object-id position))))
         ((eq output-type :fasl)
          (let ((temp-bitcode-file (compile-file-pathname input-file
                                                          :output-file output-file :output-type :bitcode)))

--- a/src/lisp/kernel/cmp/compile-file.lsp
+++ b/src/lisp/kernel/cmp/compile-file.lsp
@@ -83,13 +83,12 @@
 ;;;
 ;;; Compile-file pathnames
 
+;;; I wonder, why that doesn't take core:*clasp-build-mode* into account
 (defun cfp-output-extension (output-type)
   (cond
     ((eq output-type :bitcode) (if *use-human-readable-bitcode* "ll" "bc"))
     ((and *generate-faso* (or (eq output-type :object))) "faso")
     ((and *generate-faso* (or (eq output-type :fasl))) "fasp")
-    #+no ((and (eq core:*clasp-build-mode* :faso) (or (eq output-type :object)))"faso")
-    #+no ((and (eq core:*clasp-build-mode* :faso) (or (eq output-type :fasl))) "fasp")
     ((eq output-type :object) "o")
     ((eq output-type :fasl) "fasl")
     ((eq output-type :faso) "faso")

--- a/src/lisp/regression-tests/system-construction.lisp
+++ b/src/lisp/regression-tests/system-construction.lisp
@@ -49,6 +49,7 @@
    (let ((fasl (compile-file file :output-file (make-pathname :type "newfasl" :defaults file) :verbose nil :print nil)))
      (and (probe-file fasl) (string-equal (pathname-type fasl) "newfasl")))))
 
+;;; crosscompiling sbcl
 (test
  compile-file-serial-no-faso
  (let ((cmp::*compile-file-parallel* nil)

--- a/src/lisp/regression-tests/system-construction.lisp
+++ b/src/lisp/regression-tests/system-construction.lisp
@@ -49,6 +49,15 @@
    (let ((fasl (compile-file file :output-file (make-pathname :type "newfasl" :defaults file) :verbose nil :print nil)))
      (and (probe-file fasl) (string-equal (pathname-type fasl) "newfasl")))))
 
+(test
+ compile-file-serial-no-faso
+ (let ((cmp::*compile-file-parallel* nil)
+       (cmp::*generate-faso* nil)
+       (core:*clasp-build-mode* :faso)
+       (file "sys:regression-tests;framework.lisp"))
+   (let ((fasl (compile-file file :output-file (make-pathname :type "newfasl" :defaults file) :verbose nil :print nil)))
+     (and (probe-file fasl) (string-equal (pathname-type fasl) "newfasl")))))
+
 ;;; there shoudn't be any output if verbose and print are nil
 (test
  COMPILE-FILE.1.simplified
@@ -56,7 +65,7 @@
           (with-output-to-string
               (*standard-output*)
             (compile-file "sys:regression-tests;framework.lisp" :verbose nil :print nil))))
-        
+
 
 
 


### PR DESCRIPTION
Fix errors with the combination of 
CLASP_BUILD_MODE = 'faso'
USE_COMPILE_FILE_PARALLEL=False.

* In compile-file-output-module, respect the output-file
* in compile-file-serial use the same default :fasl for `output-type`as in compile-file-parallel
* added a regression-test

Validated by:
* running regression tests
* x-compiling sbcl (where the error was first noded)
* compiling the following quicklisp systems:
```lisp
(progn
  (time (ql:quickload :netcdf :verbose t))
  (time (ql:quickload :static-vectors :verbose t))
  (time (ql:quickload :trivial-garbage :verbose t))
  (time (ql:quickload :bordeaux-threads :verbose t))
  (time (ql:quickload :cffi :verbose t))
  (time (ql:quickload :usocket :verbose t))
  (time (ql:quickload :uuid :verbose t))
  (time (ql:quickload :trivial-backtrace :verbose t))
  (time (ql:quickload :esrap :verbose t)))
````
* quickloading mcclim 