### PR TITLE
[Wip] Drop unneeded declarations for numbers

### DIFF
--- a/include/clasp/core/array_double.h
+++ b/include/clasp/core/array_double.h
@@ -24,8 +24,8 @@ namespace core {
     typedef specialized_SimpleVector_double TemplatedBase;
   public:
     static value_type default_initial_element(void) {return 0.0;}
-    static value_type from_object(T_sp obj) { return clasp_to_double(obj);};
-    static T_sp to_object(const value_type& v) { return core::clasp_make_double_float(v); };
+    static value_type from_object(T_sp obj) { return clasp_to_double(gc::As<Number_sp>(obj));};
+    static T_sp to_object(const value_type& v) { return clasp_make_double_float(v); };
   public:
   SimpleVector_double_O(size_t length, value_type initialElement=value_type(),
                           bool initialElementSupplied=false,

--- a/include/clasp/core/array_double.h
+++ b/include/clasp/core/array_double.h
@@ -24,7 +24,7 @@ namespace core {
     typedef specialized_SimpleVector_double TemplatedBase;
   public:
     static value_type default_initial_element(void) {return 0.0;}
-    static value_type from_object(T_sp obj) { return clasp_to_double(gc::As<Number_sp>(obj));};
+    static value_type from_object(T_sp obj) { return clasp_to_double(gc::As_unsafe<Number_sp>(obj));};
     static T_sp to_object(const value_type& v) { return clasp_make_double_float(v); };
   public:
   SimpleVector_double_O(size_t length, value_type initialElement=value_type(),

--- a/include/clasp/core/numbers.fwd.h
+++ b/include/clasp/core/numbers.fwd.h
@@ -46,41 +46,12 @@ FORWARD(Bool);
 
    typedef double LongFloat;
 
-   Fixnum clasp_to_fixnum( core::Integer_sp );
    double clasp_to_double( core::Number_sp );
+   // needed in cando
    double clasp_to_double( core::T_sp );
-   double clasp_to_double( core::General_sp );
-   double clasp_to_double( core::Number_sp );
-   double clasp_to_double( core::Real_sp );
-   double clasp_to_double( core::Integer_sp );
-   double clasp_to_double( core::DoubleFloat_sp );
-   Fixnum_sp clasp_make_fixnum(gc::Fixnum i);
-   Fixnum_sp make_fixnum(gc::Fixnum i);
-   SingleFloat_sp clasp_make_single_float(float d);
-   DoubleFloat_sp clasp_make_double_float(double d);
 
-   cl_index            clasp_to_size( core::T_sp );
-   Integer_sp clasp_make_integer(size_t i);
-
-
-  Fixnum              clasp_to_fixnum( core::T_sp );
-  short               clasp_to_short( core::T_sp );
-  unsigned short      clasp_to_ushort( core::T_sp );
-  int                 clasp_to_int( core::T_sp );
-  unsigned int        clasp_to_uint( core::T_sp );
-  long                clasp_to_long( core::T_sp );
-  unsigned long       clasp_to_ulong( core::T_sp );
-  long long           clasp_to_longlong( core::T_sp );
-  unsigned long long  clasp_to_ulonglong( core::T_sp );
-  int8_t              clasp_to_int8_t( core::T_sp );
-  uint8_t             clasp_to_uint8_t( core::T_sp );
-  int16_t             clasp_to_int16_t( core::T_sp );
-  uint16_t            clasp_to_uint16_t( core::T_sp );
-  int32_t             clasp_to_int32_t( core::T_sp );
-  uint32_t            clasp_to_uint32_t( core::T_sp );
-  int64_t             clasp_to_int64_t( core::T_sp );
-  uint64_t            clasp_to_uint64_t( core::T_sp );
-
+   int64_t             clasp_to_int64_t( core::T_sp );
+   uint64_t            clasp_to_uint64_t( core::T_sp );
   // THE NEXT TWO FUNCTIONS ARE HERE FOR BACKWARDS COMPATIBILITY
   // frgo, 2017-01-21
 

--- a/include/clasp/core/numbers.h
+++ b/include/clasp/core/numbers.h
@@ -159,11 +159,11 @@ namespace core
   DoubleFloat_sp clasp_make_double_float(double d);
   Number_sp clasp_log1_complex_inner(Number_sp r, Number_sp i);
   void clasp_report_divide_by_zero(Number_sp x);
+  Integer_sp clasp_make_integer(size_t i);
+
 };
 
 namespace core {
-
-  typedef double LongFloat;
 
   Number_sp contagen_add(Number_sp na, Number_sp nb);
   Number_sp contagen_sub(Number_sp na, Number_sp nb);
@@ -323,16 +323,6 @@ namespace core {
 #endif
     static Integer_sp create( uint64_t v );
 
-    // THOSE ARE ALREADY DEFINED ABOVE
-    // static Integer_sp create( short v );
-    // static Integer_sp create( unsigned short v );
-    //
-    // static Integer_sp create( int v );
-    // static Integer_sp create( unsigned int v );
-    //
-    // static Integer_sp create( long v );
-    // static Integer_sp create( unsigned long v );
-    //
 #if !defined( CLASP_LONG_LONG_IS_INT64 )
     static Integer_sp create( long long v );
 #endif
@@ -397,8 +387,7 @@ namespace core {
 namespace core {
 
   Fixnum_sp make_fixnum(gc::Fixnum x);
-  gc::Fixnum get_fixnum(Fixnum_sp x);
-
+  
   class Fixnum_dummy_O : public Integer_O {
     LISP_CLASS(core, ClPkg, Fixnum_dummy_O, "fixnum",Integer_O);
   };
@@ -734,8 +723,6 @@ namespace core {
     Ratio_O() : _numerator(clasp_make_fixnum(0)), _denominator(clasp_make_fixnum(1)) {};
     virtual ~Ratio_O() {};
   };
-
-  void clasp_deliver_fpe(int status);
 
   inline Number_sp clasp_plus(Number_sp na, Number_sp nb) { return contagen_add(na, nb); };
   inline Number_sp clasp_minus(Number_sp na, Number_sp nb) { return contagen_sub(na, nb); };
@@ -1098,22 +1085,10 @@ namespace core {
   uint16_t            clasp_to_uint16_t( core::T_sp );
   int32_t             clasp_to_int32_t( core::T_sp );
   uint32_t            clasp_to_uint32_t( core::T_sp );
-  int64_t             clasp_to_int64_t( core::T_sp );
-  uint64_t            clasp_to_uint64_t( core::T_sp );
-
-  // THE NEXT TWO FUNCTIONS ARE HERE FOR BACKWARDS COMPATIBILITY
-  // frgo, 2017-01-21
-
-
-  uintptr_t         clasp_to_uintptr_t( core::T_sp );
-  mpz_class           clasp_to_mpz( core::T_sp );
-  cl_index            clasp_to_size( core::T_sp );
-
+  
   float               clasp_to_float( core::Number_sp );
   double              clasp_to_double( core::Number_sp );
-  LongFloat           clasp_to_long_float( core::Number_sp );
-  LongFloat           clasp_to_long_double( core::Number_sp );
-
+  
   // END OF CLASP_TO_... FUNCTIONS
 
   inline Number_sp clasp_sqrt( Number_sp z )

--- a/src/core/hashTable.cc
+++ b/src/core/hashTable.cc
@@ -235,7 +235,7 @@ CL_DEFUN T_sp cl__make_hash_table(T_sp test, Fixnum_sp size, Number_sp rehash_si
     }
     SIMPLE_ERROR(BF("Only :weakness :key (weak-key hash tables) are currently supported"));
   }
-  double rehash_threshold = maybeFixRehashThreshold(clasp_to_double(orehash_threshold));
+  double rehash_threshold = maybeFixRehashThreshold(clasp_to_double(gc::As<Number_sp>(orehash_threshold)));
   HashTable_sp table = _Nil<HashTable_O>();
   size_t isize = clasp_to_int(size);
   if (isize==0) isize = 16;

--- a/src/core/num_co.cc
+++ b/src/core/num_co.cc
@@ -113,10 +113,10 @@ CL_DEFUN Float_sp cl__float(Real_sp x, T_sp y) {
   case number_Ratio:
     switch (ty) {
     case number_SingleFloat:
-      x = gc::As<Real_sp>(clasp_make_single_float(clasp_to_double(x)));
+        x = gc::As<Real_sp>(clasp_make_single_float(clasp_to_double(gc::As<Number_sp>(x))));
       break;
     case number_DoubleFloat:
-      x = gc::As<Real_sp>(clasp_make_double_float(clasp_to_double(x)));
+        x = gc::As<Real_sp>(clasp_make_double_float(clasp_to_double(gc::As<Number_sp>(x))));
       break;
 #ifdef CLASP_LONG_FLOAT
     case number_LongFloat:
@@ -399,7 +399,7 @@ Real_mv clasp_floor2(Real_sp x, Real_sp y) {
     }
     break;
   case number_SingleFloat: { /* SF / ANY */
-    float n = clasp_to_double(y);
+    float n = clasp_to_double(gc::As<Number_sp>(y));
     float p = x.unsafe_single_float() / n;
     float q = floorf(p);
     v0 = _clasp_float_to_integer(q);
@@ -410,7 +410,7 @@ Real_mv clasp_floor2(Real_sp x, Real_sp y) {
     break;
   }
   case number_DoubleFloat: { /* DF / ANY */
-    double n = clasp_to_double(y);
+    double n = clasp_to_double(gc::As<Number_sp>(y));
     double p = gc::As_unsafe<DoubleFloat_sp>(x)->get() / n;
     double q = floor(p);
     v0 = _clasp_double_to_integer(q);
@@ -643,7 +643,7 @@ Real_mv clasp_ceiling2(Real_sp x, Real_sp y) {
     break;
   }
   case number_SingleFloat: { /* SF / ANY */
-    float n = clasp_to_double(y);
+    float n = clasp_to_double(gc::As<Number_sp>(y));
     float p = x.unsafe_single_float() / n;
     float q = ceilf(p);
     v0 = _clasp_float_to_integer(q);
@@ -651,7 +651,7 @@ Real_mv clasp_ceiling2(Real_sp x, Real_sp y) {
     break;
   }
   case number_DoubleFloat: { /* DF / ANY */
-    double n = clasp_to_double(y);
+    double n = clasp_to_double(gc::As<Number_sp>(y));
     double p = gc::As_unsafe<DoubleFloat_sp>(x)->get() / n;
     double q = ceil(p);
     v0 = _clasp_double_to_integer(q);

--- a/src/core/num_co.cc
+++ b/src/core/num_co.cc
@@ -116,7 +116,7 @@ CL_DEFUN Float_sp cl__float(Real_sp x, T_sp y) {
         x = gc::As<Real_sp>(clasp_make_single_float(clasp_to_double(gc::As<Number_sp>(x))));
       break;
     case number_DoubleFloat:
-        x = gc::As<Real_sp>(clasp_make_double_float(clasp_to_double(gc::As<Number_sp>(x))));
+        x = gc::As<Real_sp>(clasp_make_double_float(clasp_to_double(gc::As_unsafe<Number_sp>(x))));
       break;
 #ifdef CLASP_LONG_FLOAT
     case number_LongFloat:

--- a/src/core/numbers.cc
+++ b/src/core/numbers.cc
@@ -694,13 +694,13 @@ CL_DEFUN Number_sp contagen_div(Number_sp na, Number_sp nb) {
   case_Bignum_v_Complex : {
       Complex_sp cb = gc::As<Complex_sp>(nb);
       return complex_divide(clasp_to_double(na), 0.0,
-                            clasp_to_double(gc::As<Number_sp>(cb->real())), clasp_to_double(gc::As<Number_sp>(cb->imaginary())));
+                            clasp_to_double(gc::As_unsafe<Number_sp>(cb->real())), clasp_to_double(gc::As_unsafe<Number_sp>(cb->imaginary())));
     }
   case_Complex_v_Complex : {
       Complex_sp ca = gc::As<Complex_sp>(na);
       Complex_sp cb = gc::As<Complex_sp>(nb);
-      return complex_divide(clasp_to_double(gc::As<Number_sp>(ca->real())), clasp_to_double(gc::As<Number_sp>(ca->imaginary())),
-                            clasp_to_double(gc::As<Number_sp>(cb->real())), clasp_to_double(gc::As<Number_sp>(cb->imaginary())));
+      return complex_divide(clasp_to_double(gc::As_unsafe<Number_sp>(ca->real())), clasp_to_double(gc::As_unsafe<Number_sp>(ca->imaginary())),
+                            clasp_to_double(gc::As_unsafe<Number_sp>(cb->real())), clasp_to_double(gc::As_unsafe<Number_sp>(cb->imaginary())));
     }
   case_Ratio_v_Complex:
   case_SingleFloat_v_Complex:
@@ -708,7 +708,7 @@ CL_DEFUN Number_sp contagen_div(Number_sp na, Number_sp nb) {
   case_LongFloat_v_Complex : {
       Complex_sp cb = gc::As<Complex_sp>(nb);
       return complex_divide(clasp_to_double(na), 0.0,
-                            clasp_to_double(gc::As<Number_sp>(cb->real())), clasp_to_double(gc::As<Number_sp>(cb->imaginary())));
+                            clasp_to_double(gc::As_unsafe<Number_sp>(cb->real())), clasp_to_double(gc::As_unsafe<Number_sp>(cb->imaginary())));
     }
   }
   MATH_DISPATCH_END();

--- a/src/core/numbers.cc
+++ b/src/core/numbers.cc
@@ -694,13 +694,13 @@ CL_DEFUN Number_sp contagen_div(Number_sp na, Number_sp nb) {
   case_Bignum_v_Complex : {
       Complex_sp cb = gc::As<Complex_sp>(nb);
       return complex_divide(clasp_to_double(na), 0.0,
-                            clasp_to_double(cb->real()), clasp_to_double(cb->imaginary()));
+                            clasp_to_double(gc::As<Number_sp>(cb->real())), clasp_to_double(gc::As<Number_sp>(cb->imaginary())));
     }
   case_Complex_v_Complex : {
       Complex_sp ca = gc::As<Complex_sp>(na);
       Complex_sp cb = gc::As<Complex_sp>(nb);
-      return complex_divide(clasp_to_double(ca->real()), clasp_to_double(ca->imaginary()),
-                            clasp_to_double(cb->real()), clasp_to_double(cb->imaginary()));
+      return complex_divide(clasp_to_double(gc::As<Number_sp>(ca->real())), clasp_to_double(gc::As<Number_sp>(ca->imaginary())),
+                            clasp_to_double(gc::As<Number_sp>(cb->real())), clasp_to_double(gc::As<Number_sp>(cb->imaginary())));
     }
   case_Ratio_v_Complex:
   case_SingleFloat_v_Complex:
@@ -708,7 +708,7 @@ CL_DEFUN Number_sp contagen_div(Number_sp na, Number_sp nb) {
   case_LongFloat_v_Complex : {
       Complex_sp cb = gc::As<Complex_sp>(nb);
       return complex_divide(clasp_to_double(na), 0.0,
-                            clasp_to_double(cb->real()), clasp_to_double(cb->imaginary()));
+                            clasp_to_double(gc::As<Number_sp>(cb->real())), clasp_to_double(gc::As<Number_sp>(cb->imaginary())));
     }
   }
   MATH_DISPATCH_END();
@@ -1795,8 +1795,8 @@ double Ratio_O::as_double_() const {
     return ldexp(output, exponent);
   }
   else {
-    double d = clasp_to_double(this->_numerator);
-    d /= clasp_to_double(this->_denominator);
+    double d = clasp_to_double(gc::As<Number_sp>(this->_numerator));
+    d /= clasp_to_double(gc::As<Number_sp>(this->_denominator));
     return d;
   }
 }
@@ -3385,15 +3385,6 @@ double clasp_to_double(core::Number_sp x)
   return x->as_double_();
 };
 
-double clasp_to_double( core::Integer_sp x )
-{
-  if (x.fixnump()) {
-    double d = x.unsafe_fixnum();
-    return d;
-  }
-  return x->as_double_();
-};
-
 double clasp_to_double( core::T_sp x )
 {
   if (x.fixnump()) {
@@ -3407,38 +3398,6 @@ double clasp_to_double( core::T_sp x )
   }
   TYPE_ERROR(x,cl::_sym_Number_O);
 }
-
-double clasp_to_double( core::Real_sp x )
-{
-  if (x.fixnump()) {
-    double d = x.unsafe_fixnum();
-    return d;
-  } else if (x.single_floatp()) {
-    double d = x.unsafe_single_float();
-    return d;
-  } else if (gc::IsA<Number_sp>(x)) {
-    return gc::As_unsafe<Number_sp>(x)->as_double_();
-  }
-  TYPE_ERROR(x,Cons_O::createList(cl::_sym_Real_O));
-}
-
-double clasp_to_double( core::General_sp x )
-{
-  if (gc::IsA<Number_sp>(x)) {
-    return gc::As_unsafe<Number_sp>(x)->as_double_();
-  }
-  TYPE_ERROR(x,cl::_sym_Number_O);
-};
-
-
-double clasp_to_double( core::DoubleFloat_sp x )
-{
-  return x->get();
-};
-
-
-
-
 
 LongFloat clasp_to_long_float(Number_sp x)
 {

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -115,7 +115,7 @@ CL_DOCSTRING("sleep");
 CL_DEFUN T_sp cl__sleep(Real_sp oseconds) {
   // seconds - a non-negative real.
   SYMBOL_EXPORT_SC_(ClPkg, sleep);
-  double dsec = clasp_to_double(oseconds);
+  double dsec = clasp_to_double(gc::As<Number_sp>(oseconds));
   if (dsec < 0.0) {
     TYPE_ERROR(oseconds,Cons_O::createList(cl::_sym_float,clasp_make_single_float(0.0)));
   }

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -115,7 +115,7 @@ CL_DOCSTRING("sleep");
 CL_DEFUN T_sp cl__sleep(Real_sp oseconds) {
   // seconds - a non-negative real.
   SYMBOL_EXPORT_SC_(ClPkg, sleep);
-  double dsec = clasp_to_double(gc::As<Number_sp>(oseconds));
+  double dsec = clasp_to_double(gc::As_unsafe<Number_sp>(oseconds));
   if (dsec < 0.0) {
     TYPE_ERROR(oseconds,Cons_O::createList(cl::_sym_float,clasp_make_single_float(0.0)));
   }

--- a/src/llvmo/llvmoExpose.cc
+++ b/src/llvmo/llvmoExpose.cc
@@ -3168,7 +3168,7 @@ CL_DEFUN void llvm_sys__accumulate_llvm_usage_seconds(double time)
 {
   core::DoubleFloat_sp df = core::DoubleFloat_O::create(time);
   _sym_STARmostRecentLlvmFinalizationTimeSTAR->setf_symbolValue(df);
-  double accTime = clasp_to_double(_sym_STARaccumulatedLlvmFinalizationTimeSTAR->symbolValue());
+  double accTime = clasp_to_double(gc::As<core::Number_sp>(_sym_STARaccumulatedLlvmFinalizationTimeSTAR->symbolValue()));
   accTime += time;
   _sym_STARaccumulatedLlvmFinalizationTimeSTAR->setf_symbolValue(core::DoubleFloat_O::create(accTime));
   int num = unbox_fixnum(gc::As<core::Fixnum_sp>(_sym_STARnumberOfLlvmFinalizationsSTAR->symbolValue()));


### PR DESCRIPTION
* drop most variations of clasp_to_double, had repetitive code
* unfortunately `double clasp_to_double( core::T_sp );` is used from cando, so coudn't drop that and clasp_to_double neds ctasts in some places
* `gc::Fixnum get_fixnum(Fixnum_sp x);` is not used, so deleted
* `clasp_deliver_fpe` is not used, so deleted
* ` LongFloat           clasp_to_long_float`and `LongFloat           clasp_to_long_double` where declared twice, so dropped the second

* did compile with cando, so assure that I don't delete anything used there
