### PR TITLE
Cleanup numbers declarations

### DIFF
--- a/include/clasp/core/numbers.fwd.h
+++ b/include/clasp/core/numbers.fwd.h
@@ -44,51 +44,18 @@ FORWARD(Complex);
 FORWARD(Ratio);
 FORWARD(Bool);
 
-   typedef double LongFloat;
-
-   Fixnum clasp_to_fixnum( core::T_sp );
-   Fixnum clasp_to_fixnum( core::Integer_sp );
-   double clasp_to_double( core::Number_sp );
-   double clasp_to_double( core::T_sp );
-   double clasp_to_double( core::General_sp );
-   double clasp_to_double( core::Number_sp );
-   double clasp_to_double( core::Real_sp );
-   double clasp_to_double( core::Integer_sp );
-   double clasp_to_double( core::DoubleFloat_sp );
-   Fixnum_sp clasp_make_fixnum(gc::Fixnum i);
-   Fixnum_sp make_fixnum(gc::Fixnum i);
-   SingleFloat_sp clasp_make_single_float(float d);
-   DoubleFloat_sp clasp_make_double_float(double d);
-
-   size_t            clasp_to_size( core::T_sp );
+   double     clasp_to_double( core::Number_sp );
+   double     clasp_to_double( core::T_sp );
+   double     clasp_to_double( core::General_sp );
+   double     clasp_to_double( core::Number_sp );
+   double     clasp_to_double( core::Real_sp );
+   double     clasp_to_double( core::Integer_sp );
+   double     clasp_to_double( core::DoubleFloat_sp );
    Integer_sp clasp_make_integer(size_t i);
-
-
-  Fixnum              clasp_to_fixnum( core::T_sp );
-  short               clasp_to_short( core::T_sp );
-  unsigned short      clasp_to_ushort( core::T_sp );
-  int                 clasp_to_int( core::T_sp );
-  unsigned int        clasp_to_uint( core::T_sp );
-  long                clasp_to_long( core::T_sp );
-  unsigned long       clasp_to_ulong( core::T_sp );
-  long long           clasp_to_longlong( core::T_sp );
-  unsigned long long  clasp_to_ulonglong( core::T_sp );
-  int8_t              clasp_to_int8_t( core::T_sp );
-  uint8_t             clasp_to_uint8_t( core::T_sp );
-  int16_t             clasp_to_int16_t( core::T_sp );
-  uint16_t            clasp_to_uint16_t( core::T_sp );
-  int32_t             clasp_to_int32_t( core::T_sp );
-  uint32_t            clasp_to_uint32_t( core::T_sp );
-  int64_t             clasp_to_int64_t( core::T_sp );
-  uint64_t            clasp_to_uint64_t( core::T_sp );
-
-  uintptr_t           clasp_to_uintptr_t( core::T_sp );
-  mpz_class           clasp_to_mpz( core::T_sp );
-  size_t            clasp_to_size( core::T_sp );
-
-  LongFloat           clasp_to_long_float( core::Number_sp );
-  LongFloat           clasp_to_long_double( core::Number_sp );
-
+   // The following should be deleted, but is used in cando/energyRigidBodyNonbond.cc
+   size_t     clasp_to_size( core::T_sp );
+   // This is what should be called
+   size_t     clasp_to_size_t( core::T_sp );
 
 }
 #endif

--- a/include/clasp/core/numbers.h
+++ b/include/clasp/core/numbers.h
@@ -368,8 +368,7 @@ namespace core {
 namespace core {
 
   Fixnum_sp make_fixnum(gc::Fixnum x);
-  gc::Fixnum get_fixnum(Fixnum_sp x);
-
+  
   class Fixnum_dummy_O : public Integer_O {
     LISP_CLASS(core, ClPkg, Fixnum_dummy_O, "fixnum",Integer_O);
   };
@@ -694,8 +693,6 @@ namespace core {
     Ratio_O() : _numerator(clasp_make_fixnum(0)), _denominator(clasp_make_fixnum(1)) {};
     virtual ~Ratio_O() {};
   };
-
-  void clasp_deliver_fpe(int status);
 
   inline Number_sp clasp_plus(Number_sp na, Number_sp nb) { return contagen_add(na, nb); };
   inline Number_sp clasp_minus(Number_sp na, Number_sp nb) { return contagen_sub(na, nb); };
@@ -1069,12 +1066,10 @@ namespace core {
   uint64_t            clasp_to_uint64_t( core::T_sp );
   uintptr_t           clasp_to_uintptr_t( core::T_sp );
   intptr_t            clasp_to_intptr_t( core::T_sp );
-  size_t              clasp_to_size_t( core::T_sp );
   ssize_t             clasp_to_ssize_t( core::T_sp );
   mpz_class           clasp_to_mpz( core::T_sp );
 
   float               clasp_to_float( core::Number_sp );
-  double              clasp_to_double( core::Number_sp );
   LongFloat           clasp_to_long_float( core::Number_sp );
   LongFloat           clasp_to_long_double( core::Number_sp );
 


### PR DESCRIPTION
* replaces #1004 
* gc::Fixnum get_fixnum(Fixnum_sp x); is not used, so deleted
* clasp_deliver_fpe is not used, so deleted
* tested with
    * compiled including cando
    * regression tests
    * ansi-tests
    * starting icando-boehm (that compiles lots of quicklisp packages)