### PR TITLE
Use Eclectors without-signal branch (rebased to latest clasp)

### DIFF
--- a/wscript
+++ b/wscript
@@ -295,8 +295,8 @@ def update_dependencies(cfg):
                        "https://github.com/robert-strandh/Acclimation.git",
                        "dd15c86b0866fc5d8b474be0da15c58a3c04c45c")
     fetch_git_revision("src/lisp/kernel/contrib/Eclector",
-                       "https://github.com/clasp-developers/Eclector.git",
-                       "fa652c5d9750c4cbdc43082a3e07243bd2e265e4")
+                       "https://github.com/s-expressionists/Eclector.git",
+                       label = "without-signal", revision = "e92cf239783be90c97e80aff2a14d65778a38325")
                        # "7e9561c410897d499b581f6a8e98cbbd17cd7a81")
 #"66cf5e2370eef4be659212269272a5e79a82fa1c")
 #                      "7b63e7bbe6c60d3ad3413a231835be6f5824240a") works with AST clasp


### PR DESCRIPTION
* as discussed on #sicl : use the without-signal branch (has been rebased and contains all latest fixes)
* tested with
  * regression tests
  * ansi-tests
  * icando-boehm