### PR TITLE
Fix off by 1 error message for array bounds check

### DIFF
--- a/src/core/array.cc
+++ b/src/core/array.cc
@@ -296,7 +296,7 @@ CL_LISPIFY_NAME("core:check-index");
 CL_DEFUN T_mv core__check_index (size_t index, size_t max, size_t axis) {
   if (!((index >= 0) && (index < max)))
     SIMPLE_ERROR(BF("Invalid index %d for axis %d of array: expected 0-%d")
-                 % index % axis % max);
+                 % index % axis % (max-1));
   return Values0<T_O>();
 }
 

--- a/src/lisp/regression-tests/array0.lisp
+++ b/src/lisp/regression-tests/array0.lisp
@@ -44,6 +44,19 @@
         (setf (aref array) 23)
         array))
 
-;;; gave segmentation violation print the error
+;;; gave segmentation violation printing the error
 (test-expect-error fill-pointer-nil-array (fill-pointer #0anil) :type type-error)
+
+;;; used to give off by 1 wrong error message about the upper bound of the limit
+;;; Right message is Invalid index 5 for axis 0 of array: expected 0-2
+(test
+ simple-array-out-of-bounds-message
+ (search "expected 0-2"
+         (let ()
+           (handler-case 
+               (locally (declare (optimize (speed 0)(safety 3)))
+                 (aref (make-array 3 :initial-element 5) 5)
+                 "nada")
+             (error (e)
+               (princ-to-string e))))))
                    

--- a/src/llvmo/builtins.cc
+++ b/src/llvmo/builtins.cc
@@ -54,7 +54,8 @@ extern "C" {
 
 gctools::return_type cm_check_index(void* index, void* max, void* axis )
 {
-  if (((intptr_t)(index)<0) || (((intptr_t)(index)>=(intptr_t)max))) invalid_index_error(index,max,axis);
+  // this test 0 <= index < max, so legal values are 0 .. max -1 
+  if (((intptr_t)(index)<0) || (((intptr_t)(index)>=(intptr_t)max))) invalid_index_error(index,(void *) ((intptr_t) max -1),axis);
   gctools::return_type result(_Nil<core::T_O>().raw_(),0);
   return result;
 }


### PR DESCRIPTION
* fixes wrong message (error itself was correct) `invalid index 21 for axis 0 of array: expected 0-21`