### PR TITLE
Rename core:is-interactive-lisp to core:interactivep and export in :ext

### DIFF
--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -1467,7 +1467,7 @@ CL_DEFUN bool core__debugger_disabled_p() {
   return _lisp->_DebuggerDisabled;
 }
 
-CL_DEFUN bool core__is_interactive_lisp() {
+CL_DEFUN bool core__interactivep() {
   return _lisp->_Interactive;
 }
 

--- a/src/lisp/kernel/init.lsp
+++ b/src/lisp/kernel/init.lsp
@@ -181,6 +181,7 @@
 (import 'core:argv :ext)
 (import 'core:rmdir :ext)
 (import 'core:mkstemp :ext)
+(import 'core:interactivep :ext)
 
 ;;; EXT exports
 (eval-when (:execute :compile-toplevel :load-toplevel)
@@ -227,8 +228,9 @@
           with-float-traps-masked
           enable-interrupt default-interrupt ignore-interrupt
           get-signal-handler set-signal-handler
-          ;;; for asdf and slime and trivial-garbage to use ext:
-          getpid argc argv rmdir mkstemp weak-pointer-value make-weak-pointer weak-pointer-valid hash-table-weakness))
+          ;;; for asdf, slime, trivial-garbage and cando to use ext:
+          getpid argc argv rmdir mkstemp weak-pointer-value make-weak-pointer weak-pointer-valid
+          interactivep hash-table-weakness))
 (core:*make-special '*module-provider-functions*)
 (core:*make-special '*source-location*)
 (setq *source-location* nil)
@@ -717,7 +719,7 @@ the stage, the +application-name+ and the +bitcode-name+"
 (defun default-prologue-form (&optional features)
   `(progn
      ,@(mapcar #'(lambda (f) `(push ,f *features*)) features)
-     (if (core:is-interactive-lisp)
+     (if (core:interactivep)
          (bformat t "Starting %s ... loading image...%N" (lisp-implementation-version)))))
 
 (export '*extension-startup-loads*) ;; ADDED: frgo, 2016-08-10

--- a/src/lisp/kernel/lsp/epilogue-aclasp.lsp
+++ b/src/lisp/kernel/lsp/epilogue-aclasp.lsp
@@ -7,4 +7,4 @@
        (core:process-command-line-load-eval-sequence))
   (core::select-package :core)
   (let ((core:*use-interpreter-for-eval* nil))
-    (when (core:is-interactive-lisp) (core::low-level-repl))))
+    (when (core:interactivep) (core::low-level-repl))))

--- a/src/lisp/kernel/lsp/epilogue-bclasp.lsp
+++ b/src/lisp/kernel/lsp/epilogue-bclasp.lsp
@@ -6,7 +6,7 @@
           (let ((core:*use-interpreter-for-eval* nil))
             (core:maybe-load-clasprc)
             (core:process-command-line-load-eval-sequence)
-            (cond ((core:is-interactive-lisp)
+            (cond ((core:interactivep)
                    (unless (core:noinform-p)
                      (format t "Starting bclasp~%"))
                    (core:top-level :noprint (core:noprint-p)))

--- a/src/lisp/kernel/lsp/epilogue-cclasp.lisp
+++ b/src/lisp/kernel/lsp/epilogue-cclasp.lisp
@@ -8,6 +8,6 @@
     (core:process-extension-loads)
     (core:maybe-load-clasprc)
     (core:process-command-line-load-eval-sequence)
-    (if (core:is-interactive-lisp)
+    (if (core:interactivep)
         (core:top-level :noprint (core:noprint-p))
         (core:exit 0))))


### PR DESCRIPTION
Export from `:ext` since Cando is using `core:is-interactive-lisp` to determine the verbosity of quickload and progress bars. Renamed to `interactivep` since `is-interactive-lisp` doesn't really follow the lisp predicate style. If `interactivep` is not descriptive enough then maybe `interactive-session-p`?

I searched GitHub for uses of `core:is-interactive-lisp` and found only Cando and Roswell. Roswell doesn't appear to be using it in their own code, it just shows up because they have a Clasp fork.

For #1155