### PR TITLE
Also fixup core:+standard-readtable+ with eclector

### DIFF
--- a/src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector.lisp
+++ b/src/lisp/kernel/cleavir/activate-clasp-readtables-for-eclector.lisp
@@ -120,6 +120,7 @@
 (defun init-clasp-as-eclector-reader ()
   (setq eclector.readtable:*readtable* cl:*readtable*)
   (core::set-eclector-reader-readmacros cl:*readtable*)
+  (core::set-eclector-reader-readmacros (symbol-value 'core:+standard-readtable+))
   ;;; also change read 
   (setq core:*read-hook* 'read-with-readtable-synced)
   (setq core:*read-preserving-whitespace-hook* 'read-preserving-whitespace-with-readtable-synced)

--- a/src/lisp/regression-tests/read01.lisp
+++ b/src/lisp/regression-tests/read01.lisp
@@ -576,5 +576,14 @@
         (let ()
           (readtable-case *readtable*))))
 
+(test set-syntax-from-char-from-irc-clasp
+      (let ((*readtable* (copy-readtable nil)))
+        (set-syntax-from-char #\0 #\`)
+        (eql (get-macro-character #\0) (get-macro-character #\`))))
+
+(test set-macro-character-from-irc-clasp
+      (let ((*readtable* (copy-readtable nil)))
+        (set-macro-character #\0 (get-macro-character #\`))
+        (eql (get-macro-character #\0) (get-macro-character #\`))))
 
 


### PR DESCRIPTION
* `set-syntax-from-char`uses `core:+standard-readtable+`so also need to fixup this readtable with eclectors readers
* Did test extensively
  * New regression tests (and running  the existing ones)
  * Run ansi-tests
  * build `icando-boehm`
  * Recompiled 100 most important quicklisp systems