### PR TITLE
Change name of transform.

### DIFF
--- a/src/lisp/kernel/cleavir/translate-bir.lisp
+++ b/src/lisp/kernel/cleavir/translate-bir.lisp
@@ -958,7 +958,7 @@
 (defun bir-transformations (module env)
   (cleavir-bir-transformations:module-eliminate-catches module)
   (cleavir-bir-transformations:find-module-local-calls module)
-  (cleavir-bir-transformations:delete-temporary-variables module)
+  (cleavir-bir-transformations:module-optimize-variables module)
   (cc-bir-to-bmir:reduce-module-typeqs module)
   (cc-bir-to-bmir:reduce-module-primops module)
   (eliminate-load-time-value-inputs


### PR DESCRIPTION
It's no longer called delete-temporary-variables and does more.