### PR TITLE
Relax criteria for congruent lambda lists wrt &allow-other-keys

### DIFF
--- a/src/lisp/kernel/clos/fixup.lsp
+++ b/src/lisp/kernel/clos/fixup.lsp
@@ -241,7 +241,6 @@
 (defun congruent-lambda-p (l1 l2)
   (multiple-value-bind (r1 opts1 rest1 key-flag1 keywords1 a-o-k1)
       (core:process-lambda-list l1 'FUNCTION)
-    (declare (ignore a-o-k1))
     (multiple-value-bind (r2 opts2 rest2 key-flag2 keywords2 a-o-k2)
 	(core:process-lambda-list l2 'FUNCTION)
       (and (= (length r2) (length r1))
@@ -252,6 +251,12 @@
            ;; must be accepted by the method.
            (or (null key-flag1)
                (null key-flag2)
+               ;; Testing for a-o-k1 here may not be conformant when
+               ;; the fourth point of 7.6.4 is read literally, but it
+               ;; is more consistent with the generic function calling
+               ;; specification. Also it is compatible with popular
+               ;; implementations like SBCL and CCL. -- jd 2020-04-07
+               a-o-k1
                a-o-k2
                (null (set-difference (all-keywords keywords1)
                                      (all-keywords keywords2))))

--- a/src/lisp/regression-tests/clos.lisp
+++ b/src/lisp/regression-tests/clos.lisp
@@ -108,8 +108,13 @@
   (call-next-method)
   23)
 
-(test  test-issue-1031
-  (not (numberp (make-instance ' %foo-1 :a 1))))
+(test test-issue-1031
+      (not (numberp (make-instance '%foo-1 :a 1))))
+
+(defgeneric congruent-gf (a &key b &allow-other-keys))
+(test clos-lambda-list-congruent-allow-other-keys
+      (defmethod congruent-gf (a &key)
+        a))
  
 
 


### PR DESCRIPTION
Shortly discussed on #clasp

Taken from https://gitlab.com/embeddable-common-lisp/ecl/-/commit/0e6016559ecc914f1f83c1fb2bd19ab0cbee1508
* Fixes the issue from the regression-test
* Allows to compile mcclim w/o changes again