### PR TITLE
Fix regression test LOOP-COMPLEX-1

### DIFF
--- a/src/lisp/regression-tests/set-unexpected-failures.lisp
+++ b/src/lisp/regression-tests/set-unexpected-failures.lisp
@@ -21,10 +21,9 @@
         ;;; LOGBITP-1
         ;;; CL-SYMBOLS-1
         ;;; loop this are all fixed using sicl loop
-        LOOP-COMPLEX-1
+        ;;; LOOP-COMPLEX-1
         ;;; LOOP-FLOAT-1 LOOP-FLOAT-2
-        LOOP-FIXNUM-1
-        LOOP-FINALLY-1 LOOP-FINALLY-2 LOOP-FINALLY-3 LOOP-FINALLY-4
+        LOOP-FIXNUM-1 LOOP-FINALLY-1 LOOP-FINALLY-2 LOOP-FINALLY-3 LOOP-FINALLY-4
         ;;; print-5 
         PRINT-READ-1
         ;;; GENTEMP-1 SPECIAL-OPERATOR-P-1


### PR DESCRIPTION
* verifies now that the declaration for a variable is consistent with its initial value
* Ecl fixed the same problem, so took care that the clasp fix uses the same code
* Fixes regression test LOOP-COMPLEX-1
* Also fixes ansi test  loop.10.87
```lisp
(macroexpand '(loop for i from 1 to 4
        sum (complex i (1+ i)) of-type complex))
->
(BLOCK NIL
  (LET ((I 1))
    (DECLARE (TYPE FIXNUM I))
    (LET ((#:LOOP-SUM-1358 0))
      (DECLARE (TYPE (OR COMPLEX (INTEGER 0 0)) #:LOOP-SUM-1358))
      (CORE::LOOP-BODY NIL
                       (NIL NIL NIL NIL)
                       ((SETQ #:LOOP-SUM-1358
                                (+ #:LOOP-SUM-1358 (COMPLEX I (1+ I)))))
                       (NIL
                        (CORE::LOOP-REALLY-DESETQ I (CORE::LOOP-UNSAFE (1+ I)))
                        (WHEN (> I '4) (GO CORE::END-LOOP)) NIL)
                       ((RETURN-FROM NIL #:LOOP-SUM-1358))))))
````

The declaration for #:LOOP-SUM-1358 used to be just complex, which is wrong for the initial value 