### PR TITLE
Convert TYPEQ-TEST instead of TYPEQ.

### DIFF
--- a/wscript
+++ b/wscript
@@ -288,7 +288,7 @@ def update_dependencies(cfg):
     log.pprint('BLUE', 'update_dependencies()')
     fetch_git_revision("src/lisp/kernel/contrib/Cleavir",
                        "https://github.com/s-expressionists/Cleavir",
-                       "7166084dc669413f9031a773cfa46436d20aba8a")
+                       "3ac9e70a7263dde5cc6bca2b072f3e5c37cb5a23")
     fetch_git_revision("src/lisp/kernel/contrib/Concrete-Syntax-Tree",
                        "https://github.com/s-expressionists/Concrete-Syntax-Tree.git",
                        "ffade18bb5b390d9aee960d587701367f4aac92b")


### PR DESCRIPTION
Update for Cleavir change which also lets us constant fold TYPEQs.