### PR TITLE
Added bounds checks for elt, have all errors use CORE:SEQUENCE-OUT-OF-BOUNDS

### DIFF
--- a/src/core/cons.cc
+++ b/src/core/cons.cc
@@ -465,16 +465,30 @@ T_sp Cons_O::setf_nth(cl_index index, T_sp val) {
 
 T_sp Cons_O::elt(cl_index index) const {
   _OF();
-  if (index < 0 || index >= this->length()) {
-    SIMPLE_ERROR(BF("Illegal index %d for Cons containing %d elements") % index % this->length());
+  size_t max = this->length();
+  unlikely_if (index < 0 || index >= max) {
+    ERROR(core::_sym_sequence_out_of_bounds,
+          core::lisp_createList(kw::_sym_expected_type,
+                                core::lisp_createList(cl::_sym_integer,
+                                                      clasp_make_fixnum(0),
+                                                      core::lisp_createList(clasp_make_fixnum(max))),
+                                kw::_sym_datum, clasp_make_fixnum(index),
+                                kw::_sym_object, this->asSmartPtr()));
   }
   return ((this->onth(index)));
 }
 
 T_sp Cons_O::setf_elt(cl_index index, T_sp value) {
   _OF();
-  if (index < 0 || index >= this->length()) {
-    SIMPLE_ERROR(BF("Illegal index %d for Cons containing %d elements") % index % this->length());
+  size_t max = this->length();
+  unlikely_if (index < 0 || index >= this->length()) {
+    ERROR(core::_sym_sequence_out_of_bounds,
+          core::lisp_createList(kw::_sym_expected_type,
+                                core::lisp_createList(cl::_sym_integer,
+                                                      clasp_make_fixnum(0),
+                                                      core::lisp_createList(clasp_make_fixnum(max))),
+                                kw::_sym_datum, clasp_make_fixnum(index),
+                                kw::_sym_object, this->asSmartPtr()));
   }
   return ((this->setf_nth(index, value)));
 }

--- a/src/core/sequence.cc
+++ b/src/core/sequence.cc
@@ -165,7 +165,14 @@ CL_DEFUN T_sp core__setf_elt(T_sp sequence, size_t index, T_sp value) {
     sequence.unsafe_cons()->setf_elt(index, value);
     return value;
   } else if (sequence.nilp()) {
-    TYPE_ERROR(sequence, cl::_sym_sequence);
+    // nil is a sequence, so can't type error on sequence
+    ERROR(core::_sym_sequence_out_of_bounds,
+            core::lisp_createList(kw::_sym_expected_type,
+                                  core::lisp_createList(cl::_sym_integer,
+                                                        clasp_make_fixnum(0),
+                                                        core::lisp_createList(clasp_make_fixnum(0))),
+                                  kw::_sym_datum, clasp_make_fixnum(index),
+                                  kw::_sym_object, sequence));
   } else if (Vector_sp vsequence = sequence.asOrNull<Vector_O>()) {
     size_t max = vsequence->length();
     unlikely_if (index < 0 || index >= max)

--- a/src/core/sequence.cc
+++ b/src/core/sequence.cc
@@ -132,8 +132,17 @@ CL_DEFUN T_sp cl__elt(T_sp sequence, size_t index) {
     return sequence.unsafe_cons()->elt(index);
   } else if (sequence.nilp()) {
     TYPE_ERROR(sequence, cl::_sym_sequence);
-  } else if (Vector_sp vseq = sequence.asOrNull<Vector_O>()) {
-    return vseq->rowMajorAref(index);
+  } else if (Vector_sp vsequence = sequence.asOrNull<Vector_O>()) {
+    size_t max = vsequence->length();
+    unlikely_if (index < 0 || index >= max)
+      ERROR(core::_sym_sequence_out_of_bounds,
+            core::lisp_createList(kw::_sym_expected_type,
+                                  core::lisp_createList(cl::_sym_integer,
+                                                        clasp_make_fixnum(0),
+                                                        core::lisp_createList(clasp_make_fixnum(max))),
+                                  kw::_sym_datum, clasp_make_fixnum(index),
+                                  kw::_sym_object, vsequence));
+    return vsequence->rowMajorAref(index);
   } else {
     T_sp tindex = clasp_make_fixnum(index);
     return eval::funcall(seqext::_sym_elt, sequence, tindex);
@@ -151,6 +160,15 @@ CL_DEFUN T_sp core__setf_elt(T_sp sequence, size_t index, T_sp value) {
   } else if (sequence.nilp()) {
     TYPE_ERROR(sequence, cl::_sym_sequence);
   } else if (Vector_sp vsequence = sequence.asOrNull<Vector_O>()) {
+    size_t max = vsequence->length();
+    unlikely_if (index < 0 || index >= max)
+      ERROR(core::_sym_sequence_out_of_bounds,
+            core::lisp_createList(kw::_sym_expected_type,
+                                  core::lisp_createList(cl::_sym_integer,
+                                                        clasp_make_fixnum(0),
+                                                        core::lisp_createList(clasp_make_fixnum(max))),
+                                  kw::_sym_datum, clasp_make_fixnum(index),
+                                  kw::_sym_object, vsequence));
     vsequence->rowMajorAset(index, value);
     return value;
   } else {

--- a/src/core/sequence.cc
+++ b/src/core/sequence.cc
@@ -131,7 +131,14 @@ CL_DEFUN T_sp cl__elt(T_sp sequence, size_t index) {
   if (sequence.consp()) {
     return sequence.unsafe_cons()->elt(index);
   } else if (sequence.nilp()) {
-    TYPE_ERROR(sequence, cl::_sym_sequence);
+    // nil is a sequence, so can't type error on sequence
+    ERROR(core::_sym_sequence_out_of_bounds,
+            core::lisp_createList(kw::_sym_expected_type,
+                                  core::lisp_createList(cl::_sym_integer,
+                                                        clasp_make_fixnum(0),
+                                                        core::lisp_createList(clasp_make_fixnum(0))),
+                                  kw::_sym_datum, clasp_make_fixnum(index),
+                                  kw::_sym_object, sequence));
   } else if (Vector_sp vsequence = sequence.asOrNull<Vector_O>()) {
     size_t max = vsequence->length();
     unlikely_if (index < 0 || index >= max)


### PR DESCRIPTION
* Cons_O::elt already had a bounds check, just but the correct error
* Cons_O::setf_elt dito
* for the vector case, put checks in
  * cl__elt
  * core__setf_elt
* fix error message for (elt nil <an-index>), nil is a sequence
* and the same for (setf (elt ...))