### PR TITLE
Fix incorrect declarations in list-length, add type check for input-parameter

### DIFF
--- a/src/lisp/kernel/lsp/assorted.lsp
+++ b/src/lisp/kernel/lsp/assorted.lsp
@@ -11,12 +11,15 @@
 (defun list-length (list)
   "Return the length of the given list, or NIL if the list is circular."
   ;; from sbcl (public domain)
+  (check-type list list) 
   (do ((n 0 (+ n 2))
        (y list (cddr y))
        (z list (cdr z)))
       (nil)
     (declare (type fixnum n) ; fix if list lengths can be more than fixnums
-	     (type list y z))
+             ;;; both cdr and cddr of a list might not return a list,
+             ;;; e.g.  (car '(A B . C))
+	     #+(or)(type list y z))
     (when (endp y) (return n))
     (when (endp (cdr y)) (return (1+ n)))
     (when (and (eq y z) (plusp n)) (return nil))))

--- a/src/lisp/regression-tests/cons01.lisp
+++ b/src/lisp/regression-tests/cons01.lisp
@@ -124,3 +124,6 @@
 (test-expect-error  ASSOC-IF-NOT.ERROR.12 (ASSOC-IF-NOT #'IDENTITY '((A . B) :BAD (C . D))) :type type-error)
 
 (test remf-failure-cl-http (let ((place (list 9000 23)))(remf place 9000)))
+
+(test-expect-error LIST-LENGTH-SYMBOL (LIST-LENGTH 'A) :type type-error)
+(test-expect-error LIST-LENGTH.ERROR.1 (list-length '(1 . 2)) :type type-error)


### PR DESCRIPTION
* list as an input parameter must be a list, ifnot should raise a type error
* (declare ... (type list y z)) is not correct, since cddr and cdr might return type t and not necessary a list
* added proper regression tests