### PR TITLE
Dump bignums directly rather than dumping the decimal string.

### DIFF
--- a/include/clasp/llvmo/intrinsics.h
+++ b/include/clasp/llvmo/intrinsics.h
@@ -63,7 +63,7 @@ void ltvc_setf_row_major_aref(gctools::GCRootsInModule* holder, core::T_O* array
 void ltvc_setf_gethash(gctools::GCRootsInModule* holder,core::T_O* hash_table_t,core::T_O* key_index_t,core::T_O* value_index_t );
 LtvcReturn ltvc_make_fixnum(gctools::GCRootsInModule* holder, char tag, size_t index, int64_t val);
 LtvcReturn ltvc_make_bignum(gctools::GCRootsInModule* holder, char tag, size_t index, core::T_O* bignum_string_t);
-LtvcReturn ltvc_make_next_bignum(gctools::GCRootsInModule* holder, char tag, size_t index, core::T_O* bignum_string_t);
+LtvcReturn ltvc_make_next_bignum(gctools::GCRootsInModule* holder, char tag, size_t index, core::T_O* bignum);
 LtvcReturn ltvc_make_bitvector(gctools::GCRootsInModule* holder, char tag, size_t index, core::T_O* bitvector_string_t);
 LtvcReturn ltvc_make_symbol(gctools::GCRootsInModule* holder, char tag, size_t index, core::T_O* name_t,core::T_O* package_t );
 LtvcReturn ltvc_make_character(gctools::GCRootsInModule* holder, char tag, size_t index, uintptr_t val);

--- a/src/core/byte-code-interpreter.cc
+++ b/src/core/byte-code-interpreter.cc
@@ -114,7 +114,7 @@ void parse_ltvc_make_next_bignum(gctools::GCRootsInModule* roots, T_sp fin, bool
   if (log) printf("%s:%d:%s parse_ltvc_make_next_bignum\n", __FILE__, __LINE__, __FUNCTION__);
   char tag = ltvc_read_char( fin, log, byte_index );
   size_t index = ltvc_read_size_t( fin, log, byte_index );
-  T_O* arg2 = ltvc_read_object(roots,  fin, log, byte_index );
+  T_O* arg2 = ltvc_read_bignum( fin, log, byte_index );
   ltvc_make_next_bignum( roots, tag, index, arg2);
 };
 void parse_ltvc_make_bitvector(gctools::GCRootsInModule* roots, T_sp fin, bool log, size_t& byte_index) {

--- a/src/core/compiler.cc
+++ b/src/core/compiler.cc
@@ -1500,6 +1500,30 @@ std::string ltvc_read_string(T_sp stream, bool log, size_t& index)
   return str;
 }
 
+CL_DEFUN size_t core__ltvc_write_bignum(T_sp object, T_sp stream, size_t index)
+{
+  SELF_DOCUMENT(long long,stream,index);
+  core::Bignum_sp bignum = gc::As<Bignum_sp>(object);
+  mp_size_t length = bignum->length();
+  const mp_limb_t* limbs = bignum->limbs();
+  compact_write_size_t(length, stream, index);
+  for (mp_size_t i = 0; i < std::abs(length); i++)
+    compact_write_size_t(limbs[i], stream, index);
+  return index;
+}
+
+T_O* ltvc_read_bignum(T_sp stream, bool log, size_t& index)
+{
+  SELF_CHECK(long long,stream,index);
+  mp_size_t length = compact_read_size_t(stream, index);
+  size_t size = std::abs(length);
+  mp_limb_t limbs[length];
+  for (mp_size_t i = 0; i < size; i++) {
+    limbs[i] = compact_read_size_t(stream, index);
+  }
+  return reinterpret_cast<T_O*>(Bignum_O::create_from_limbs(length, 0, false, size, limbs).raw_());
+}
+
 CL_DEFUN size_t core__ltvc_write_float(T_sp object, T_sp stream, size_t index)
 {
   SELF_DOCUMENT(float,stream,index);

--- a/src/lisp/kernel/cleavir/setup.lisp
+++ b/src/lisp/kernel/cleavir/setup.lisp
@@ -157,7 +157,16 @@
   (define-function-attributes core:two-arg-char< :flushable)
   (define-function-attributes core:two-arg-char<= :flushable)
   (define-function-attributes core:two-arg-char> :flushable)
-  (define-function-attributes core:two-arg-char>= :flushable))
+  (define-function-attributes core:two-arg-char>= :flushable)
+
+  (define-function-attributes core::map-into-sequence :dyn-call :dx-call)
+  (define-function-attributes core::map-into-sequence/1 :dyn-call :dx-call)
+  (define-function-attributes core::map-for-effect :dyn-call :dx-call)
+  (define-function-attributes core::map-for-effect/1 :dyn-call :dx-call)
+  (define-function-attributes core::map-to-list :dyn-call :dx-call)
+  (define-function-attributes core::map-to-list/1 :dyn-call :dx-call)
+  (define-function-attributes core::every/1 :dyn-call :dx-call)
+  (define-function-attributes core::some/1 :dyn-call :dx-call))
 
 (defun treat-as-special-operator-p (name)
   (cond

--- a/src/lisp/kernel/cmp/cmpintrinsics.lsp
+++ b/src/lisp/kernel/cmp/cmpintrinsics.lsp
@@ -278,6 +278,8 @@ Boehm and MPS use a single pointer"
 ;; Define the T_O struct - right now just put in a dummy i32 - later put real fields here
 (define-symbol-macro %t% %i8%) ; (llvm-sys:struct-type-get (thread-local-llvm-context) nil  nil)) ;; "T_O"
 (define-symbol-macro %t*% (llvm-sys:type-get-pointer-to %t%))
+;; alias for bignum dumping
+(define-symbol-macro %bignum% %t*%)
 (define-symbol-macro %t**% (llvm-sys:type-get-pointer-to %t*%))
 (define-symbol-macro %t*[0]% (llvm-sys:array-type-get %t*% 0))
 (define-symbol-macro %t*[0]*% (llvm-sys:type-get-pointer-to %t*[0]%))

--- a/src/lisp/kernel/cmp/cmpliteral.lsp
+++ b/src/lisp/kernel/cmp/cmpliteral.lsp
@@ -338,8 +338,7 @@ to (literal-machine-function-description-vector *literal-machine*) and return th
 
 (defun ltv/bignum (bignum index read-only-p &key (toplevelp t))
   (declare (ignore toplevelp))
-  (let ((bn-str (prin1-to-base-string bignum)))
-    (add-creator "ltvc_make_next_bignum" index bignum (load-time-reference-literal bn-str read-only-p :toplevelp nil))))
+  (add-creator "ltvc_make_next_bignum" index bignum bignum))
 
 (defun ltv/bitvector (bitvector index read-only-p &key (toplevelp t))
   (declare (ignore toplevelp))
@@ -562,6 +561,7 @@ to (literal-machine-function-description-vector *literal-machine*) and return th
     ((fixnump arg) (core:ltvc-write-size-t arg stream byte-index))
     ((characterp arg) (core:ltvc-write-char arg stream byte-index))
     ((stringp arg) (core:ltvc-write-string arg stream byte-index))
+    ((core:bignump arg) (core:ltvc-write-bignum arg stream byte-index))
     ((immediate-datum-p arg)
      (core:ltvc-write-object #\i (immediate-datum-value arg) stream byte-index))
     ((single-float-datum-p arg) (core:ltvc-write-float (single-float-datum-value arg) stream byte-index))
@@ -1132,6 +1132,7 @@ If it isn't NIL then copy the literal from its index in the LTV into result."
   (set-c++-info 'cmp:%float% "float" "float")
   (set-c++-info 'cmp:%double% "double" "double")
   (set-c++-info 'cmp:%uintptr_t% "uintptr_t" "size_t")
+  (set-c++-info 'cmp::%bignum% "T_O*" "bignum")
   (set-c++-info :unknown "UNKNOWN" "UNKNOWN")
   )
 

--- a/src/lisp/kernel/cmp/primitives.lsp
+++ b/src/lisp/kernel/cmp/primitives.lsp
@@ -96,7 +96,7 @@
     (primitive         "ltvc_setf_gethash" %ltvc-return% (list %gcroots-in-module*% %t*% %t*% %t*%) :ltvc t)
     (primitive         "ltvc_make_fixnum" %ltvc-return% (list %gcroots-in-module*% %i8% %size_t% %uintptr_t%) :ltvc t)
     (primitive         "ltvc_make_package" %ltvc-return% (list %gcroots-in-module*% %i8% %size_t% %t*%) :ltvc t)
-    (primitive         "ltvc_make_next_bignum" %ltvc-return% (list %gcroots-in-module*% %i8% %size_t% %t*%) :ltvc t)
+    (primitive         "ltvc_make_next_bignum" %ltvc-return% (list %gcroots-in-module*% %i8% %size_t% %bignum%) :ltvc t)
     (primitive         "ltvc_make_bitvector" %ltvc-return% (list %gcroots-in-module*% %i8% %size_t% %t*%) :ltvc t)
     (primitive         "ltvc_make_symbol" %ltvc-return% (list %gcroots-in-module*% %i8% %size_t% %t*% %t*%) :ltvc t)
     (primitive         "ltvc_make_character" %ltvc-return% (list %gcroots-in-module*% %i8% %size_t% %uintptr_t%) :ltvc t)

--- a/src/llvmo/link_intrinsics.cc
+++ b/src/llvmo/link_intrinsics.cc
@@ -334,10 +334,9 @@ LtvcReturn ltvc_make_fixnum(gctools::GCRootsInModule* holder, char tag, size_t i
   NO_UNWIND_END();
 }
 
-LtvcReturn ltvc_make_next_bignum(gctools::GCRootsInModule* holder, char tag, size_t index, core::T_O* bignum_string_t)
+LtvcReturn ltvc_make_next_bignum(gctools::GCRootsInModule* holder, char tag, size_t index, T_O* bignum)
 {NO_UNWIND_BEGIN();
-  core::SimpleBaseString_sp bignum_string = gctools::As<core::SimpleBaseString_sp>(core::T_sp(bignum_string_t));
-  core::T_sp val = core::Bignum_O::make(bignum_string->get_std_string());
+  core::T_sp val = core::T_sp(bignum);
   LTVCRETURN holder->setTaggedIndex(tag,index,val.tagged_());
   NO_UNWIND_END();
 }


### PR DESCRIPTION
* Removes string consing when dumping.
* Less byte code needed to be dumped and read in.
* No need to parse a string when reading back in a bignum.