### PR TITLE
Remove feature parameter from talk link

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## NOTE:  November 28, 2018 - This contains a pre-release of Clasp 0.9.
 
-[We have a new talk up on youtube!](https://www.youtube.com/watch?v=mbdXeRBbgDM&feature=youtu.be)
+[We have a new talk up on youtube!](https://www.youtube.com/watch?v=mbdXeRBbgDM)
 
 ##  Overview
 Clasp is a new [Common Lisp](https://common-lisp.net/) implementation that seamlessly interoperates with C++ libraries and programs using [LLVM](http://llvm.org/) for compilation to native code. This allows Clasp to take advantage of a vast array of preexisting libraries and programs, such as out of the scientific computing ecosystem. Embedding them in a Common Lisp environment allows you to make use of rapid prototyping, incremental development, and other capabilities that make it a powerful language.


### PR DESCRIPTION
The `feature` parameter on YouTube links is clutter and does not change anything on the page.