### PR TITLE
Show the values of global variables and constants in apropos

### DIFF
--- a/src/lisp/kernel/lsp/packlib.lsp
+++ b/src/lisp/kernel/lsp/packlib.lsp
@@ -141,11 +141,11 @@ to NIL) and returns all values."
                 (princ "  Macro")
                 (princ "  Function"))))
   (when (boundp symbol)
-        (if (constantp symbol)
-            (princ "  Constant")
-            (princ "  has value")))
+    (if (constantp symbol)
+        (princ "  Constant: ")
+        (princ "  has value: "))
+    (prin1 (symbol-value symbol)))
   (terpri))
-
 
 (defun apropos (string &optional package)
   "Args: (string &optional (package nil))


### PR DESCRIPTION
* as does ecl now
* Example:
```lisp
COMMON-LISP-USER> (apropos "load-p")
*LOAD-PATHNAME*  has value: #P"APP-FASL:CCLASP-BOEHM-IMAGE.FASP.NEWEST"
*LOAD-PRINT*  has value: NIL
CHEM:LOAD-PDB-FROM-STREAM  Function
CHEM:SIMPLE-LOAD-PDB  Function
````