### PR TITLE
Flamegraphs fix annoying compiler warnings

### DIFF
--- a/src/profiler/stacks.lisp
+++ b/src/profiler/stacks.lisp
@@ -385,8 +385,8 @@ exec sbcl --noinform --dynamic-space-size 2048 --disable-ldb --lose-on-corruptio
                      (terpri fout)))))))
 
 (defun fraction (fin stop-at)
-  (let (#+(or)(header (read-dtrace-header fin)))
-    #+(or)(declare (ignore header))
+  (let ((header (read-dtrace-header fin)))
+       (declare (ignore header))
     (let ((counts (make-hash-table :test #'equal))
           (num-backtraces 0))
       (loop for backtrace = (read-dtrace-backtrace-raw fin nil :eof)

--- a/src/profiler/stacks.lisp
+++ b/src/profiler/stacks.lisp
@@ -386,7 +386,7 @@ exec sbcl --noinform --dynamic-space-size 2048 --disable-ldb --lose-on-corruptio
 
 (defun fraction (fin stop-at)
   (let ((header (read-dtrace-header fin)))
-       (declare (ignore header))
+    (declare (ignore header))
     (let ((counts (make-hash-table :test #'equal))
           (num-backtraces 0))
       (loop for backtrace = (read-dtrace-backtrace-raw fin nil :eof)

--- a/src/profiler/stacks.lisp
+++ b/src/profiler/stacks.lisp
@@ -267,7 +267,6 @@ exec sbcl --noinform --dynamic-space-size 2048 --disable-ldb --lose-on-corruptio
 (defun invert-frames (fin fout &key (depth nil))
   (let ((header (read-dtrace-header fin))
         (backtraces nil))
-    (declare (ignore header))
     (loop named read-backtraces
           for raw-backtrace = (let ((bt (read-dtrace-backtrace fin nil :eof)))
                                 (when (eq bt :eof) (return-from read-backtraces nil))
@@ -386,8 +385,8 @@ exec sbcl --noinform --dynamic-space-size 2048 --disable-ldb --lose-on-corruptio
                      (terpri fout)))))))
 
 (defun fraction (fin stop-at)
-  (let ((header (read-dtrace-header fin)))
-    (declare (ignore header))
+  (let (#+(or)(header (read-dtrace-header fin)))
+    #+(or)(declare (ignore header))
     (let ((counts (make-hash-table :test #'equal))
           (num-backtraces 0))
       (loop for backtrace = (read-dtrace-backtrace-raw fin nil :eof)
@@ -471,7 +470,7 @@ exec sbcl --noinform --dynamic-space-size 2048 --disable-ldb --lose-on-corruptio
 
 (defun perf-to-dtrace-backtrace (backtrace-lines)
   ;(format t (first backtrace-lines))
-  (let* ((count (parse-integer (second (reverse
+  (let* (#+(or)(count (parse-integer (second (reverse
                                         (uiop:split-string
                                          (string-right-trim " " (first backtrace-lines)))))))
          (raw-frames (cdr backtrace-lines))


### PR DESCRIPTION
now ./do-flame doesn't complain about unused variables:
````
karsten-poecks-macbook-pro:profiler karstenpoeck$ ./do-flame 34357
Password:
dtrace: system integrity protection is on, some features will not be available

dtrace: description 'profile-97 ' matched 2 probes
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0x1) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0x8000) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0xfdffffff) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0xfeffffff) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0x1) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0x4fbda9a6) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0x4ee478d3) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0xd8580412451882d9) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0x5c542092) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0x4fbda9a6) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0x4fbda9a6) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0x4fbda9a6) in action #2
dtrace: error on enabled probe ID 1 (ID 40: profile:::profile-97): invalid address (0x8d874f9e) in action #2
cmd = ./cleanup-stacks
options split = (NIL)
Running cleanup-stacks
/tmp/out-34357.stacks
/tmp/out-34357.stacks
cmd = ./collapse
Maximum number of frames: 400
/tmp/out-34357.folded
/tmp/out-34357.svg
````