### PR TITLE
Define log1 for bignum, better Ratio_O::as_double_

### DIFF
--- a/include/clasp/core/bignum.h
+++ b/include/clasp/core/bignum.h
@@ -245,8 +245,6 @@ public: // Functions here
   virtual bool evenp_() const { return (mpz_get_ui(this->_value.get_mpz_t()) & 1) == 0; };
   virtual bool oddp_() const { return (mpz_get_ui(this->_value.get_mpz_t()) & 1) != 0; };
 
-  Number_sp log1() const;
-
 }; // Bignum class
 
 }; // core namespace

--- a/include/clasp/core/bignum.h
+++ b/include/clasp/core/bignum.h
@@ -152,6 +152,7 @@ public: // Functions here
   Bignum get() const;
   Bignum get_or_if_nil_default(Bignum default_value) const;
   Number_sp abs_() const;
+  Number_sp log1_() const;
   Number_sp sqrt_() const;
   Number_sp reciprocal_() const;
   Number_sp rational_() const final { return this->asSmartPtr(); };

--- a/include/clasp/core/numbers.fwd.h
+++ b/include/clasp/core/numbers.fwd.h
@@ -48,16 +48,12 @@ FORWARD(Bool);
 
    Fixnum clasp_to_fixnum( core::Integer_sp );
    double clasp_to_double( core::Number_sp );
-   float clasp_to_float( core::Number_sp );
    double clasp_to_double( core::T_sp );
    double clasp_to_double( core::General_sp );
    double clasp_to_double( core::Number_sp );
    double clasp_to_double( core::Real_sp );
    double clasp_to_double( core::Integer_sp );
    double clasp_to_double( core::DoubleFloat_sp );
-   float clasp_to_float( core::SingleFloat_sp );
-   float clasp_to_float( core::T_sp );
-   float clasp_to_float( core::General_sp );
    Fixnum_sp clasp_make_fixnum(gc::Fixnum i);
    Fixnum_sp make_fixnum(gc::Fixnum i);
    SingleFloat_sp clasp_make_single_float(float d);
@@ -67,7 +63,7 @@ FORWARD(Bool);
    Integer_sp clasp_make_integer(size_t i);
 
 
-     Fixnum              clasp_to_fixnum( core::T_sp );
+  Fixnum              clasp_to_fixnum( core::T_sp );
   short               clasp_to_short( core::T_sp );
   unsigned short      clasp_to_ushort( core::T_sp );
   int                 clasp_to_int( core::T_sp );
@@ -101,8 +97,6 @@ FORWARD(Bool);
   mpz_class           clasp_to_mpz( core::T_sp );
   cl_index            clasp_to_size( core::T_sp );
 
-  float               clasp_to_float( core::Number_sp );
-  double              clasp_to_double( core::Number_sp );
   LongFloat           clasp_to_long_float( core::Number_sp );
   LongFloat           clasp_to_long_double( core::Number_sp );
 

--- a/src/core/bignum.cc
+++ b/src/core/bignum.cc
@@ -359,17 +359,6 @@ Number_sp Bignum_O::abs_() const {
   return ((cp));
 }
 
