### PR TITLE
Fix handling of compiler conditions, so that source information is reported

### DIFF
--- a/src/lisp/kernel/cleavir/setup.lisp
+++ b/src/lisp/kernel/cleavir/setup.lisp
@@ -406,8 +406,12 @@ when this is t a lot of graphs will be generated.")
 (defmethod cmp:compiler-condition-origin
     ((condition cleavir-conditions:program-condition))
   ;; FIXME: ignore-errors is a bit paranoid
-  (ignore-errors (car (cleavir-conditions:origin condition))))
-
+  (let ((origin (cleavir-conditions:origin condition)))
+    (ignore-errors
+     (if (consp origin)
+         (car origin)
+         origin))))
+         
 (defun build-and-draw-ast (filename cst)
   (let ((ast (cleavir-cst-to-ast:cst-to-ast cst *clasp-env* *clasp-system*)))
     (cleavir-ast-graphviz:draw-ast ast filename)

--- a/src/lisp/kernel/cmp/compiler-conditions.lsp
+++ b/src/lisp/kernel/cmp/compiler-conditions.lsp
@@ -166,19 +166,20 @@
 
 (defmethod print-compiler-condition :after (condition)
   (let ((origin (compiler-condition-origin condition)))
-    (when origin
-      (let (;; deal with start/end pairs
-            (origin (if (consp origin) (car origin) origin)))
-        (handler-case
-            (format *error-output* "~&    at ~a ~d:~d~%"
-                    (file-scope-pathname
-                     (file-scope origin))
-                    (source-pos-info-lineno origin)
-                    (source-pos-info-column origin))
-          (error (e)
-            ;; Recursive errors are annoying. Therefore,
-            (format *error-output* "~&    at #<error printing origin ~a>~%"
-                    origin)))))))
+    (cond (origin
+           (let (;; deal with start/end pairs
+                 (origin (if (consp origin) (car origin) origin)))
+             (handler-case
+                 (format *error-output* "~&    at ~a ~d:~d~%"
+                         (file-scope-pathname
+                          (file-scope origin))
+                         (source-pos-info-lineno origin)
+                         (source-pos-info-column origin))
+               (error ()
+                 ;; Recursive errors are annoying. Therefore,
+                 (format *error-output* "~&    at #<error printing origin ~a>~%"
+                         origin)))))
+          (t (format *error-output* "~&    at unknown source~%")))))
 
 (defun format-compiler-condition (what condition)
   (format *error-output* "caught ~S:~%~@<  ~@;~A~:>" what condition))


### PR DESCRIPTION
* The parallel compiler did not use the compiler condition infrastructure properly, so that  
  * compiler-error-handler
  * compiler-style-warning-handler
  * compiler-warning-handler
  * were not called, and consequently source positions were not reported (since print-compiler-condition was not used)

* fixed that `(cmp:compiler-condition-origin cleavir-conditions:program-condition)`crashed since it expected a cons of origins, but `clean-up-variable` just puts 1 origin
* To make explicit where we don't find origin information I added `    at unknown source` when we report a condition without origin

* what still is to be done, but i'd tackle that separately, is that `*compiler-error-count*` and friends don't communicate over threads, so the numbers reported in `compilation-unit-finished` are not correct

* `clean-up-variable` is just present in bir, thats why i developed all that in bir