### PR TITLE
finally fix pprint-circle right

### DIFF
--- a/src/lisp/kernel/lsp/pprint.lsp
+++ b/src/lisp/kernel/lsp/pprint.lsp
@@ -9,9 +9,6 @@
 ;;; CMU Common Lisp pretty printer.
 ;;; Written by William Lott.  Algorithm stolen from Richard Waters' XP.
 ;;;
-
-#+(or)(eval-when (:compile-toplevel :execute :load-toplevel)
-	(setq core::*echo-repl-read* t))
   
 (in-package "SI")
 
@@ -716,9 +713,6 @@
 	 nil)
 	((or (null object)
 	     (zerop count)
-	     (fixnump object)
-	     (characterp object)
-	     (and (symbolp object) (symbol-package object))
 	     (null *circle-counter*))
 	 t)
 	((eql 'NULL (setf code (gethash object *circle-stack* 'NULL)))
@@ -750,18 +744,11 @@
 	 (setf *print-level* (1- *print-level*)))))
 
 (defun search-print-circle (object)
-  (let ((code (gethash object *circle-stack* -1)))
-    (if (fixnump *circle-counter*)
-	(cond ((or (eql code -1) (null code))
-	       ;; Is not referenced or was not found before
-	       0)
-	      ((eql code t)
-	       ;; Reference twice but had no code yet
-	       (setf (gethash object *circle-stack*)
-		     (setf *circle-counter* (1+ *circle-counter*)))
-	       (- *circle-counter*))
-	      (t code))
-	(cond ((eql code -1)
+  (multiple-value-bind
+        (code present-p)
+      (gethash object *circle-stack*)
+    (if (not (fixnump *circle-counter*))
+        (cond ((not present-p)
 	       ;; Was not found before
 	       (setf (gethash object *circle-stack*) nil)
 	       0)
@@ -771,62 +758,83 @@
 	       1)
 	      (t
 	       ;; Further references
-	       2)))))
+	       2))
+	(cond ((or (not present-p) (null code))
+	       ;; Is not referenced or was not found before
+	       0)
+	      ((eql code t)
+	       ;; Reference twice but had no code yet
+               (incf *circle-counter*)
+	       (setf (gethash object *circle-stack*)
+		     *circle-counter*)
+	       (- *circle-counter*))
+	      (t code)))))
+	       
+(defun write-object-with-circle (object stream function)
+  (if (and *print-circle*
+           (not (null object))
+           (not (fixnump object))
+           (not (characterp object))
+           (or (not (symbolp object)) (null (symbol-package object))))
+            ;;; *print-circle* and an object that might have a circle
+      (if (null *circle-counter*)
+          (let* ((hash (make-hash-table :test 'eq
+                                        :size 1024))
+                 (*circle-counter* t)
+                 (*circle-stack* hash))
+            (write-object-with-circle object (make-broadcast-stream) function)
+            (setf *circle-counter* 0)
+            (write-object-with-circle object stream function)
+            (clrhash hash)
+            object)
+          (let ((code (search-print-circle object)))
+            (cond ((not (fixnump *circle-counter*))
+                   ;; We are only inspecting the object to be printed.
+                   ;; Only print X if it was not referenced before
+                   (if (not (zerop code))
+                       object
+                       (funcall function object stream)))
+                  ((zerop code)
+                   ;; Object is not referenced twice
+                   (funcall function object stream))
+                  ((minusp code)
+                   ;; Object is referenced twice. We print its definition 
+                   (write-char #\# stream)
+                   (let ((*print-radix* nil)
+                         (*print-base* 10))
+                     (write-ugly-object (- code) stream))
+                   (write-char #\= stream)
+                   (funcall function object stream))
+                  (t
+                   ;; Second reference to the object
+                   (write-char #\# stream)
+                   (let ((*print-radix* nil)
+                         (*print-base* 10))
+                     (write-ugly-object code stream))
+                   (write-char #\# stream)
+                   object))
+            ))
+      ;;; live is good, print simple
+      (funcall function object stream)
+      ))
 
 (defun do-pprint-logical-block (function object stream prefix
 				per-line-prefix-p suffix)
-  (unless (listp object)
-    (write-object object stream)
-    (return-from do-pprint-logical-block nil))
-  (when (and (not *print-readably*) (eql *print-level* 0))
-    (write-char #\# stream)
-    (return-from do-pprint-logical-block nil))
-  (unless (or (not *print-circle*)
-	      (fixnump object)
-	      (characterp object)
-	      (and (symbolp object) (symbol-package object)
-                   ;; This is so that we do handle print-circle even when e.g. pretty printing a vector
-                   ;; (for which object = nil here).
-                   ;; It doesn't SEEM to result in (NIL . NIL) being printed as (#1=NIL . #1#), but
-                   ;; I don't understand this very well.
-                   (not (null object))))
-    (let (code)
-      (cond ((not *circle-counter*)
-	     (let* ((hash (make-hash-table :test 'eq :size 1024
-					   :rehash-size 1.5
-					   :rehash-threshold 0.75))
-		    (*circle-counter* t)
-		    (*circle-stack* hash))
-	       (do-pprint-logical-block function object
-					(make-pretty-stream (make-broadcast-stream))
-					prefix per-line-prefix-p suffix)
-	       (setf *circle-counter* 0)
-	       (do-pprint-logical-block function object stream
-					prefix per-line-prefix-p suffix))
-	     (return-from do-pprint-logical-block nil))
-	    ((zerop (setf code (search-print-circle object)))
-	     ;; Object was not referenced before: we must either traverse it
-	     ;; or print it.
-	     )
-	    ((minusp code)
-	     ;; First definition, we write the #n=... prefix
-	     (write-string "#" stream)
-	     (let ((*print-radix* nil) (*print-base* 10))
-	       (write-ugly-object (- code) stream))
-	     (write-string "=" stream))
-	    (t
-	     ;; Further references, we write the #n# tag and exit
-	     (write-string "#" stream)
-	     (let ((*print-radix* nil) (*print-base* 10))
-	       (write-ugly-object code stream))
-	     (write-string "#" stream)
-	     (return-from do-pprint-logical-block nil)))))
-  (let ((*print-level* (and (not *print-readably*)
-			    *print-level*
-			    (1- *print-level*))))
-    (start-logical-block stream prefix per-line-prefix-p suffix)
-    (funcall function object stream)
-    (end-logical-block stream))
+  (cond ((not (listp object))
+         (write-object object stream))
+        ((and (not *print-readably*) (eql *print-level* 0))
+         (write-char #\# stream))
+        (t (write-object-with-circle
+            object stream
+            #'(lambda (object stream1)
+                (unless (pretty-stream-p stream1)
+                  (setf stream1 (make-pretty-stream stream1)))
+                (let ((*print-level* (and (not *print-readably*)
+                                          *print-level*
+                                          (1- *print-level*))))
+                  (start-logical-block stream1 prefix per-line-prefix-p suffix)
+                  (funcall function object stream1)
+                  (end-logical-block stream1))))))
   nil)
 
 (defun pprint-logical-block-helper (function object stream prefix
@@ -1220,13 +1228,16 @@
 	 (pprint-multi-dim-array stream array))))
 
 (defun pprint-vector (stream vector)
-  (pprint-logical-block (stream nil :prefix "#(" :suffix ")")
-    (dotimes (i (length vector))
-      (unless (zerop i)
-	(write-char #\space stream)
-	(pprint-newline :fill stream))
-      (pprint-pop)
-      (write-object (aref vector i) stream))))
+  (write-object-with-circle
+   vector stream
+   #'(lambda (vector stream)
+       (pprint-logical-block (stream nil :prefix "#(" :suffix ")")
+         (dotimes (i (length vector))
+           (unless (zerop i)
+             (write-char #\space stream)
+             (pprint-newline :fill stream))
+           (pprint-pop)
+           (write-object (aref vector i) stream))))))
 
 (defun pprint-array-contents (stream array)
   (declare (array array))
@@ -1253,19 +1264,24 @@
     (output-guts stream 0 (array-dimensions array))))
 
 (defun pprint-multi-dim-array (stream array)
+  (write-object-with-circle
+   array stream
+   #'(lambda (array stream)
   (funcall (formatter "#~DA") stream (array-rank array))
-  (pprint-array-contents stream array))
+  (pprint-array-contents stream array))))
 
 (defun pprint-raw-array (stream array)
-  (write-string "#A" stream)
-  (pprint-logical-block (stream nil :prefix "(" :suffix ")")
+  (write-object-with-circle
+   array stream
+   #'(lambda (array stream)
+       (pprint-logical-block (stream nil :prefix "#A(" :suffix ")")
     (write-object (array-element-type array) stream)
     (write-char #\Space stream)
     (pprint-newline :fill stream)
     (write-object (array-dimensions array) stream)
     (write-char #\Space stream)
     (pprint-newline :fill stream)
-    (pprint-array-contents stream array)))
+         (pprint-array-contents stream array)))))
 
 (defun pprint-lambda-list (stream lambda-list &rest noise)
   (declare (ignore noise))
@@ -1587,8 +1603,6 @@
     (with-package-iterator pprint-block)
     (with-simple-restart pprint-block)
     (with-standard-io-syntax pprint-progn))))
