### PR TITLE
Silence obj_deallocate_unmanaged_instance

### DIFF
--- a/src/gctools/gc_interface.cc
+++ b/src/gctools/gc_interface.cc
@@ -320,7 +320,7 @@ const char *obj_name(gctools::stamp_t stamp) {
 #define GC_DEALLOCATOR_METHOD
 void obj_deallocate_unmanaged_instance(gctools::smart_ptr<core::T_O> obj ) {
   void* client = &*obj;
-  printf("%s:%d About to obj_deallocate_unmanaged_instance %s\n", __FILE__, __LINE__, _rep_(obj).c_str() );
+  // printf("%s:%d About to obj_deallocate_unmanaged_instance %s\n", __FILE__, __LINE__, _rep_(obj).c_str() );
   // The client must have a valid header
 #ifdef USE_MPS
   #ifndef RUNNING_MPSPREP


### PR DESCRIPTION
This printf dumps the whole printable representation of the object which is especially irritating when using static-vectors. Not sure if the message is really needed. If so should it be shorter or maybe a trace message facility that one can turn off? For now I just commented it out to avoid a slew of messages in the cando-jupyter molecule trajectory stuff.