### PR TITLE
Add more sources to TAGS (to implement meta-dot for c++ sources & mps sources)

### DIFF
--- a/makefile
+++ b/makefile
@@ -33,6 +33,11 @@ TAGS:
 	rm TAGS
 	find src/ -type f -iname "*.cc" | etags --append -
 	find include/ -type f -iname "*.h" | etags --append -
+#build time configs
+	find build/ -type f -iname "*.h" | etags --append -
+#mps
+	find src/mps/code/ -type f -iname "*.h" | etags --append -
+	find src/mps/code/ -type f -iname "*.c" | etags --append -
 
 pull-sicl-master:
 	(cd src/lisp/kernel/contrib/sicl && git pull origin master)


### PR DESCRIPTION
* slightly improve TAGS for editing the c++ sures in emacs
  * include also mps
  * build time configs
* does not change any code, just tag generation with make TAGS