### PR TITLE
Special case printing 0 + test

### DIFF
--- a/src/core/numberToString.cc
+++ b/src/core/numberToString.cc
@@ -133,6 +133,10 @@ CL_DEFUN StrNs_sp core__integer_to_string(StrNs_sp buffer, Integer_sp integer,
   if (integer.fixnump()) {
     char txt[64];
     gc::Fixnum fn = unbox_fixnum(gc::As<Fixnum_sp>(integer));
+    if (fn == 0) {
+      StringPushStringCharStar(buffer,"0");
+      return buffer;
+    };
     if (fn < 0) {
       StringPushStringCharStar(buffer,"-");
       fn = - fn;

--- a/src/lisp/regression-tests/printer01.lisp
+++ b/src/lisp/regression-tests/printer01.lisp
@@ -453,5 +453,6 @@ BBBBCCCC**DDDD"))
 (test print-0-strange-radix
       (string= "0"
                (LET ((*PRINT-READABLY* NIL))
-                 (WITH-OUTPUT-TO-STRING (*STANDARD-OUTPUT*)
-                   (PRIN1 0)))))
+                 (LET ((*PRINT-BASE* 7))
+                   (WITH-OUTPUT-TO-STRING (*STANDARD-OUTPUT*)
+                     (PRIN1 0))))))

--- a/src/lisp/regression-tests/printer01.lisp
+++ b/src/lisp/regression-tests/printer01.lisp
@@ -450,4 +450,8 @@ BBBBCCCCDDDD"))
        "AA  
 BBBBCCCC**DDDD"))
 
-
+(test print-0-strange-radix
+      (string= "0"
+               (LET ((*PRINT-READABLY* NIL))
+                 (WITH-OUTPUT-TO-STRING (*STANDARD-OUTPUT*)
+                   (PRIN1 0)))))


### PR DESCRIPTION
fixes
`(LET ((*PRINT-BASE* 7))(core:write-object 0 *standard-output*))
-> ... set fill-pointer 18446744073709551615 past vector size 256`
by special case for 0 in order not to go bignum