### PR TITLE
Fix unsafe handling of Unicode strings

### DIFF
--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -249,6 +249,7 @@ namespace core {
   /*! Return the value at the indices */
     virtual T_sp replaceArray(T_sp other) = 0;
     virtual void __write__(T_sp strm) const override;
+    virtual void __writeString(size_t istart, size_t iend, T_sp stream) const; 
     virtual string __repr__() const override;
   // ------------------------------------------------------------
   //

--- a/include/clasp/core/string.h
+++ b/include/clasp/core/string.h
@@ -83,8 +83,9 @@ namespace core {
     virtual bool equal(T_sp other) const final;
     virtual bool equalp(T_sp other) const final;
     virtual void __write__(T_sp strm) const final; // implemented in write_array.cc
+    virtual void __writeString(size_t istart, size_t iend, T_sp stream) const final; // implemented in write_array.cc
     virtual std::string get_std_string() const final { return this->length()==0 ? string("") : string((char*)&(*this)[0],this->length());};
-      virtual std::string __repr__() const override ;
+    virtual std::string __repr__() const override;
     virtual void sxhash_(HashGenerator& hg) const final {this->ranged_sxhash(hg,0,this->length());}
     virtual void ranged_sxhash(HashGenerator& hg, size_t start, size_t end) const final {
       if (hg.isFilling()) {
@@ -154,6 +155,7 @@ namespace core {
     // Implement these methods for simple vectors - some are implemented in parent classes
     // for convenience if not speed
     virtual void __write__(T_sp strm) const final;
+    virtual void __writeString(size_t istart, size_t iend, T_sp stream) const final; // implemented in write_array.cc
     virtual bool equal(T_sp other) const final;
     virtual bool equalp(T_sp other) const final;
     virtual std::string get_std_string() const final;
@@ -260,6 +262,7 @@ namespace core {
     const_iterator end() const { return &(*this)[this->length()]; };
   public:
     virtual void __write__(T_sp strm) const final;
+    virtual void __writeString(size_t istart, size_t iend, T_sp stream) const final; // implemented in write_array.cc
     virtual std::string get_std_string() const final { return std::string((const char*)this->begin(),this->length());};
       virtual std::string __repr__() const override ;
   public: // Str8Ns specific functions
@@ -315,6 +318,7 @@ namespace core {
     const_iterator end() const { return &(*this)[this->length()]; };
   public:
     virtual void __write__(T_sp strm) const final;
+    virtual void __writeString(size_t istart, size_t iend, T_sp stream) const final; // implemented in write_array.cc
     virtual std::string get_std_string() const final;
     virtual std::string __repr__() const final;
   public: // StrWNs specific functions

--- a/src/core/write_array.cc
+++ b/src/core/write_array.cc
@@ -181,6 +181,11 @@ void Array_O::__write__(T_sp stream) const {
   else write_array_unreadable(this->asSmartPtr(), adims, stream);
 }
 
+void Array_O::__writeString(size_t istart, size_t iend, T_sp stream) const {
+ // Linker seems to require that
+  SUBIMP();
+}
+
 // This separate method is necessary because we need to account for fill pointers -
 // the basic stuff above uses array dimensions, so it's not appropriate.
 void ComplexVector_O::__write__(T_sp stream) const {
@@ -275,6 +280,34 @@ void StrWNs_O::__write__(T_sp stream) const {
   this->asAbstractSimpleVectorRange(str,start,end);
   SimpleCharacterString_sp sc = gc::As<SimpleCharacterString_sp>(str);
   unsafe_write_SimpleCharacterString(sc,start,end,stream);
+}
+
+void StrWNs_O::__writeString (size_t istart, size_t iend, T_sp stream) const {
+  size_t start, end;
+  AbstractSimpleVector_sp str;
+  this->asAbstractSimpleVectorRange(str,start,end);
+  SimpleCharacterString_sp sc = gc::As<SimpleCharacterString_sp>(str);
+  sc->__writeString(istart, iend, stream);
+}
+
+void Str8Ns_O::__writeString (size_t istart, size_t iend, T_sp stream) const {
+  size_t start, end;
+  AbstractSimpleVector_sp str;
+  this->asAbstractSimpleVectorRange(str,start,end);
+  SimpleBaseString_sp sb = gc::As<SimpleBaseString_sp>(str);
+  sb->__writeString(istart, iend, stream);
+}
+
+void SimpleBaseString_O::__writeString (size_t start, size_t end, T_sp stream) const {
+  for (cl_index ndx = start; ndx < end; ndx++) {
+    clasp_write_char((* this)[ndx],stream);
+  }
+}
+
+void SimpleCharacterString_O::__writeString (size_t start, size_t end, T_sp stream) const {
+  for (cl_index ndx = start; ndx < end; ndx++) {
+      clasp_write_char((* this)[ndx],stream);
+  }
 }
 
 }; // namespace core

--- a/src/lisp/regression-tests/printer01.lisp
+++ b/src/lisp/regression-tests/printer01.lisp
@@ -496,3 +496,99 @@ wrong
             (write #(12345 12345 12345 12345 12345 12345 12345 12345 12345 12345 12345)
                    :ESCAPE T :PRETTY T :CIRCLE T :LINES 1 :RIGHT-MARGIN 28 :readably nil :stream stream))))
        0))
+
+(test write-string-happy-path
+      (string-equal
+       "ABABĀĀĀĀ » "
+       (with-output-to-string (stream)
+               ;;; SimpleBaseString_O
+         (write-string
+          (MAKE-ARRAY 2
+                      :INITIAL-CONTENTS (list (code-char 65) (code-char 66))
+                      :ELEMENT-TYPE 'base-char)
+          stream)
+        ;;; Str8Ns_O
+         (write-string
+          (MAKE-ARRAY 2
+                      :INITIAL-CONTENTS (list (code-char 65) (code-char 66))
+                      :adjustable t
+                      :ELEMENT-TYPE 'base-char)
+          stream)
+        ;;;  SimpleCharacterString_O
+         (write-string 
+          (MAKE-ARRAY 2
+                      :INITIAL-CONTENTS
+                      (list (code-char 256) (code-char 256))
+                      :ELEMENT-TYPE 'character)
+          stream)
+        ;;;  StrWNs_O
+         (write-string
+          (MAKE-ARRAY 2
+                      :INITIAL-CONTENTS
+                      (list (code-char 256) (code-char 256))
+                      :adjustable t
+                      :ELEMENT-TYPE 'character)
+          stream)
+         (write-string " » " stream))))
+
+(let ((string "1234567890"))
+  (with-output-to-string (stream)
+    (test-expect-error write-string-error-1
+                       (write-string string stream :start nil) :type type-error)
+    (test-expect-error write-string-error-2
+                       (write-string string stream :start -1) :type type-error)
+    (test-expect-error write-string-error-2a
+                       (write-string string stream :start 100) :type type-error)
+    (test-expect-error write-string-error-3
+                       (write-string string stream :start (make-hash-table)) :type type-error)
+    (test-expect-error write-string-error-4
+                       (write-string string stream :end nil) :type type-error)
+    (test-expect-error write-string-error-5
+                       (write-string string stream :end -1) :type type-error)
+    (test-expect-error write-string-error-5a
+                       (write-string string stream :end 100) :type type-error)
+    (test-expect-error write-string-error-6
+                       (write-string string stream :end (make-hash-table)) :type type-error)
+    (test-expect-error write-string-error-7
+                       (write-string string stream :start 2 :end 1) :type type-error)))
+
+(test write-string-subseq-SimpleBaseString_O
+      (let ((string "12345")
+            (from 1)
+            (to 4))
+        (string= (subseq string from to)
+                 (with-output-to-string (stream)
+                   (write-string string stream :start from :end to)))))
+
+(test write-string-subseq-SimpleCharacterString_O
+      (let ((string "12»45")
+            (from 1)
+            (to 4))
+        (string= (subseq string from to)
+                 (with-output-to-string (stream)
+                   (write-string string stream :start from :end to)))))
+
+(test write-string-subseq-Str8Ns_O
+      (let ((string (MAKE-ARRAY 5
+                                :INITIAL-CONTENTS (list #\1 #\2 #\3 #\4 #\5)
+                                :adjustable t
+                                :ELEMENT-TYPE 'base-char))
+            (from 1)
+            (to 4))
+        (string= (subseq string from to)
+                 (with-output-to-string (stream)
+                   (write-string string stream :start from :end to)))))
+
+(test write-string-subseq-StrWNs_O
+      (let ((string (MAKE-ARRAY 5
+                                :INITIAL-CONTENTS (list #\1 #\2 (char "12»45" 2) #\4 #\5)
+                                :adjustable t
+                                :ELEMENT-TYPE 'base-char))
+            (from 1)
+            (to 4))
+        (string= (subseq string from to)
+                 (with-output-to-string (stream)
+                   (write-string string stream :start from :end to)))))
+
+
+


### PR DESCRIPTION
* Fixes issue #1134 
* Add regression tests
* Common Root for all string types seems to be `Array_O` so introduced `__writeString` there