### PR TITLE
Fix FileStream_O::__repr__() for pipes

### DIFF
--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -349,6 +349,7 @@ GCPROTECTED:
 public: // Functions here
   virtual string __repr__() const;
   T_sp filename() const { return this->_Filename; };
+  virtual bool has_file_position() const;
 }; // FileStream class
 };
 
@@ -385,6 +386,7 @@ public: // Functions here
 
 public:
   int fileDescriptor() const { return this->_FileDescriptor; };
+  virtual bool has_file_position() const;
 };
 };
 

--- a/include/clasp/core/unixfsys.h
+++ b/include/clasp/core/unixfsys.h
@@ -116,6 +116,7 @@ Symbol_sp core__file_kind(T_sp filename, bool follow_links = true);
 T_mv af_renameFile(T_sp oldn, T_sp newn, T_sp if_exists = kw::_sym_supersede);
 T_sp cl__delete_file(T_sp filespec);
 String_sp clasp_strerror(int e);
+bool clasp_has_file_position (int filedescriptor);
 };
 
 namespace ext {

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -3034,9 +3034,8 @@ io_file_get_position(T_sp strm) {
   clasp_disable_interrupts();
   offset = lseek(f, 0, SEEK_CUR);
   clasp_enable_interrupts();
-  unlikely_if(offset < 0) {
+  unlikely_if(offset < 0)
     io_error(strm);
-  }
   if (sizeof(clasp_off_t) == sizeof(long)) {
     output = Integer_O::create((gctools::Fixnum)offset);
   } else {

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -3034,8 +3034,9 @@ io_file_get_position(T_sp strm) {
   clasp_disable_interrupts();
   offset = lseek(f, 0, SEEK_CUR);
   clasp_enable_interrupts();
-  unlikely_if(offset < 0)
-      io_error(strm);
+  unlikely_if(offset < 0) {
+    io_error(strm);
+  }
   if (sizeof(clasp_off_t) == sizeof(long)) {
     output = Integer_O::create((gctools::Fixnum)offset);
   } else {
@@ -5654,13 +5655,24 @@ String_sp StringOutputStream_O::getAndReset() {
 
 namespace core {
 
+bool FileStream_O::has_file_position () const {
+  return false;
+}
+
+bool IOFileStream_O::has_file_position () const {
+  int fd = fileDescriptor();
+  return clasp_has_file_position(fd);
+}
+
 string FileStream_O::__repr__() const {
   stringstream ss;
   ss << "#<" << this->_instanceClass()->_classNameAsString();
   ss << " " << _rep_(this->filename());
-  if (!this->_Closed) {
-    ss <<  " file-pos ";
-    ss << _rep_(clasp_file_position(this->asSmartPtr()));
+  if (this->has_file_position()) {
+    if (!this->_Closed) {
+      ss <<  " file-pos ";
+      ss << _rep_(clasp_file_position(this->asSmartPtr()));
+    }
   }
   ss << ">";
   return ss.str();

--- a/src/core/unixfsys.cc
+++ b/src/core/unixfsys.cc
@@ -2240,6 +2240,17 @@ CL_DEFUN T_mv ext__fstat(int filedescriptor) {
                                      
 };
 
+bool clasp_has_file_position (int filedescriptor) {
+  struct stat sb;
+  if (fstat(filedescriptor, &sb) == -1)
+    return false;
+  else
+    if (S_ISSOCK(sb.st_mode) || S_ISFIFO(sb.st_mode) || S_ISDIR(sb.st_mode))
+      return false;
+    else
+      return true;
+}
+
 CL_LAMBDA(pathname);
 CL_DECLARE();
 CL_DOCSTRING("Returns data of the posix stat() function for pathname"

--- a/src/lisp/regression-tests/posix.lisp
+++ b/src/lisp/regression-tests/posix.lisp
@@ -58,4 +58,13 @@
                    (ext:file-stream-file-descriptor 23)
                    :type type-error)
 
+(test
+ FileStream_O__repr__
+ (multiple-value-bind
+       (errno pid-or-error-message stream)
+     (ext:vfork-execvp (list "llvm-config" "--ldflags" "--libdir" "--libs") t)
+   (if stream
+       (write stream)
+       nil)))
+
 


### PR DESCRIPTION
* `(ext:vfork-execvp (list "llvm-config" "--ldflags" "--libdir" "--libs") t)` used to fail since `FileStream_O::__repr__()` tried to print the file position, but that fails for pipes
* now testing whether the file-position call can work before calling
* added a regression-test