### PR TITLE
Fix compliation on Arch

### DIFF
--- a/include/clasp/core/core.h
+++ b/include/clasp/core/core.h
@@ -104,6 +104,7 @@ class type_info;
 #include <pthread.h>
 #endif
 
+#include <memory>
 #include <map>
 
 #define VARARGS

--- a/wscript
+++ b/wscript
@@ -2334,7 +2334,7 @@ class dummy_task(Task.Task):
 def runCmdLargeOutput(cmd):
     outf = StringIO()
     serr = StringIO()
-    proc = subprocess.Popen(cmd, bufsize=8192, shell=False, \
+    proc = subprocess.Popen(cmd, bufsize=8192, shell=False, text=True, \
                             stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     dataend = False
     while (proc.returncode is None) or (not dataend):


### PR DESCRIPTION
- Included `memory.h` to fix a bunch of `no template named 'shared_ptr' in namespace 'std'` errors.
- Set `text=True` on Popen for sbcl version check