### PR TITLE
Correct read-byte gray streams, use io_stream_ops instead of io_file_ops for sockets

### DIFF
--- a/src/sockets/sockets.cc
+++ b/src/sockets/sockets.cc
@@ -584,13 +584,13 @@ CL_DEFUN core::T_sp sockets_internal__ll_makeStreamFromFd(const string &name,  /
   core::StreamMode direction;
   switch (streamMode) {
   case core::clasp_stream_mode_input:
-      direction = core::clasp_smm_input_file;
+      direction = core::clasp_smm_input;
     break;
   case core::clasp_stream_mode_output:
-      direction = core::clasp_smm_output_file;
+      direction = core::clasp_smm_output;
     break;
   case core::clasp_stream_mode_io:
-      direction = core::clasp_smm_io_file;
+      direction = core::clasp_smm_io;
     break;
   default: {
     SIMPLE_ERROR(BF("Illegal stream mode %d") % streamMode);


### PR DESCRIPTION
* did run ./waf test with no new problems
* did execute (drakma:http-request "http://files.rcsb.org/view/1BLJ.pdb"), works now 
```lisp
karsten-poecks-macbook-pro:clasp-karsten karstenpoeck$ build/clasp --eval "(require :asdf)" --load "~/quicklisp/setup.lisp" --eval "(ql:quickload :drakma)"
Starting cclasp-boehm-0.4.2-2700-g259fa8923-cst ... loading image...
Writing jitted symbols to /tmp/perf-43330.map
; Registering system quicklisp
To load "drakma":
  Load 1 ASDF system:
    drakma
; Loading "drakma"
; Registering system puri
; Registering system cl-base64
; Registering system chunga
; Registering system trivial-gray-streams
; Registering system flexi-streams
; Registering system cl-ppcre
; Registering system chipz
; Registering system usocket
; Registering system split-sequence
; Registering system cl+ssl
; Registering system cffi
; Registering system alexandria
; Registering system trivial-features
; Registering system babel
; Registering system bordeaux-threads
; Registering system trivial-garbage
.......
Top level in: #<PROCESS TOP-LEVEL @0x10e497019 (Running)>.
COMMON-LISP-USER> (drakma:http-request "http://files.rcsb.org/view/1BLJ.pdb")

"HEADER    PHOSPHORYLATION                         26-MAR-96   1BLJ              
TITLE     NMR ENSEMBLE OF BLK SH2 DOMAIN, 20 STRUCTURES                         
COMPND    MOL_ID: 1;                                                            
COMPND   2 MOLECULE: P55 BLK PROTEIN TYROSINE KINASE;                           
COMPND   3 CHAIN: A;                                                            
COMPND   4 FRAGMENT: SH2 DOMAIN, SRC HOMOLOGY 2;                                
COMPND   5 EC: 2.7.1.112;                                                       
COMPND   6 ENGINEERED: YES;                                                     
COMPND   7 OTHER_DETAILS: PEPTIDE FREE                                          
SOURCE    MOL_ID: 1;                                                            
SOURCE   2 ORGANISM_SCIENTIFIC: MUS MUSCULUS;                                   
SOURCE   3 ORGANISM_COMMON: HOUSE MOUSE;                                        
SOURCE   4 ORGANISM_TAXID: 10090;                                               
SOURCE   5 GENE: P55 BLK KINASE (RESIDUES 107 -;                                
SOURCE   6 EXPRESSION_SYSTEM: ESCHERICHIA COLI BL21;                            
SOURCE   7 EXPRESSION_SYSTEM_TAXID: 511693;                                     
SOURCE   8 EXPRESSION_SYSTEM_STRAIN: BL21;                                      
SOURCE   9 EXPRESSION_SYSTEM_PLASMID: PGEX-2T;                                  
.....
ATOM   1816  HB3 ALA A 114     -15.530 -10.650  -1.142  1.00  0.00           H  
TER    1817      ALA A 114                                                      
ENDMDL                                                                          
MASTER      500    0    0    2    7    0    0    636320   20    0    9          
END                                                                             
"
200
((:DATE . "Sat, 20 Jun 2020 17:44:57 GMT") (:SERVER . "Apache/2.4.29 (Ubuntu)")
 (:EXPIRES . "0")
 (:CACHE-CONTROL . "must-revalidate, post-check=0, pre-check=0")
 (:PRAGMA . "public") (:VARY . "Accept-Encoding")
 (:ACCESS-CONTROL-ALLOW-HEADERS
  . "Origin, X-Requested-With, Content-Type, Accept-Encoding")
 (:ACCESS-CONTROL-ALLOW-METHODS . "GET, HEAD, DNT")
 (:ACCESS-CONTROL-ALLOW-ORIGIN . "*")
 (:CONTENT-TYPE . "text/plain;charset=UTF-8") (:CONNECTION . "close")
 (:TRANSFER-ENCODING . "chunked") (:X-BACKEND-SERVER . "10.100.75.19"))
#<URI http://files.rcsb.org/view/1BLJ.pdb>
#<FLEXI-STREAMS:FLEXI-IO-STREAM>
T
"OK"
````