### PR TITLE
Fix (fboundp '(setf nil)) signalling an error

### DIFF
--- a/src/lisp/regression-tests/control01.lisp
+++ b/src/lisp/regression-tests/control01.lisp
@@ -43,6 +43,11 @@
 (test-expect-error FBOUNDP.ERROR.4 (FBOUNDP '(SETF dummy . BAR)) :type type-error)
 (test-expect-error FBOUNDP.ERROR.5 (FBOUNDP '(SETF dummy BAR)) :type type-error)
 (test-expect-error FBOUNDP.ERROR.9 (FBOUNDP '(SETF . dummy)) :type type-error)
+(test-expect-error FBOUNDP.ERROR.10 (FBOUNDP '(SETF nil nil)) :type type-error)
+(test FBOUNDP.11 (null (FBOUNDP '(SETF nil))))
+(test FBOUNDP.12 (core:valid-function-name-p '(SETF nil)))
+(test FBOUNDP.13 (null (core:function-block-name '(SETF nil))))
+
 
 (test-expect-error fmakunbound.1 (fmakunbound '(setf)) :type type-error)
 (test-expect-error fmakunbound.2 (fmakunbound '(SETF dummy . BAR)) :type type-error)


### PR DESCRIPTION
* (fboundp '(setf nil)) incorrectly returned an error, now simply nil
* did dropped some useless parenthesis in the c++ code
* extended functionBlockName so that we can distinguish a BlockName of nil from and error indicated by nil and used that in the 2 callers
* added regression-tests
* did run regression-tests and ansi-tests