-
-
 
 (progn
   (let ((*print-pprint-dispatch* (make-pprint-dispatch-table)))

--- a/src/lisp/regression-tests/printer01.lisp
+++ b/src/lisp/regression-tests/printer01.lisp
@@ -464,12 +464,23 @@ wrong
 
 (test pprint-failure-2a
       ;; should only find  ".." once in the output, not twice
-      (= 2 (count #\.
-                  (let ((*package* (find-package :cl-user)))
-                    (with-output-to-string (stream)
-                      (with-standard-io-syntax
-                        (write `(this prints wrongly)
-                               :pretty t  :circle t :lines 1 :right-margin 15 :readably nil :stream stream)))))))
+      (let ((output 
+              (let ((*package* (find-package :cl-user)))
+                (with-output-to-string (stream)
+                  (with-standard-io-syntax
+                    (let ((the-list (let ((*package* (find-package :cl-user)))(read-from-string "(this prints wrongly)"))))
+                      (write the-list :pretty t  :circle t :lines 1 :right-margin 15 :readably nil :stream stream)))))))
+        (= 2 (count #\. output))))
+
+(test pprint-failure-2b
+      ;; should only find  ".." once in the output, not twice
+      (let ((output 
+              (let ((*package* (find-package :cl-user)))
+                (with-output-to-string (stream)
+                  (with-standard-io-syntax
+                    (let ((the-list (let ((*package* (find-package :core)))(read-from-string "(this prints wrongly)"))))
+                      (write the-list :pretty t  :circle t :lines 1 :right-margin 15 :readably nil :stream stream)))))))
+        (= 2 (count #\. output))))
 
 (test pprint-failure-2
       ;; should only find  ".." once in the output, not twice
@@ -479,49 +490,52 @@ wrong
                       (write `(1234 12345 1234567)
                              :pretty t  :circle t :lines 1 :right-margin 15 :readably nil :stream stream))))))
 (test pprint-failure-3a
-      (>
-       (length
-        (let ((*package* (find-package :cl-user)))
-          (with-output-to-string (stream)
-            (with-standard-io-syntax
-              (write #(PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV)
-                     :ESCAPE T :PRETTY T :CIRCLE T :LINES 0 :RIGHT-MARGIN 28 :readably nil :stream stream)))))
-       0))
+      (= 2 (count #\.
+                  (let ((*package* (find-package :cl-user)))
+                    (with-output-to-string (stream)
+                      (with-standard-io-syntax
+                        (write #(PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV PROGV)
+                               :ESCAPE T :PRETTY T :CIRCLE T :LINES 0 :RIGHT-MARGIN 28 :readably nil :stream stream)))))))
 
 (test pprint-failure-3b
-      (>
-       (length
-        (with-output-to-string (stream)
-          (with-standard-io-syntax
-            (write #(12345 12345 12345 12345 12345 12345 12345 12345 12345 12345 12345)
-                   :ESCAPE T :PRETTY T :CIRCLE T :LINES 1 :RIGHT-MARGIN 28 :readably nil :stream stream))))
-       0))
+      (= 2 (count #\.
+                  (with-output-to-string (stream)
+                    (with-standard-io-syntax
+                      (write #(12345 12345 12345 12345 12345 12345 12345 12345 12345 12345 12345)
+                             :ESCAPE T :PRETTY T :CIRCLE T :LINES 1 :RIGHT-MARGIN 28 :readably nil :stream stream))))))
+
+(test pprint-failure-3c
+      (= 2 (count #\.
+                  (with-output-to-string (stream)
+                    (with-standard-io-syntax
+                      (write #(1 1)
+                             :ESCAPE T :PRETTY T :CIRCLE T :LINES 1 :RIGHT-MARGIN 1 :readably nil :stream stream))))))
 
 (test write-string-happy-path
       (string-equal
        "ABABĀĀĀĀ » "
        (with-output-to-string (stream)
-               ;;; SimpleBaseString_O
+         ;;; SimpleBaseString_O
          (write-string
           (MAKE-ARRAY 2
                       :INITIAL-CONTENTS (list (code-char 65) (code-char 66))
                       :ELEMENT-TYPE 'base-char)
           stream)
-        ;;; Str8Ns_O
+         ;;; Str8Ns_O
          (write-string
           (MAKE-ARRAY 2
                       :INITIAL-CONTENTS (list (code-char 65) (code-char 66))
                       :adjustable t
                       :ELEMENT-TYPE 'base-char)
           stream)
-        ;;;  SimpleCharacterString_O
+         ;;;  SimpleCharacterString_O
          (write-string 
           (MAKE-ARRAY 2
                       :INITIAL-CONTENTS
                       (list (code-char 256) (code-char 256))
                       :ELEMENT-TYPE 'character)
           stream)
-        ;;;  StrWNs_O
+         ;;;  StrWNs_O
          (write-string
           (MAKE-ARRAY 2
                       :INITIAL-CONTENTS

--- a/src/lisp/regression-tests/set-unexpected-failures.lisp
+++ b/src/lisp/regression-tests/set-unexpected-failures.lisp
@@ -1,23 +1,11 @@
 (in-package #:clasp-tests)
 
 (setq *expected-failures*
-      '(;;; ANSI-PUSHNEW.14A 
+      '(
         LOOP-FIXNUM-1 LOOP-FINALLY-1 LOOP-FINALLY-2 LOOP-FINALLY-3 LOOP-FINALLY-4
         TYPES-CLASSES-10
-        ;;; printer
-        PRINT.ARRAY.RANDOM.1.TAKE.1
-        PRINT.ARRAY.RANDOM.1.TAKE.2
-        PRINT.VECTOR.RANDOM.1.TAKE.1
-        PRINT.VECTOR.RANDOM.1.TAKE.2
-
-        READ-SYMBOL.19
         READ-SUPPRESS.17
         CLHS-23.2.16
-        
-        READ-PRINT-CONSISTENCY-ARRAYS
         SBCL-CROSS-COMPILE-4 ;;;not important
         INCLUDE-LEVEL-2A INCLUDE-LEVEL-2B INCLUDE-LEVEL-3 ;;; a problem for sbcl x-compiling
-        ;;; more printer tests
-        PPRINT-FAILURE-2A
-        PPRINT-FAILURE-3A
-        PPRINT-FAILURE-3B))
+  ))


### PR DESCRIPTION
* this replaces https://github.com/clasp-developers/clasp/pull/958
* Finally fixes ansi-bugs `FORMAT.E.26, PRINT.SYMBOL.RANDOM.3, PRINT.ARRAY.2.25, PRINT.ARRAY.2.26, 
   PRINT.BACKQUOTE.RANDOM.1, PRINT.BACKQUOTE.RANDOM.5, 
   PRINT.BACKQUOTE.RANDOM.10, PRINT.BACKQUOTE.RANDOM.11, 
   PRINT.VECTOR.RANDOM.1, PRINT.VECTOR.RANDOM.2, PRINT.VECTOR.RANDOM.3, 
   PRINT.ARRAY.2.21, PRINT.ARRAY.2.22, PRINT.ARRAY.2.23, 
   PRINT.ARRAY.2.24, READ-SYMBOL.19, PRINT.BACKQUOTE.RANDOM.13, 
   PRINT.VECTOR.RANDOM.4.`
* no longer causes regressions in existing tests (in my first intent I had control errors not catching the throw)
* tested with
  * Regression tests
  * ansi-tests
* adapted expected errors for regression-test suite