### PR TITLE
Drop with-ecl-io-syntax, +ecl-syntax-progv-list+ & friends

### DIFF
--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -1069,7 +1069,6 @@ void CoreExposer_O::define_essential_globals(Lisp_sp lisp) {
   cl::_sym_internalTimeUnitsPerSecond->defconstant(make_fixnum(CLASP_INTERNAL_TIME_UNITS_PER_SECOND));
   _sym_STARstartRunTimeSTAR->defparameter(PosixTime_O::createNow());
   cl::_sym_MultipleValuesLimit->defconstant(make_fixnum(MultipleValues::MultipleValuesLimit));
-  // _sym_STARprint_structureSTAR->defparameter(_Nil<T_O>());
   _sym_STARprintPackageSTAR->defparameter(_Nil<T_O>());
   _sym_STARcircle_counterSTAR->defparameter(_Nil<T_O>());
   _sym_STARcircle_stackSTAR->defparameter(_Nil<T_O>());

--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -1069,7 +1069,7 @@ void CoreExposer_O::define_essential_globals(Lisp_sp lisp) {
   cl::_sym_internalTimeUnitsPerSecond->defconstant(make_fixnum(CLASP_INTERNAL_TIME_UNITS_PER_SECOND));
   _sym_STARstartRunTimeSTAR->defparameter(PosixTime_O::createNow());
   cl::_sym_MultipleValuesLimit->defconstant(make_fixnum(MultipleValues::MultipleValuesLimit));
-  _sym_STARprint_structureSTAR->defparameter(_Nil<T_O>());
+  // _sym_STARprint_structureSTAR->defparameter(_Nil<T_O>());
   _sym_STARprintPackageSTAR->defparameter(_Nil<T_O>());
   _sym_STARcircle_counterSTAR->defparameter(_Nil<T_O>());
   _sym_STARcircle_stackSTAR->defparameter(_Nil<T_O>());

--- a/src/core/write_ugly.cc
+++ b/src/core/write_ugly.cc
@@ -131,10 +131,6 @@ void FuncallableInstance_O::__write__(T_sp stream) const {
   }
 }
 
-  SYMBOL_EXPORT_SC_(CorePkg, structure_print_function);
-  SYMBOL_EXPORT_SC_(CorePkg, STARprint_structureSTAR);
-
-
 void Integer_O::__write__(T_sp stream) const {
   SafeBufferStr8Ns buffer;
   int print_base = clasp_print_base();

--- a/src/lisp/kernel/init.lsp
+++ b/src/lisp/kernel/init.lsp
@@ -309,62 +309,6 @@ as a VARIABLE doc and can be retrieved by (documentation 'NAME 'variable)."
     (defconstant +ecl-safe-declarations+
       '(optimize (safety 2) (speed 1) (debug 1) (space 1))))
 
-
-
-
-(defvar +ecl-syntax-progv-list+
-  (list
-   '(
-     *print-pprint-dispatch*'
-     *print-array*
-     *print-base*
-     *print-case*
-     *print-circle*
-     *print-escape*
-     *print-gensym*
-     *print-length*
-     *print-level*
-     *print-lines*
-     *print-miser-width*
-     *print-pretty*
-     *print-radix*
-     *print-readably*
-     *print-right-margin*
-     *read-base*
-     *read-default-float-format*
-     *read-eval*
-     *read-suppress*
-     *readtable*
-     si::*print-package*
-     si:*print-structure*
-     si::*sharp-eq-context*
-     si:*circle-counter*)
-   nil                              ;;  *pprint-dispatch-table*
-   t                                ;;  *print-array*
-   10                               ;;  *print-base*
-   :downcase                        ;;  *print-case*
-   t                                ;;  *print-circle*
-   t                                ;;  *print-escape*
-   t                                ;;  *print-gensym*
-   nil                              ;;  *print-length*
-   nil                              ;;  *print-level*
-   nil                              ;;  *print-lines*
-   nil                              ;;  *print-miser-width*
-   nil                              ;;  *print-pretty*
-   nil                              ;;  *print-radix*
-   t                                ;;  *print-readably*
-   nil                              ;;  *print-right-margin*
-   10                               ;;  *read-base*
-   'single-float                    ;;  *read-default-float-format*
-   t                                ;;  *read-eval*
-   nil                              ;;  *read-suppress*
-   *readtable*                      ;;  *readtable*
-   (find-package :cl)               ;;  si::*print-package*
-   t                                ;  si::*print-structure*
-   nil                              ;  si::*sharp-eq-context*
-   nil                              ;  si::*circle-counter*
-   ))
-
 (defvar +io-syntax-progv-list+
   (list
    '(

--- a/src/lisp/kernel/lsp/iolib.lsp
+++ b/src/lisp/kernel/lsp/iolib.lsp
@@ -302,16 +302,6 @@ the one defined in the ANSI standard. *print-base* is 10, *print-array* is t,
 	   (si:cons-cdr %progv-list)
 	 ,@body))))
 
-(defmacro with-ecl-io-syntax (&body body)
-  "Syntax: ({forms}*)
-The forms of the body are executed in a print environment that corresponds to
-the one used internally by ECL compiled files."
-  (with-clean-symbols (%progv-list)
-    `(let ((%progv-list +ecl-syntax-progv-list+))
-       (progv (si:cons-car %progv-list)
-	   (si:cons-cdr %progv-list)
-	 ,@body))))
-
 (defmacro print-unreadable-object
 	  ((object stream &key type identity) &body body)
   (if body

--- a/src/lisp/kernel/lsp/pprint.lsp
+++ b/src/lisp/kernel/lsp/pprint.lsp
@@ -1597,6 +1597,5 @@
         *standard-pprint-dispatch* *initial-pprint-dispatch*)
   (setf (pprint-dispatch-table-read-only-p *standard-pprint-dispatch*) t)
   (setf (first (cdr si::+io-syntax-progv-list+)) *standard-pprint-dispatch*)
-  (setf (first (cdr si::+ecl-syntax-progv-list+)) *standard-pprint-dispatch*)
   #-clasp-min
   (setf *print-pretty* t))


### PR DESCRIPTION
* `*STARprint_structureSTAR and , si:*print-structure*`
* `structure_print_function`
* to verify:
````
git grep -i -I "with-ecl-io-syntax" *
git grep -i -I "+ecl-syntax-progv-list+" *
git grep -i -I "print_structure" *
git grep -i -I "printstructure" *
git grep -i -I "structure_print_function" *
git grep -i -I "structureprintfunction" *
````
* and did run the regression-tests