### PR TITLE
Don't export cl:the-next-bignum

### DIFF
--- a/include/clasp/core/bignum.h
+++ b/include/clasp/core/bignum.h
@@ -324,7 +324,7 @@ struct gctools::GCInfo<core::TheNextBignum_O> {
 
 namespace core {
 class TheNextBignum_O : public Integer_O {
-  LISP_CLASS(core, ClPkg, TheNextBignum_O, "TheNextBignum",Integer_O);
+  LISP_CLASS(core, CorePkg, TheNextBignum_O, "TheNextBignum",Integer_O);
 public:
   typedef mp_limb_t limb_type;
   TheNextBignum_O(int64_t signed_length, limb_type initialElement=0, bool initialElementSupplied=false,size_t initialContentsSize=0, const limb_type* initialContents=NULL) : _limbs(signed_length,initialElement,initialElementSupplied,initialContentsSize,initialContents) {

--- a/src/lisp/regression-tests/symbol0.lisp
+++ b/src/lisp/regression-tests/symbol0.lisp
@@ -74,3 +74,9 @@
 (test build-sbcl-1 (setf (symbol-plist nil)(list 1 2)))
 (test build-sbcl-2 (setf (get nil 1) 2))
 
+(test 978-symbols-common-lisp-exported
+      (let ((sum 0))
+        (do-external-symbols (sym (find-package :cl))
+          (incf sum))
+        (= 978 sum)))
+


### PR DESCRIPTION
* must not be exported from cl, but rather from core
* test that the right number of symbols are exported