### PR TITLE
Type Error insted of simply error when proclaim gets a non-proper-list

### DIFF
--- a/src/lisp/kernel/init.lsp
+++ b/src/lisp/kernel/init.lsp
@@ -474,7 +474,9 @@ as a VARIABLE doc and can be retrieved by (documentation 'NAME 'variable)."
 Gives a global declaration.  See DECLARE for possible DECL-SPECs."
   ;;decl must be a proper list
   (if (not (core:proper-list-p decl))
-      (error "decl must be a proper list: ~a" decl)) 
+      (error 'type-error
+             :datum decl
+             :expected-type '(and list (satisfies core:proper-list-p)))) 
   (cond
     ((eq (car decl) 'SPECIAL)
      (mapc #'sys::*make-special (cdr decl)))


### PR DESCRIPTION
* also fixes `PROCLAIM.ERROR.7` in ansi tests
* no regressions neither in clasp nor in ansi-tests