### PR TITLE
Fix signal mask that was restored inadvertently by longjump

### DIFF
--- a/src/lisp/kernel/cleavir/translate.lisp
+++ b/src/lisp/kernel/cleavir/translate.lisp
@@ -344,7 +344,7 @@
         (let ((bufp (cmp:irc-bit-cast cont cmp::%jmp-buf-tag*%)))
           (%intrinsic-invoke-if-landing-pad-or-call
            ;; `+ because we can't pass 0 to longjmp.
-           "longjmp" (list bufp (%i32 (1+ destination-id)))))
+           "_longjmp" (list bufp (%i32 (1+ destination-id)))))
         ;; C++ exception
         (cmp:with-landing-pad (never-entry-landing-pad
                                (cleavir-bir:dynamic-environment instruction))

--- a/src/lisp/kernel/cmp/primitives.lsp
+++ b/src/lisp/kernel/cmp/primitives.lsp
@@ -281,7 +281,7 @@
          (primitive-unwinds "cc_oddKeywordException" %void% (list %function-description*%))
          (primitive         "cc_multipleValuesArrayAddress" %t*[0]*% nil)
          (primitive         "_setjmp" %i32% (list %jmp-buf-tag*%))
-         (primitive-unwinds "longjmp" %void% (list %jmp-buf-tag*% %i32%))
+         (primitive-unwinds "_longjmp" %void% (list %jmp-buf-tag*% %i32%))
          (primitive-unwinds "cc_unwind" %void% (list %t*% %size_t%))
          (primitive-unwinds "cc_throw" %void% (list %t*%) :does-not-return t)
          (primitive         "cc_saveMultipleValue0" %void% (list %tmv%))

--- a/src/lisp/regression-tests/float-features.lisp
+++ b/src/lisp/regression-tests/float-features.lisp
@@ -7,7 +7,6 @@
          (ext:with-float-traps-masked (:divide-by-zero)
            (/ (bar) (foo))))))
 
-#+(or)
 (test float-features-1b
       (handler-case
           (flet ((foo () (if (> 10 (random 20)) 0.0 0.0))
@@ -30,7 +29,6 @@
          (let ((n (random 100)))
            (+ (foo-ext-1 n) (bar-ext-1 n))))))
 
-#+(or)
 (test float-features-4
       (handler-case
           (let ((n (random 100)))
@@ -51,7 +49,6 @@
          (let ((n (random 100)))
            (+ (foo-ext-2 n) (bar-ext-2 n))))))
 
-#+(or)
 (test float-features-6
       (handler-case
           (let ((n (random 100)))
@@ -74,7 +71,6 @@
          (let ((n (random 100)))
            (/ (foo-ext-3 n) (bar-ext-3 n))))))
 
-#+(or)
 (test float-features-8
       (handler-case
           (ext:with-float-traps-masked ()


### PR DESCRIPTION
* _setjmp() _longjmp() are specified to don't reset the signal mask
* _setjmp() longjmp() seem to reset the signal mask to random values
* with the wrong signal mask, handlers are blocked
* will introduce functions to query and set the signal mask in a further pr
* with the change, the sometimes failing float-feature test work again
* and finally `(mod  1 0)`reliably produces a fpe