### PR TITLE
Compile-file should return a truename

### DIFF
--- a/src/lisp/kernel/cmp/compile-file-parallel.lsp
+++ b/src/lisp/kernel/cmp/compile-file-parallel.lsp
@@ -455,7 +455,7 @@ Each bitcode filename will contain the form-index.")
                      nil)
                     ;; Usual result
                     (t (output-cfp-result ast-jobs output-path output-type)
-                       output-path)))))))))
+                       (truename output-path))))))))))
 
 (defun cl:compile-file (input-file &rest args &key (output-type (default-library-type) output-type-p)
                                                 output-file (verbose *compile-verbose*) &allow-other-keys)

--- a/src/lisp/kernel/cmp/compile-file.lsp
+++ b/src/lisp/kernel/cmp/compile-file.lsp
@@ -347,9 +347,10 @@ Compile a lisp source file into an LLVM module."
   (let* ((*compile-file-parallel* nil))
     (if (not output-file-p) (setq output-file (cfp-output-file-default input-file output-type)))
     (with-compiler-env ()
-      (let* ((output-path (if output-type-p
-                              (compile-file-pathname input-file :output-file output-file :output-type output-type)
-                              (compile-file-pathname input-file :output-file output-file)))
+      (let* ((output-path
+               (if output-type-p
+                    (compile-file-pathname input-file :output-file output-file :output-type output-type)
+                    (compile-file-pathname input-file :output-file output-file)))
              (*track-inlined-functions* (make-hash-table :test #'equal))
              (output-info-pathname (when output-info (make-pathname :type "info" :defaults output-path)))
              (*compilation-module-index* 0) ; FIXME: necessary?
@@ -382,7 +383,7 @@ Compile a lisp source file into an LLVM module."
                                           :position image-startup-position)
               (when output-info-pathname (generate-info input-file output-info-pathname))
               (gctools:thread-local-cleanup)
-              output-path)))))))
+              (truename output-path))))))))
 
 (defun reloc-model ()
   (cond


### PR DESCRIPTION
Function COMPILE-FILE
Syntax:
compile-file input-file &key output-file verbose print external-format
=> output-truename, warnings-p, failure-p
...
output-truename---a pathname (the truename of the output file), or nil.

Fixes ansi-tests:
* COMPILE-FILE.17
* COMPILE-FILE.18