### PR TITLE
Fix calls to find-method with :before or :after

### DIFF
--- a/src/lisp/kernel/clos/change.lsp
+++ b/src/lisp/kernel/clos/change.lsp
@@ -297,10 +297,10 @@
             ;; before method
             ;; not sure whether removing these is a good idea. Couldn't a user have defined them?
             ;; And e.g. have a subclass that retains the accessor.
-            (when (setq found (find-method gf-object ':before (list class-name) nil))
+            (when (setq found (find-method gf-object (list :before) (list class-name) nil))
               (remove-method gf-object found))
             ;; after method
-            (when (setq found (find-method gf-object ':after (list class-name) nil))
+            (when (setq found (find-method gf-object (list :after) (list class-name) nil))
               (remove-method gf-object found))
             ;; This is unnecessary but kind of nice?
             ;; Other implementations have different behavior.
@@ -317,10 +317,10 @@
             (when (setq found (find-method gf-object nil (list 'T class-name) nil))
               (remove-method gf-object found))
             ;; before method
-            (when (setq found (find-method gf-object ':before (list 'T class-name) nil))
+            (when (setq found (find-method gf-object (list :before) (list 'T class-name) nil))
               (remove-method gf-object found))
             ;; after method
-            (when (setq found (find-method gf-object ':after (list 'T class-name) nil))
+            (when (setq found (find-method gf-object (list :after) (list 'T class-name) nil))
               (remove-method gf-object found))
             (when (null (generic-function-methods gf-object))
               (fmakunbound writer))))))))


### PR DESCRIPTION
I don't know how to write a regression test for that, but the calls to find-method with ':before are wrong, qualifiers is defined as a list. Clasp compiler now nicely advises abut that.

```lisp
--52169(out)--> ; Compiling file: /Users/karstenpoeck/lisp/compiler/clasp-karsten/src/lisp/kernel/clos/change.lsp
--52169(out)--> Writing temporary bitcode file to: #P"/Users/karstenpoeck/lisp/compiler/clasp-karsten/build/boehm/fasl/cclasp-boehm-bitcode/src/lisp/kernel/clos/change.ll"
--52169(out)--> Writing faso file to: #P"/Users/karstenpoeck/lisp/compiler/clasp-karsten/build/boehm/fasl/cclasp-boehm-bitcode/src/lisp/kernel/clos/change.faso"
--52169(out)--> Time run(99.326 secs) consed(627751488 bytes)
--52169(err)--> ; caught WARNING:
--52169(err)--> ;   The derived type of #<OUTPUT  @0x12d23a131>
--52169(err)--> ;   is (MEMBER AFTER)
--52169(err)--> ;   but is asserted as (OR CONS (MEMBER NIL))
--52169(err)--> ;   by #<CLEAVIR-BIR:THEI>.
--52169(err)--> ;     at /Users/karstenpoeck/lisp/compiler/clasp-karsten/src/lisp/kernel/clos/change.lsp 303:30
--52169(err)--> ; 
--52169(err)--> ; caught WARNING:
--52169(err)--> ;   The derived type of #<OUTPUT  @0x12d230cc1>
--52169(err)--> ;   is (MEMBER BEFORE)
--52169(err)--> ;   but is asserted as (OR CONS (MEMBER NIL))
--52169(err)--> ;   by #<CLEAVIR-BIR:THEI>.
--52169(err)--> ;     at /Users/karstenpoeck/lisp/compiler/clasp-karsten/src/lisp/kernel/clos/change.lsp 300:30
--52169(err)--> ; 
--52169(err)--> ; caught WARNING:
--52169(err)--> ;   The derived type of #<OUTPUT  @0x12d2bea01>
--52169(err)--> ;   is (MEMBER AFTER)
--52169(err)--> ;   but is asserted as (OR CONS (MEMBER NIL))
--52169(err)--> ;   by #<CLEAVIR-BIR:THEI>.
--52169(err)--> ;     at /Users/karstenpoeck/lisp/compiler/clasp-karsten/src/lisp/kernel/clos/change.lsp 323:30
--52169(err)--> ; 
--52169(err)--> ; caught WARNING:
--52169(err)--> ;   The derived type of #<OUTPUT  @0x12d2b2111>
--52169(err)--> ;   is (MEMBER BEFORE)
--52169(err)--> ;   but is asserted as (OR CONS (MEMBER NIL))
--52169(err)--> ;   by #<CLEAVIR-BIR:THEI>.
--52169(err)--> ;     at /Users/karstenpoeck/lisp/compiler/clasp-karsten/src/lisp/kernel/clos/change.lsp 320:30
--52169(err)--> ; 
--52169(err)--> ; 
--52169(err)--> ; compilation unit finished
--52169(err)--> ;   caught 4 WARNING conditions
````

First I did not understood the message, but it is clear enough. Find-Method is defined as 
`(ftype (function (generic-function list list &optional t) (maybe method))
                find-method)`

`':before` is not a list but `(MEMBER BEFORE)` (printing seems to eat the `:`)

With the following test code I can validate the fix
```lisp
(defclass boo ()
  ((a :initarg :a :initform 23 :accessor %a)))

(defmethod %a :before ((me boo))
  45)

(trace find-method remove-method)

(defclass boo ()
  ((a :initarg :a :initform 23 :accessor %a)
   (b :initarg :b :initform 23 :accessor %b)))
````
Bad before fix:
```lisp
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION %A> NIL (BOO) NIL)
<1 (FIND-METHOD #<STANDARD-READER-METHOD %A (BOO)>)
1> (REMOVE-METHOD #<STANDARD-GENERIC-FUNCTION %A> #<STANDARD-READER-METHOD %A (BOO)>)
<1 (REMOVE-METHOD #<STANDARD-GENERIC-FUNCTION %A>)
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION %A> :BEFORE (BOO) NIL)
<1 (FIND-METHOD NIL)
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION %A> :AFTER (BOO) NIL)
<1 (FIND-METHOD NIL)
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION (SETF %A)> NIL (T BOO) NIL)
<1 (FIND-METHOD #<STANDARD-WRITER-METHOD (SETF %A) (T BOO)>)
1> (REMOVE-METHOD #<STANDARD-GENERIC-FUNCTION (SETF %A)> #<STANDARD-WRITER-METHOD (SETF %A) (T
                                                                                             BOO)>)
<1 (REMOVE-METHOD #<STANDARD-GENERIC-FUNCTION (SETF %A)>)
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION (SETF %A)> :BEFORE (T BOO) NIL)
<1 (FIND-METHOD NIL)
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION (SETF %A)> :AFTER (T BOO) NIL)
<1 (FIND-METHOD NIL)
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION %A> NIL (#<The STANDARD-CLASS COMMON-LISP-USER::BOO>) NIL)
<1 (FIND-METHOD NIL)

#<The STANDARD-CLASS COMMON-LISP-USER::BOO>
````
Good:
```lisp
COMMON-LISP-USER> (defclass boo ()
  ((a :initarg :a :initform 23 :accessor %a)
   (b :initarg :b :initform 23 :accessor %b)))
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION %A> NIL (BOO) NIL)
<1 (FIND-METHOD #<STANDARD-READER-METHOD %A (BOO)>)
1> (REMOVE-METHOD #<STANDARD-GENERIC-FUNCTION %A> #<STANDARD-READER-METHOD %A (BOO)>)
<1 (REMOVE-METHOD #<STANDARD-GENERIC-FUNCTION %A>)
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION %A> (:BEFORE) (BOO) NIL)
<1 (FIND-METHOD #<STANDARD-METHOD %A :BEFORE (BOO)>)
1> (REMOVE-METHOD #<STANDARD-GENERIC-FUNCTION %A> #<STANDARD-METHOD %A :BEFORE (BOO)>)
<1 (REMOVE-METHOD #<STANDARD-GENERIC-FUNCTION %A>)
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION %A> (:AFTER) (BOO) NIL)
<1 (FIND-METHOD NIL)
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION (SETF %A)> NIL (T BOO) NIL)
<1 (FIND-METHOD #<STANDARD-WRITER-METHOD (SETF %A) (T BOO)>)
1> (REMOVE-METHOD #<STANDARD-GENERIC-FUNCTION (SETF %A)> #<STANDARD-WRITER-METHOD (SETF %A) (T
                                                                                             BOO)>)
<1 (REMOVE-METHOD #<STANDARD-GENERIC-FUNCTION (SETF %A)>)
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION (SETF %A)> (:BEFORE) (T BOO) NIL)
<1 (FIND-METHOD NIL)
1> (FIND-METHOD #<STANDARD-GENERIC-FUNCTION (SETF %A)> (:AFTER) (T BOO) NIL)
<1 (FIND-METHOD NIL)

#<The STANDARD-CLASS COMMON-LISP-USER::BOO>
```` 