-Number_sp Bignum_O::log1_() const {
-  if (this->minusp_()) {
-    return clasp_log1_complex_inner(this->asSmartPtr(), clasp_make_fixnum(0));
-  } else {
-    gc::Fixnum l = clasp_integer_length(this->asSmartPtr()) - 1;
-    Ratio_sp r = clasp_make_ratio(this->asSmartPtr(), clasp_ash(clasp_make_fixnum(1), l));
-    float d = logf(r->as_float_()) + l * logf(2.0);
-    return clasp_make_single_float(d);
-  }
-}
-
 bool Bignum_O::eql_(T_sp o) const {
   if (o.fixnump()) {
     return (this->_value == clasp_to_mpz(gc::As<Fixnum_sp>(o)));

--- a/src/core/bignum.cc
+++ b/src/core/bignum.cc
@@ -359,6 +359,17 @@ Number_sp Bignum_O::abs_() const {
   return ((cp));
 }
 
+Number_sp Bignum_O::log1_() const {
+  if (this->minusp_()) {
+    return clasp_log1_complex_inner(this->asSmartPtr(), clasp_make_fixnum(0));
+  } else {
+    gc::Fixnum l = clasp_integer_length(this->asSmartPtr()) - 1;
+    Ratio_sp r = clasp_make_ratio(this->asSmartPtr(), clasp_ash(clasp_make_fixnum(1), l));
+    float d = logf(r->as_float_()) + l * logf(2.0);
+    return clasp_make_single_float(d);
+  }
+}
+
 bool Bignum_O::eql_(T_sp o) const {
   if (o.fixnump()) {
     return (this->_value == clasp_to_mpz(gc::As<Fixnum_sp>(o)));

--- a/src/core/numbers.cc
+++ b/src/core/numbers.cc
@@ -2774,7 +2774,7 @@ Number_sp Bignum_O::log1_() const {
   } else {
     Fixnum length = clasp_integer_length(bignum) - 1;
     Integer_sp ash = clasp_ash(make_fixnum(1), length);
-    Number_sp rational = clasp_make_rational(bignum, ash);
+    Rational_sp rational = clasp_make_rational(bignum, ash);
     float d = logf(clasp_to_float(rational)) + length * logf(2.0);
     return clasp_make_single_float(d);
   }

--- a/src/core/numbers.cc
+++ b/src/core/numbers.cc
@@ -1786,7 +1786,7 @@ static Integer_sp mantissa_and_exponent_from_ratio(Bignum_sp num, Bignum_sp den,
 double Ratio_O::as_double_() const {
   if (core__bignump(this->_numerator) && core__bignump(this->_denominator)) {
     gc::Fixnum exponent;
-    Integer_sp mantissa = mantissa_and_exponent_from_ratio(gc::As<Bignum_sp>(this->_numerator),gc::As<Bignum_sp>(this->_denominator), FLT_MANT_DIG, &exponent);
+    Integer_sp mantissa = mantissa_and_exponent_from_ratio(gc::As<Bignum_sp>(this->_numerator),gc::As<Bignum_sp>(this->_denominator), DBL_MANT_DIG, &exponent);
     double output;
     if (mantissa.fixnump())
       output = gc::As<Fixnum_sp>(mantissa).unsafe_fixnum();
@@ -2767,13 +2767,15 @@ Number_sp clasp_log1_complex_inner(Number_sp r, Number_sp i) {
   return clasp_make_complex(a, p);
 }
 
-Number_sp Bignum_O::log1() const {
-  if (clasp_minusp(this->asSmartPtr())) {
-    return clasp_log1_complex_inner(this->const_sharedThis<Bignum_O>(), make_fixnum(0));
+Number_sp Bignum_O::log1_() const {
+  Bignum_sp bignum = this->asSmartPtr();
+  if (clasp_minusp(bignum)) {
+    return clasp_log1_complex_inner(bignum, make_fixnum(0));
   } else {
-    Fixnum l = clasp_integer_length(this->const_sharedThis<Bignum_O>()) - 1;
-    Number_sp r = clasp_make_ratio(this->asSmartPtr(), clasp_ash(make_fixnum(1), l));
-    float d = logf(clasp_to_float(r)) + l * logf(2.0);
+    Fixnum length = clasp_integer_length(bignum) - 1;
+    Integer_sp ash = clasp_ash(make_fixnum(1), length);
+    Number_sp rational = clasp_make_rational(bignum, ash);
+    float d = logf(clasp_to_float(rational)) + length * logf(2.0);
     return clasp_make_single_float(d);
   }
 }
@@ -2797,7 +2799,7 @@ Number_sp DoubleFloat_O::log1_() const {
 }
 
 #ifdef CLASP_LONG_FLOAT
-Number_sp LongFloat_O::log1() const {
+Number_sp LongFloat_O::log1_() const {
   LongFloat f = this->as_long_float();
   if (std::isnan(f))
     return this->asSmartPtr();
@@ -3356,7 +3358,7 @@ ssize_t clasp_to_ssize( core::T_sp x )
 
   // --- FLOAT ---
 
-float clasp_to_float( core::Number_sp x )
+float clasp_to_float(core::Number_sp x)
 {
   if (x.fixnump())
   {
@@ -3367,25 +3369,6 @@ float clasp_to_float( core::Number_sp x )
     return (float) x.unsafe_single_float();
   }
   return x->as_float_();
-}
-
-
-float clasp_to_float( core::T_sp x )
-{
-  if (x.fixnump()) return (float) x.unsafe_fixnum();
-  else if (x.single_floatp()) return (float) x.unsafe_single_float();
-  else if (gc::IsA<Number_sp>(x)) {
-    return gc::As_unsafe<Number_sp>(x)->as_float_();
-  }
-  TYPE_ERROR(x,cl::_sym_Number_O);
-}
-
-float clasp_to_float( core::General_sp x )
-{
-  if (gc::IsA<Number_sp>(x)) {
-    return gc::As_unsafe<Number_sp>(x)->as_float_();
-  }
-  TYPE_ERROR(x,cl::_sym_Number_O);
 }
 
 // --- DOUBLE ---

--- a/src/lisp/regression-tests/numbers.lisp
+++ b/src/lisp/regression-tests/numbers.lisp
@@ -594,9 +594,64 @@
 
 (test log-bignum
       (labels ((factorial (n)(if (<= n 1) 1 (* n (factorial (1- n))))))
-        (typep (log (factorial 200)) 'float)))
+        (let ((result (log (factorial 200)))) 
+          (and (floatp result)
+               (not (ext:float-nan-p result))))))
 
 (test load-log-bignum
       (labels ((factorial (n)(if (<= n 1) 1 (* n (factorial (1- n))))))
-        (loop for x from 1 to 500 collect
-             (log (factorial x)))))
+        (every #'(lambda(result)
+                   (and (floatp result)
+                        (not (ext:float-nan-p result))))
+               (loop for x from 1 to 500 collect
+                        (log (factorial x))))))
+
+(test big-ratio-coerce
+      (let ((result
+              (COERCE 6795704571147613088400718678381656244393117734249898937417419069310191575883868986428455446312916068568665979830007649804543533991572608932250835738151489076845330821569858726908084574701882988127547528934585469826755385222874837210418773111903651670205662000421193529634355863606092768847694362480173879256904596515653328461457501880112334566400744016842783001773321772818609367618076742443023275354232092047563787771643659430278130974461062642384241926963624924919867161137264969829092223075246982819340445538562498073940878705520674737984170082956322173496241162764552348099573721983300906273607793253095492671040351/2500000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000 'SINGLE-FLOAT)))
+        (and (floatp result)
+             (not (ext:float-nan-p result)))))
+             
+;;; cannot be run yet, because of https://github.com/clasp-developers/clasp/issues/961        
+#+(or)
+(progn
+  (test-expect-error
+   integer_decode_float_infinity_short_positive
+   (integer-decode-float #.ext:short-float-positive-infinity)
+   :type arithmetic-error)
+
+  (test-expect-error
+   integer_decode_float_infinity_single_positive
+   (integer-decode-float #.ext:single-float-positive-infinity)
+   :type arithmetic-error)
+
+  (test-expect-error
+   integer_decode_float_infinity_double_positive
+   (integer-decode-float #.ext:double-float-positive-infinity)
+   :type arithmetic-error)
+
+  (test-expect-error
+   integer_decode_float_infinity_long_positive
+   (integer-decode-float #.ext:long-float-positive-infinity)
+   :type arithmetic-error)
+
+  (test-expect-error
+   integer_decode_float_infinity_short_negative
+   (integer-decode-float #.ext:short-float-negative-infinity)
+   :type arithmetic-error)
+
+  (test-expect-error
+   integer_decode_float_infinity_single_negative
+   (integer-decode-float #.ext:single-float-negative-infinity)
+   :type arithmetic-error)
+
+  (test-expect-error
+   integer_decode_float_infinity_double_negative
+   (integer-decode-float #.ext:double-float-negative-infinity)
+   :type arithmetic-error)
+
+  (test-expect-error
+   integer_decode_float_infinity_long_negative
+   (integer-decode-float #.ext:long-float-negative-infinity)
+   :type arithmetic-error)
+  )

--- a/src/lisp/regression-tests/read01.lisp
+++ b/src/lisp/regression-tests/read01.lisp
@@ -537,10 +537,39 @@
       (null
        (loop for s in '("RubOut" "PAGe" "BacKspace" "RetUrn" "Tab" "LineFeed"
                         "SpaCE" "NewLine")
-          unless
-            (let ((c1 (name-char (string-upcase s)))
-                  (c2 (name-char (string-downcase s)))
-                  (c3 (name-char (string-capitalize s)))
-                  (c4 (name-char s)))
-              (and (char= c1 c2) (char= c2 c3) (char= c3 c4)))
-          collect s)))
+             unless
+             (let ((c1 (name-char (string-upcase s)))
+                   (c2 (name-char (string-downcase s)))
+                   (c3 (name-char (string-capitalize s)))
+                   (c4 (name-char s)))
+               (and (char= c1 c2) (char= c2 c3) (char= c3 c4)))
+             collect s)))
+
+;;; Problems with eclector https://github.com/s-expressionists/Eclector/issues/63
+(defstruct syntax-test-struct-1 a b c)
+
+(test SYNTAX.SHARP-S.3
+      (multiple-value-bind
+            (a b c d)
+          (let ((v (read-from-string "#s(syntax-test-struct-1 \"A\" x)")))
+            (values
+             (not (not (typep v 'syntax-test-struct-1)))
+             (syntax-test-struct-1-a v)
+             (syntax-test-struct-1-b v)
+             (syntax-test-struct-1-c v)))
+        (and a (eql b 'x) (null c)(null d))))
+
+;;; https://github.com/s-expressionists/Eclector/issues/67
+(test eclector-issue-67
+      (equal
+       (WITH-INPUT-FROM-STRING (*STANDARD-INPUT* "1 2 3 ]")
+         (READ-DELIMITED-LIST #\] NIL))
+       '(1 2 3)))
+
+(test very-long-floats-maxima
+      (let (($%e 2.7182818284590452353602874713526624977572470936999595749669676277240766303535475945713821785251664274274663919320030599218174135966290435729003342952605956307381323286279434907632338298807531952510190115738341879307021540891499348841675092447614606680822648001684774118537423454424371075390777449920695517027618386062613313845830007520449338265602976067371132007093287091274437470472306969772093101416928368190255151086574637721112523897844250569536967707854499699679468644549059879316368892300987931277361782154249992295763514822082698951936680331825288693984964651058209392398294887933203625094431173012381970684161404))
+        (and (floatp $%e)
+             (not (ext:float-nan-p $%e)))))
+
+
+


### PR DESCRIPTION
* replaces https://github.com/clasp-developers/clasp/pull/827
* defines
  * Bignum_O::log1_
  * Ratio_O::as_double_()
* allows:
```lisp
(labels ((factorial (n)(if (<= n 1) 1 (* n (factorial (1- n))))))
        (log (factorial 200)))

-> 863.232
````
* in cl-bench fixes:
  * pi-decimal/big
  * pi-atan
* fixes reading of very long float-tokens with eclector
  * see test very-long-floats-maxima and
  * test big-ratio-coerce
* read01.lisp has some additional tests not related to this change, that I has accumulated
* numbers.lisp has some disabled test regarding arithmetic errors that currently don't work because of https://github.com/clasp-developers/clasp/issues/961. Added them so they don't get lost
* maxima only works with this pr (and latest sicl changes from karlosz)