### PR TITLE
handle llvm version (potentially 2-digit) better in wscript

### DIFF
--- a/wscript
+++ b/wscript
@@ -956,8 +956,8 @@ def configure(cfg):
 
     cur_clang_version = run_llvm_config(cfg, "--version")
     log.debug("cur_clang_version = %s", cur_clang_version)
-    llvm_version_test = not ("LLVM_VERSION_OVERRIDE" in cfg.env)
-    if (llvm_version_test and (int(cur_clang_version[0]) != LLVM_VERSION)):
+    llvm_version_test = not ("LLVM_VERSION_OVERRIDE" in cfg.env)#    if (llvm_version_test and (int(cur_clang_version[0]) != LLVM_VERSION)):
+    if (llvm_version_test and (int(cur_clang_version.split('.')[0]) != LLVM_VERSION)):
         raise Exception("You must have clang/llvm version %d installed - you have %s" % (LLVM_VERSION, cur_clang_version[0]) )
     # find a lisp for the scraper
     if not cfg.env.SCRAPER_LISP:

--- a/wscript
+++ b/wscript
@@ -956,7 +956,7 @@ def configure(cfg):
 
     cur_clang_version = run_llvm_config(cfg, "--version")
     log.debug("cur_clang_version = %s", cur_clang_version)
-    llvm_version_test = not ("LLVM_VERSION_OVERRIDE" in cfg.env)#    if (llvm_version_test and (int(cur_clang_version[0]) != LLVM_VERSION)):
+    llvm_version_test = not ("LLVM_VERSION_OVERRIDE" in cfg.env)
     if (llvm_version_test and (int(cur_clang_version.split('.')[0]) != LLVM_VERSION)):
         raise Exception("You must have clang/llvm version %d installed - you have %s" % (LLVM_VERSION, cur_clang_version[0]) )
     # find a lisp for the scraper


### PR DESCRIPTION
* as discussed on #clasp
  * prepare for 2-digit llvm number
  * contributed by `docl`