### PR TITLE
Export symbols from ext that are used in the wild (asdf, slime, trivial garbage)

### DIFF
--- a/src/lisp/kernel/init.lsp
+++ b/src/lisp/kernel/init.lsp
@@ -161,6 +161,12 @@
 (import 'core:quit :ext)
 (import 'core:btcl :ext)
 (import 'core:ihs-argument :ext)
+(import 'core:getpid :ext)
+(import 'core:argc :ext)
+(import 'core:argv :ext)
+(import 'core:rmdir :ext)
+(import 'core:mkstemp :ext)
+
 ;;; EXT exports
 (eval-when (:execute :compile-toplevel :load-toplevel)
   (select-package :ext))
@@ -205,7 +211,9 @@
           ihs-argument
           with-float-traps-masked
           enable-interrupt default-interrupt ignore-interrupt
-          get-signal-handler set-signal-handler))
+          get-signal-handler set-signal-handler
+          ;;; for asdf and slime and trivial-garbage to use ext:
+          getpid argc argv rmdir mkstemp weak-pointer-value make-weak-pointer weak-pointer-valid hash-table-weakness))
 (core:*make-special '*module-provider-functions*)
 (core:*make-special '*source-location*)
 (setq *source-location* nil)


### PR DESCRIPTION
* so that no symbols from `core` or from `si` are used outside of clasp
  * as step 2 - when this is merged - change asdf and slime not to use symbols from `core` or `si`
  * and document these symbols in the manual