### PR TITLE
Add regression test for unwinding.

### DIFF
--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -39,6 +39,7 @@
 (load-if-compiled-correctly "sys:regression-tests;control01.lisp")
 (load-if-compiled-correctly "sys:regression-tests;loop.lisp")
 (load-if-compiled-correctly "sys:regression-tests;numbers-core.lisp")
+(load-if-compiled-correctly "sys:regression-tests;unwind.lisp")
 #+unicode
 (load-if-compiled-correctly "sys:regression-tests;encodings.lisp")
 (load-if-compiled-correctly "sys:regression-tests;system-construction.lisp")

--- a/src/lisp/regression-tests/unwind.lisp
+++ b/src/lisp/regression-tests/unwind.lisp
@@ -1,0 +1,7 @@
+(in-package #:clasp-tests)
+
+;; Assert that this compilation does not invoke any unwinds.
+(test compile-file-no-unwind
+      (let ((unwinds (gctools:thread-local-unwinds)))
+        (cmp::compile-file-serial "sys:kernel;lsp;predlib.lsp")
+        (= unwinds (gctools:thread-local-unwinds))))


### PR DESCRIPTION
Make sure we don't unwind while compiling. (This is really a check on Eclector being optimized well.)