### PR TITLE
Fix issue 1148

### DIFF
--- a/src/lisp/kernel/cmp/compile-file-parallel.lsp
+++ b/src/lisp/kernel/cmp/compile-file-parallel.lsp
@@ -304,13 +304,14 @@ multithreaded performance that we should explore."
 
 (defun compile-file-to-result (given-input-pathname
                                &key
-                                 output-type
-                                 output-path
-                                 environment
-                                 (optimize t)
-                                 (optimize-level *optimization-level*)
-                                 ast-only
-                                 write-bitcode)
+                               output-type
+                               output-path
+                               environment
+                               (optimize t)
+                               (optimize-level *optimization-level*)
+                               ast-only
+                               write-bitcode
+                               external-format)
   "* Arguments
 - given-input-pathname :: A pathname.
 - output-path :: A pathname.
@@ -320,7 +321,7 @@ Compile a lisp source file into an LLVM module."
   (let* ((*package* *package*)
          (clasp-source-root (translate-logical-pathname "source-dir:"))
          (clasp-source (merge-pathnames (make-pathname :directory '(:relative :wild-inferiors) :name :wild :type :wild) clasp-source-root))
-         (source-sin (open given-input-pathname :direction :input)))
+         (source-sin (open given-input-pathname :direction :input :external-format (or external-format :default))))
     (with-open-stream (sin source-sin)
       (when *compile-verbose*
         (bformat t "; Compiling file parallel: %s%N" (namestring given-input-pathname)))
@@ -415,7 +416,7 @@ Each bitcode filename will contain the form-index.")
                                 (cleanup nil)
                                 (write-bitcode *compile-file-parallel-write-bitcode*))
   "See CLHS compile-file."
-  (declare (ignore external-format type cleanup))
+  (declare (ignore type cleanup))
   (setf output-type (maybe-fixup-output-type output-type output-type-p))
   (let ((*compile-file-parallel* t))
     (if (not output-file-p) (setq output-file (cfp-output-file-default input-file output-type)))
@@ -446,7 +447,8 @@ Each bitcode filename will contain the form-index.")
                      :optimize optimize
                      :optimize-level optimize-level
                      :ast-only ast-only
-                     :write-bitcode write-bitcode)))
+                     :write-bitcode write-bitcode
+                     :external-format external-format)))
               (cond (dry-run (format t "Doing nothing further~%") nil)
                     ((null output-path)
                      (error "The output-file is nil for input filename ~a~%" input-file))

--- a/src/lisp/kernel/cmp/compile-file.lsp
+++ b/src/lisp/kernel/cmp/compile-file.lsp
@@ -226,7 +226,8 @@ and the pathname of the source file - this will also be used as the module initi
                                  environment
                                  image-startup-position
                                  (optimize t)
-                                 (optimize-level *optimization-level*))
+                                 (optimize-level *optimization-level*)
+                                 external-format)
   "* Arguments
 - given-input-pathname :: A pathname.
 - output-path :: A pathname.
@@ -241,7 +242,7 @@ Compile a lisp source file into an LLVM module."
 				    :pathname given-input-pathname
 				    :format-control "compile-file-to-module could not find the file ~s to open it"
 				    :format-arguments (list given-input-pathname))))
-         (source-sin (open input-pathname :direction :input))
+         (source-sin (open input-pathname :direction :input :external-format (or external-format :default)))
          (module (llvm-create-module (namestring input-pathname)))
 	 (module-name (cf-module-name type given-input-pathname)))
     (or module (error "module is NIL"))
@@ -379,7 +380,8 @@ Compile a lisp source file into an LLVM module."
                                                   :environment environment
                                                   :image-startup-position image-startup-position
                                                   :optimize optimize
-                                                  :optimize-level optimize-level)))
+                                                  :optimize-level optimize-level
+                                                  :external-format external-format)))
               (compile-file-output-module module output-file output-type output-path input-file type
                                           :position image-startup-position)
               (when output-info-pathname (generate-info input-file output-info-pathname))

--- a/src/lisp/regression-tests/encodings.lisp
+++ b/src/lisp/regression-tests/encodings.lisp
@@ -73,5 +73,15 @@
       (let ()
         (load #P"sys:modules;asdf;test;lambda.lisp" :external-format :ISO-8859-2)
         (equal (list 206 357) (%string-char-codes  asdf-test::*LAMBDA-STRING*))))
+
+(test compile-file-with-lambda
+      (let ()
+        (cmp::compile-file-serial #P"sys:regression-tests;latin2-check.lisp" :external-format :iso-8859-1)
+        (cmp::compile-file-parallel #P"sys:regression-tests;latin2-check.lisp" :external-format :iso-8859-1)))
+
+(test-expect-error compile-file-with-lambda-default-encoding
+                   (compile-file #P"sys:regression-tests;latin2-check.lisp" :external-format :us-ascii)
+                   :type ext:stream-decoding-error)
 ;;; clean-up
 (delete-package (find-package :asdf-test))
+(delete-package (find-package :encoding-test))

--- a/src/lisp/regression-tests/latin2-check.lisp
+++ b/src/lisp/regression-tests/latin2-check.lisp
@@ -1,0 +1,27 @@
+(defpackage #:encoding-test (:use :cl))
+
+(in-package :encoding-test)
+
+(defvar *boole-array*)
+
+(defun boole$ (op i1 i2)
+  (declare (type (integer 0 15) op)
+           (type integer i1 i2))
+  (boole (aref *boole-array* op) i1 i2))
+  
+;                        PRINTING and READING
+
+; Without the setting of custom:*default-file-encoding* for clisp in
+; acl2.lisp, the build breaks with the following string (note the accented "i"
+; in Martin, below):
+;   Francisco J. Martín Mateos
+; With that setting, we do not need an explicit :external-format argument for
+; the call of with-open-file in acl2-check.lisp that opens a stream for
+; "acl2-characters".
+
+; Because of the comment above, save an Emacs buffer connected to this file
+; after setting the necessary buffer-local variable as follows.
+
+; (setq save-buffer-coding-system 'iso-8859-1)
+
+


### PR DESCRIPTION
* fixes #1148 by simply passing :external-format until the call to open and use it there
* regression-tests, test-file extracted from acl2  