### PR TITLE
Respect verbose parameter

### DIFF
--- a/src/llvmo/debugInfoExpose.cc
+++ b/src/llvmo/debugInfoExpose.cc
@@ -442,7 +442,7 @@ CL_DEFUN core::T_mv object_file_for_instruction_pointer(core::Pointer_sp instruc
   ObjectFileInfo* cur = global_object_files.load();
   size_t count;
   char* ptr = (char*)instruction_pointer->ptr();
-  if (!cur) {
+  if ((!cur) && verbose){
     core::write_bf_stream(BF("No object files registered - cannot find object file for address %p\n") % (void*)ptr);
   }
   while (cur) {


### PR DESCRIPTION
* Message "No object files registered - cannot find object file for address %p\n" were within backtrace output, when :source-positions = t
Example
```lisp
(handler-case 
    (let ((x 1))
      (let ((y (- x (expt 1024 0))))
        (declare (optimize (safety 3))
                 (notinline /))
        (/ 2 y)))
  (error ()
    (clasp-debug:print-backtrace :source-positions t)))
->
   1: (CLASP-DEBUG:CALL-WITH-STACK #<FUNCTION CLASP-DEBUG::WITH-STACK-LAMBDA> :DELIMITED T)No object files registered - cannot find object file for address 0x3919eaf40
   2: (CLASP-DEBUG:PRINT-BACKTRACE :SOURCE-POSITIONS T)No object files registered - cannot find object file for address 0x391b5990a
   3: (LAMBDA ())No object files registered - cannot find object file for address 0x10e038140
...
````
with the pr applied:
```lisp
 (handler-case 
    (let ((x 1))
      (let ((y (- x (expt 1024 0))))
        (declare (optimize (safety 3))
                 (notinline /))
        (/ 2 y)))
  (error ()
    (clasp-debug:print-backtrace :source-positions t)))
   1: (CLASP-DEBUG:CALL-WITH-STACK #<FUNCTION CLASP-DEBUG::WITH-STACK-LAMBDA> :DELIMITED T)
   2: (CLASP-DEBUG:PRINT-BACKTRACE :SOURCE-POSITIONS T)
   3: (LAMBDA ())
   4: ((METHOD CLASP-CLEAVIR::CCLASP-EVAL-WITH-ENV (T T)) (BLOCK #:G9944
  (LET ((#:G9945 NIL))
    (DECLARE (IGNORABLE #:G9945))
    (TAGBODY
      (RETURN-FROM #:G9944
        (HANDLER-BIND
         ((ERROR
           #'(LAMBDA (CORE::TEMP)
               (DECLARE (IGNORABLE CORE::TEMP))
               (GO #:G9946))))
         (LET ((X 1))
           (LET ((Y (- X (EXPT 1024 0))))
             (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
             (/ 2 Y)))))
     #:G9946
      (RETURN-FROM #:G9944
        (LOCALLY (CLASP-DEBUG:PRINT-BACKTRACE :SOURCE-POSITIONS T)))))) NIL)
   8: (CLASP-CLEAVIR::SIMPLE-EVAL (BLOCK #:G9944
  (LET ((#:G9945 NIL))
    (DECLARE (IGNORABLE #:G9945))
    (TAGBODY
      (RETURN-FROM #:G9944
        (HANDLER-BIND
         ((ERROR
           #'(LAMBDA (CORE::TEMP)
               (DECLARE (IGNORABLE CORE::TEMP))
               (GO #:G9946))))
         (LET ((X 1))
           (LET ((Y (- X (EXPT 1024 0))))
             (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
             (/ 2 Y)))))
     #:G9946
      (RETURN-FROM #:G9944
        (LOCALLY (CLASP-DEBUG:PRINT-BACKTRACE :SOURCE-POSITIONS T)))))) NIL #<STANDARD-GENERIC-FUNCTION CLASP-CLEAVIR::CCLASP-EVAL-WITH-ENV>)
   9: (CLASP-CLEAVIR::CCLASP-EVAL (BLOCK #:G9944
  (LET ((#:G9945 NIL))
    (DECLARE (IGNORABLE #:G9945))
    (TAGBODY
      (RETURN-FROM #:G9944
        (HANDLER-BIND
         ((ERROR
           #'(LAMBDA (CORE::TEMP)
               (DECLARE (IGNORABLE CORE::TEMP))
               (GO #:G9946))))
         (LET ((X 1))
           (LET ((Y (- X (EXPT 1024 0))))
             (DECLARE (OPTIMIZE (SAFETY 3)) (NOTINLINE /))
             (/ 2 Y)))))
     #:G9946
      (RETURN-FROM #:G9944
        (LOCALLY (CLASP-DEBUG:PRINT-BACKTRACE :SOURCE-POSITIONS T)))))) NIL)
  11: (SWANK::EVAL-REGION "(handler-case 
    (let ((x 1))
      (let ((y (- x (expt 1024 0))))
        (declare (optimize (safety 3))
                 (notinline /))
        (/ 2 y)))
  (error ()
    (clasp-debug:print-backtrace :source-positions t)))
")
    |---> /Users/karstenpoeck/quicklisp/local-projects/slime-git/swank.lisp:1785
  12: (LAMBDA ())
    |---> /Users/karstenpoeck/quicklisp/local-projects/slime-git/contrib/swank-repl.lisp:268
  13: (SWANK-REPL::TRACK-PACKAGE #<FUNCTION (LAMBDA NIL)>)
    |---> /Users/karstenpoeck/quicklisp/local-projects/slime-git/contrib/swank-repl.lisp:277
...
````