### PR TITLE
Forgot imports into ext before exporting

### DIFF
--- a/src/lisp/kernel/init.lsp
+++ b/src/lisp/kernel/init.lsp
@@ -189,6 +189,10 @@
 (import 'core:argv :ext)
 (import 'core:rmdir :ext)
 (import 'core:mkstemp :ext)
+(import 'core:weak-pointer-value :ext)
+(import 'core:make-weak-pointer :ext)
+(import 'core:weak-pointer-valid :ext)
+(import 'core:hash-table-weakness :ext)
 
 ;;; EXT exports
 (eval-when (:execute :compile-toplevel :load-toplevel)


### PR DESCRIPTION
did not import the 4 symbols from core before exporting them. Now they really work in ext