### PR TITLE
(slot-exists-p should not return multiple-values per ansi

### DIFF
--- a/src/lisp/kernel/clos/std-slot-value.lsp
+++ b/src/lisp/kernel/clos/std-slot-value.lsp
@@ -229,7 +229,7 @@ consequences are not defined.")
   (with-slots ((slots slots) (location-table location-table))
       (class-of self)
     (if location-table ; only for direct instances of standard-class, etc
-        (gethash slot-name location-table nil)
+        (values (gethash slot-name location-table nil))
         (find slot-name slots :key #'slot-definition-name))))
 
 (defun slot-boundp (self slot-name)

--- a/src/lisp/regression-tests/clos.lisp
+++ b/src/lisp/regression-tests/clos.lisp
@@ -72,3 +72,24 @@
          (a b c)
          (:illegal-option nil)))
  :type program-error)
+
+(test slot-exists-p-gives-single-value-slot-exists
+      (null (cdr
+             (multiple-value-list
+              (slot-exists-p (make-instance 'test) 'foo)))))
+
+(test slot-exists-p-gives-single-value-slot-not-exists
+      (null (cdr
+             (multiple-value-list
+              (slot-exists-p (make-instance 'test) 'fooasdasdasd)))))
+
+(test slot-exists-p-gives-single-value-slot-not-exists-build-in-class
+      (null (cdr
+             (multiple-value-list
+              (slot-exists-p (find-class 'test) 'fooasdasdasd)))))
+
+(test slot-exists-p-other-arguments
+      (notany  #'(lambda(object)
+                   (slot-exists-p object 'foo))
+               (list 42 42.0 'c "324789" (code-char 65)
+                     (vector 1 2 3) (make-hash-table))))


### PR DESCRIPTION
* fixes following ansi-test:
`DEFCLASS-2-HAS-SLOT-NAMED-SLOT1, DEFCLASS-2-HAS-SLOT-NAMED-SLOT2, 
   DEFCLASS-2-HAS-SLOT-NAMED-SLOT3, DEFCLASS-2-ALLOCATE-INSTANCE, 
   DEFCLASS-4-HAS-SLOT-NAMED-SLOT1, DEFCLASS-4-HAS-SLOT-NAMED-SLOT4, 
   DEFCLASS-4-ALLOCATE-INSTANCE, SLOT-EXISTS-P.1, SLOT-EXISTS-P.2, 
   SLOT-EXISTS-P.3, SLOT-EXISTS-P.4, SLOT-EXISTS-P.5, SLOT-EXISTS-P.6, 
   SLOT-EXISTS-P.7, `