### PR TITLE
Shadow cl:load, so that it can be used as a class in clasp-cleavir-bmir

### DIFF
--- a/src/lisp/kernel/cleavir/packages.lisp
+++ b/src/lisp/kernel/cleavir/packages.lisp
@@ -211,7 +211,7 @@
 
 (defpackage #:clasp-cleavir-bmir
   (:nicknames #:cc-bmir)
-  (:shadow #:characterp #:consp)
+  (:shadow #:characterp #:consp #:load)
   (:export #:fixnump #:characterp #:consp #:single-float-p #:generalp
            #:headerq #:info)
   (:export #:memref2 #:offset #:load #:store))


### PR DESCRIPTION
* to solve ansi-test `ALL-EXPORTED-CL-CLASS-NAMES-ARE-VALID`