### PR TITLE
Make make-array more robust + regression-tests

### DIFF
--- a/src/core/array.cc
+++ b/src/core/array.cc
@@ -745,9 +745,12 @@ size_t calculateArrayTotalSizeAndValidateDimensions(List_sp dim_desig, size_t& r
    // we are in an allocator here
   for ( auto cur : dim_desig ) {
     T_sp tdim = oCar(cur);
-    if (!tdim.fixnump()) SIMPLE_ERROR(BF("Array dimension %s must be an integer") % _rep_(tdim));
+    if (!tdim.fixnump())
+      // Implicitely tests cl::_sym_arrayTotalSizeLimit, since this is most_positive_fixnum
+      TYPE_ERROR(tdim,cl::_sym_UnsignedByte);
     Fixnum fdim = tdim.unsafe_fixnum();
-    if (fdim<0) SIMPLE_ERROR(BF("Array dimensions %d must be positive") % fdim);
+    if (fdim<0)
+      TYPE_ERROR(tdim,cl::_sym_UnsignedByte);
     size_t dim = fdim;
     arrayTotalSize *= dim;
     ++rank;

--- a/src/lisp/kernel/lsp/arraylib.lsp
+++ b/src/lisp/kernel/lsp/arraylib.lsp
@@ -88,6 +88,8 @@ contiguous block."
      (let ((dim (if (fixnump dimensions)
 		    dimensions
 		    (car dimensions))))
+       (unless (and (fixnump dim)(< -1 dim array-total-size-limit))
+         (error 'type-error :datum dim :expected-type 'ext:array-index))
        (let ((x (make-vector upgraded-element-type dim adjustable fill-pointer displaced-to displaced-index-offset
                              initial-element initial-element-supplied-p)))
          (when (and displaced-to initial-element-supplied-p)
@@ -105,7 +107,7 @@ contiguous block."
        (when (and displaced-to initial-element-supplied-p)
          (fill-array-with-elt x initial-element 0 nil))
        x))
-    (t (error "Illegal dimensions ~a for make-array" dimensions))))
+    (t (error 'type-error :datum dimensions :expected-type 'ext:array-index))))
 
 (defun array-in-bounds-p (array &rest indices)
   "Args: (array &rest indexes)

--- a/src/lisp/regression-tests/array0.lisp
+++ b/src/lisp/regression-tests/array0.lisp
@@ -59,4 +59,55 @@
                  "nada")
              (error (e)
                (princ-to-string e))))))
+
+;;; Drmeister on #clasp
+;;; Bike: (make-array '(nil 5)) doesn't generate an error but it should
+
+(test-expect-error array-too-big
+                   (make-array (1+ array-total-size-limit))
+                   :type type-error)
+
+(test-expect-error array-too-big-list
+                   (make-array (list (1+ array-total-size-limit)))
+                   :type type-error)
+
+(test-expect-error array-wrong-dimension-list-a
+                   (make-array (list nil 13))
+                   :type type-error)
+
+(test-expect-error array-wrong-dimension-list-b
+                   (make-array (list #\a 13))
+                   :type type-error)
+
+(test-expect-error array-wrong-dimension-list-c
+                   (make-array (list -13))
+                   :type type-error)
+
+;;; and w/o compiler-macro
+(test-expect-error array-too-big-not-inline
+                   (locally (declare (notinline make-array))
+                     (make-array (1+ array-total-size-limit)))
+                   :type type-error)
+
+(test-expect-error array-too-big-list-not-inline
+                    (locally (declare (notinline make-array))
+                      (make-array (list (1+ array-total-size-limit))))
+                   :type type-error)
+
+(test-expect-error array-wrong-dimension-list-a-not-inline
+                   (locally (declare (notinline make-array))
+                     (make-array (list nil 13)))                 
+                   :type type-error)
+
+(test-expect-error array-wrong-dimension-list-b-not-inline
+                    (locally (declare (notinline make-array))
+                      (make-array (list #\a 13)))
+                   :type type-error)
+
+(test-expect-error array-wrong-dimension-list-c-not-inline
+                    (locally (declare (notinline make-array))
+                      (make-array (list -13)))
+                   :type type-error)
+
+
                    


### PR DESCRIPTION
* better (type)-error in calculateArrayTotalSizeAndValidateDimensions
* more type-checks in make-array
* regression-tests for all (and they found more errors) with and w/o the compiler-macro 