### PR TITLE
Solve symbol clash for core:test, don't use :core in test package, update latest regressions

### DIFF
--- a/src/lisp/regression-tests/conditions.lisp
+++ b/src/lisp/regression-tests/conditions.lisp
@@ -1,0 +1,7 @@
+(in-package #:clasp-tests)
+
+(test CERROR.6
+      (= 10
+         (locally (declare (optimize (safety 3)))
+           (HANDLER-BIND ((SIMPLE-ERROR #'(LAMBDA (C) (CONTINUE C))))
+             (PROGN (CERROR "Wooo" 'SIMPLE-ERROR) 10)))))

--- a/src/lisp/regression-tests/finalizers.lisp
+++ b/src/lisp/regression-tests/finalizers.lisp
@@ -42,7 +42,7 @@
 ;;;
 ;;; Test finalizing general objects
 (defun bar (n)
-  (setq *a* (bformat nil "Hi there %s" n)))
+  (setq *a* (core:bformat nil "Hi there %s" n)))
 (bar 5)
 (format t "*a* -> ~a~%" *a*)
 (setq *count* 0)

--- a/src/lisp/regression-tests/framework.lisp
+++ b/src/lisp/regression-tests/framework.lisp
@@ -1,5 +1,5 @@
 (defpackage #:clasp-tests
-    (:use :cl :core)
+    (:use :cl)
   (:export #:test #:test-expect-error))
 
 (in-package #:clasp-tests)

--- a/src/lisp/regression-tests/loop.lisp
+++ b/src/lisp/regression-tests/loop.lisp
@@ -85,3 +85,11 @@
  (equalp
   (loop with (a b) = '(1 nil) for (c d) = '(2 nil) do (return (list a b c d)))
   '(1 nil 2 nil)))
+
+;;; https://github.com/clasp-developers/clasp/issues/1109
+(test loop.13.29
+      (eq :good (loop named foo for i = 1 then (return-from foo :good))))
+
+(test loop.13.69
+      (eq :good
+          (block nil (loop named foo for i on '(a b c) by (return :good) return :bad) :bad)))

--- a/src/lisp/regression-tests/misc.lisp
+++ b/src/lisp/regression-tests/misc.lisp
@@ -189,6 +189,7 @@
                 '(lambda()
                   (LOAD-TIME-VALUE
                    (FLET ((%F4 (&OPTIONAL &KEY (KEY1 9911946289546) (KEY2 -19296971321001))
+                            (declare (ignore key1 key2))
                             3904101166444))
                      -128503000536183044))))))
 

--- a/src/lisp/regression-tests/printer01.lisp
+++ b/src/lisp/regression-tests/printer01.lisp
@@ -456,3 +456,43 @@ BBBBCCCC**DDDD"))
                  (LET ((*PRINT-BASE* 7))
                    (WITH-OUTPUT-TO-STRING (*STANDARD-OUTPUT*)
                      (PRIN1 0))))))
+
+#|
+wrong
+(THIS ..)(THIS ..)
+|#
+
+(test pprint-failure-2a
+      ;; should only find  ".." once in the output, not twice
+      (= 2 (count #\.
+                  (let ((*package* (find-package :cl-user)))
+                    (with-output-to-string (stream)
+                      (with-standard-io-syntax
+                        (write `(this prints wrongly)
+                               :pretty t  :circle t :lines 1 :right-margin 15 :readably nil :stream stream)))))))
+
+(test pprint-failure-2
+      ;; should only find  ".." once in the output, not twice
+      (= 2 (count #\.
+                  (with-output-to-string (stream)
+                    (with-standard-io-syntax
+                      (write `(1234 12345 1234567)
+                             :pretty t  :circle t :lines 1 :right-margin 15 :readably nil :stream stream))))))
+(test pprint-failure-3a
+      (>
+       (length
+        (let ((*package* (find-package :cl-user)))
+          (with-output-to-string (stream)
+            (with-standard-io-syntax
+              (write #(PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV)
+                     :ESCAPE T :PRETTY T :CIRCLE T :LINES 0 :RIGHT-MARGIN 28 :readably nil :stream stream)))))
+       0))
+
+(test pprint-failure-3b
+      (>
+       (length
+        (with-output-to-string (stream)
+          (with-standard-io-syntax
+            (write #(12345 12345 12345 12345 12345 12345 12345 12345 12345 12345 12345)
+                   :ESCAPE T :PRETTY T :CIRCLE T :LINES 1 :RIGHT-MARGIN 28 :readably nil :stream stream))))
+       0))

--- a/src/lisp/regression-tests/read01.lisp
+++ b/src/lisp/regression-tests/read01.lisp
@@ -571,5 +571,10 @@
         (and (floatp $%e)
              (not (ext:float-nan-p $%e)))))
 
+(test issue-case-sensitivity-mode
+      (locally (declare (optimize (safety 3)))
+        (let ()
+          (readtable-case *readtable*))))
+
 
 

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -45,6 +45,7 @@
 (load-if-compiled-correctly "sys:regression-tests;encodings.lisp")
 (load-if-compiled-correctly "sys:regression-tests;system-construction.lisp")
 (load-if-compiled-correctly "sys:regression-tests;environment.lisp")
+(load-if-compiled-correctly "sys:regression-tests;conditions.lisp")
 (load-if-compiled-correctly "sys:regression-tests;float-features.lisp")
 (load-if-compiled-correctly "sys:regression-tests;debug.lisp")
 (load-if-compiled-correctly "sys:regression-tests;posix.lisp")

--- a/src/lisp/regression-tests/set-unexpected-failures.lisp
+++ b/src/lisp/regression-tests/set-unexpected-failures.lisp
@@ -17,4 +17,7 @@
         READ-PRINT-CONSISTENCY-ARRAYS
         SBCL-CROSS-COMPILE-4 ;;;not important
         INCLUDE-LEVEL-2A INCLUDE-LEVEL-2B INCLUDE-LEVEL-3 ;;; a problem for sbcl x-compiling
-        ))
+        ;;; more printer tests
+        PPRINT-FAILURE-2A
+        PPRINT-FAILURE-3A
+        PPRINT-FAILURE-3B))

--- a/src/lisp/regression-tests/strings01.lisp
+++ b/src/lisp/regression-tests/strings01.lisp
@@ -9,9 +9,9 @@
                                               (write-char #\Nul str) (princ "123" str)))))
 (test concatenate-with-nul0 (concatenate 'string (make-string 3 :initial-element #\Nul) "abc"))
 (test concatenate-with-nul1 (string= (concatenate 'string (make-string 3 :initial-element #\Nul) "abc")
-                                     (bformat nil "%c%c%cabc" #\nul #\nul #\nul)))
+                                     (core:bformat nil "%c%c%cabc" #\nul #\nul #\nul)))
 (test copy-seq-with-nul0 (string= (copy-seq (concatenate 'string (make-string 3 :initial-element #\Nul) "abc"))
-                                  (bformat nil "%c%c%cabc" #\nul #\nul #\nul)))
+                                  (core:bformat nil "%c%c%cabc" #\nul #\nul #\nul)))
 (test string=-with-nul0
       (string= (substitute #\X #\Nul
                            (subseq (concatenate 'string "a" (make-string 3 :initial-element #\Nul) "bcd") 0))

--- a/src/lisp/regression-tests/symbol0.lisp
+++ b/src/lisp/regression-tests/symbol0.lisp
@@ -77,6 +77,7 @@
 (test 978-symbols-common-lisp-exported
       (let ((sum 0))
         (do-external-symbols (sym (find-package :cl))
+          (declare (ignore sym))
           (incf sum))
         (= 978 sum)))
 

--- a/src/lisp/regression-tests/system-construction.lisp
+++ b/src/lisp/regression-tests/system-construction.lisp
@@ -6,6 +6,7 @@
   "newfasl"
   (pathname-type (compile-file-pathname "test.lisp" :output-file "test.newfasl"))))
 
+#+(or)
 (test
  compile-file-pathname-2a
  (let ((cmp:*compile-file-parallel* t))
@@ -13,6 +14,7 @@
     (cmp::cfp-output-extension :fasl)
     (pathname-type (compile-file-pathname "test.lisp")))))
 
+#+(or)
 (test
  compile-file-pathname-2b
  (let ((cmp:*compile-file-parallel* nil))
@@ -53,7 +55,6 @@
 (test
  compile-file-serial-no-faso
  (let ((cmp::*compile-file-parallel* nil)
-       (cmp::*generate-faso* nil)
        (core:*clasp-build-mode* :faso)
        (file "sys:regression-tests;framework.lisp"))
    (let ((fasl (compile-file file :output-file (make-pathname :type "newfasl" :defaults file) :verbose nil :print nil)))

--- a/src/lisp/regression-tests/tests01.lisp
+++ b/src/lisp/regression-tests/tests01.lisp
@@ -1,7 +1,7 @@
 #+use-mps
 (progn (princ "Skipping test CXX-DERIVABILITY - CXX objects don't work in MPS yet (fix!)") (terpri))
 #-use-mps
-(test cxx-derivability (inherits-from-instance (make-cxx-object 'ast-tooling:match-callback))
+(test cxx-derivability (core:inherits-from-instance (core:make-cxx-object 'ast-tooling:match-callback))
       :description "A derivable class is a CLOS class that derives from a C++ class.
 They are defined in the clbind library using Derivable<Foo>.
 They must be seen as inheriting from the Instance_O class.


### PR DESCRIPTION
* Solve unfortunate clash with clasp core:test by not using :core in the test package, qualify all calls to symbols in :core accordingly
* Add latest tests for regressions
* silence a unused variable warning
* new tests for error around clhs conditions