### PR TITLE
Fix some least float constants

### DIFF
--- a/src/core/numerics.cc
+++ b/src/core/numerics.cc
@@ -206,29 +206,31 @@ SYMBOL_EXPORT_SC_(ClPkg, pi);
 void exposeCando_Numerics() {
   cl::_sym_mostPositiveSingleFloat->defconstant(clasp_make_single_float(FLT_MAX));
   cl::_sym_mostNegativeSingleFloat->defconstant(clasp_make_single_float(-FLT_MAX));
-  cl::_sym_leastPositiveSingleFloat->defconstant(clasp_make_single_float(FLT_MIN));
-  cl::_sym_leastNegativeSingleFloat->defconstant(clasp_make_single_float(-FLT_MIN));
+  cl::_sym_leastPositiveSingleFloat->defconstant(clasp_make_single_float( std::numeric_limits<float>::denorm_min()));
+  cl::_sym_leastNegativeSingleFloat->defconstant(clasp_make_single_float(-std::numeric_limits<float>::denorm_min()));
   cl::_sym_mostPositiveShortFloat->defconstant(clasp_make_single_float(FLT_MAX));
   cl::_sym_mostNegativeShortFloat->defconstant(clasp_make_single_float(-FLT_MAX));
-  cl::_sym_leastPositiveShortFloat->defconstant(clasp_make_single_float(FLT_MIN));
-  cl::_sym_leastNegativeShortFloat->defconstant(clasp_make_single_float(-FLT_MIN));
+  cl::_sym_leastPositiveShortFloat->defconstant(clasp_make_single_float( std::numeric_limits<float>::denorm_min()));
+  cl::_sym_leastNegativeShortFloat->defconstant(clasp_make_single_float(-std::numeric_limits<float>::denorm_min()));
   cl::_sym_mostPositiveDoubleFloat->defconstant(DoubleFloat_O::create(DBL_MAX));
   cl::_sym_mostNegativeDoubleFloat->defconstant(DoubleFloat_O::create(-DBL_MAX));
-  cl::_sym_leastPositiveDoubleFloat->defconstant(DoubleFloat_O::create(DBL_MIN));
-  cl::_sym_leastNegativeDoubleFloat->defconstant(DoubleFloat_O::create(-DBL_MIN));
+  cl::_sym_leastPositiveDoubleFloat->defconstant(DoubleFloat_O::create(std::numeric_limits<double>::denorm_min()));
+  cl::_sym_leastNegativeDoubleFloat->defconstant(DoubleFloat_O::create(-std::numeric_limits<double>::denorm_min()));
   cl::_sym_mostPositiveLongFloat->defconstant(DoubleFloat_O::create(DBL_MAX));
   cl::_sym_mostNegativeLongFloat->defconstant(DoubleFloat_O::create(-DBL_MAX));
-  cl::_sym_leastPositiveLongFloat->defconstant(DoubleFloat_O::create(DBL_MIN));
-  cl::_sym_leastNegativeLongFloat->defconstant(DoubleFloat_O::create(-DBL_MIN));
-  cl::_sym_leastNegativeNormalizedSingleFloat->defconstant(clasp_make_single_float(-std::numeric_limits<float>::denorm_min()));
-  cl::_sym_leastNegativeNormalizedShortFloat->defconstant(clasp_make_single_float(-std::numeric_limits<float>::denorm_min()));
-  cl::_sym_leastNegativeNormalizedDoubleFloat->defconstant(DoubleFloat_O::create(-std::numeric_limits<double>::denorm_min()));
-  cl::_sym_leastNegativeNormalizedLongFloat->defconstant(LongFloat_O::create(-std::numeric_limits<LongFloat>::denorm_min()));
+  cl::_sym_leastPositiveLongFloat->defconstant(DoubleFloat_O::create(std::numeric_limits<double>::denorm_min()));
+  cl::_sym_leastNegativeLongFloat->defconstant(DoubleFloat_O::create(-std::numeric_limits<double>::denorm_min()));
+  
+  cl::_sym_leastNegativeNormalizedSingleFloat->defconstant(clasp_make_single_float(-FLT_MIN));
+  cl::_sym_leastNegativeNormalizedShortFloat->defconstant(clasp_make_single_float(-FLT_MIN));
+  cl::_sym_leastNegativeNormalizedDoubleFloat->defconstant(DoubleFloat_O::create(-DBL_MIN));
+  cl::_sym_leastNegativeNormalizedLongFloat->defconstant(LongFloat_O::create(-DBL_MIN));
   // the following must be positive, not negative, fixes #434
-  cl::_sym_leastPositiveNormalizedSingleFloat->defconstant(clasp_make_single_float(std::numeric_limits<float>::denorm_min()));
-  cl::_sym_leastPositiveNormalizedShortFloat->defconstant(clasp_make_single_float(std::numeric_limits<float>::denorm_min()));
-  cl::_sym_leastPositiveNormalizedDoubleFloat->defconstant(DoubleFloat_O::create(std::numeric_limits<double>::denorm_min()));
-  cl::_sym_leastPositiveNormalizedLongFloat->defconstant(LongFloat_O::create(std::numeric_limits<LongFloat>::denorm_min()));
+  cl::_sym_leastPositiveNormalizedSingleFloat->defconstant(clasp_make_single_float(FLT_MIN));
+  cl::_sym_leastPositiveNormalizedShortFloat->defconstant(clasp_make_single_float(FLT_MIN));
+  cl::_sym_leastPositiveNormalizedDoubleFloat->defconstant(DoubleFloat_O::create(DBL_MIN));
+  cl::_sym_leastPositiveNormalizedLongFloat->defconstant(LongFloat_O::create(DBL_MIN));
+  
   cl::_sym_pi->defconstant(DoubleFloat_O::create(3.14159265358979323846264338));
   // extensions
   ext::_sym_singleFloatPositiveInfinity->defconstant(clasp_make_single_float(std::numeric_limits<float>::infinity()));

--- a/src/lisp/regression-tests/numbers.lisp
+++ b/src/lisp/regression-tests/numbers.lisp
@@ -654,3 +654,61 @@
               unless (equal x y)
               do (format t "Diff ~a with ~a~2%" x y)))
         (values no-error-p)))
+
+(test-true float-constants-1
+      (<=  least-positive-double-float least-positive-normalized-double-float
+           least-positive-single-float least-positive-normalized-single-float))
+
+(test-true float-constants-2
+      (<=  least-positive-long-float least-positive-normalized-long-float
+           least-positive-short-float least-positive-normalized-short-float))
+
+(test-true float-constants-3
+      (<= least-positive-long-float least-positive-double-float
+          least-positive-single-float least-positive-short-float))
+
+(test-true float-constants-4
+      (<= least-positive-normalized-long-float least-positive-normalized-double-float
+          least-positive-normalized-single-float least-positive-normalized-short-float))
+
+(test-true float-constants-1-negative
+      (>=  least-negative-double-float least-negative-normalized-double-float
+           least-negative-single-float least-negative-normalized-single-float))
+
+(test-true float-constants-2-negative
+      (>=  least-negative-long-float least-negative-normalized-long-float
+           least-negative-short-float least-negative-normalized-short-float))
+
+(test-true float-constants-3-negative
+      (>= least-negative-long-float  least-negative-double-float
+          least-negative-single-float least-negative-short-float))
+
+(test-true float-constants-4-negative
+      (>= least-negative-normalized-long-float  least-negative-normalized-double-float
+          least-negative-normalized-single-float least-negative-normalized-short-float))
+
+(test-true float-constants-5
+      (every #'plusp
+             (list least-positive-short-float least-positive-normalized-short-float
+                   least-positive-single-float least-positive-normalized-single-float
+                   least-positive-double-float least-positive-normalized-double-float
+                   least-positive-long-float least-positive-normalized-double-float)))
+
+(test-true float-constants-5-negative
+      (every #'minusp
+             (list least-negative-short-float least-negative-normalized-short-float
+                   least-negative-single-float least-negative-normalized-single-float
+                   least-negative-double-float least-negative-normalized-double-float
+                   least-negative-long-float least-negative-normalized-long-float)))
+
+(test-true random-short
+      (zerop (random least-positive-short-float)))
+
+(test-true random-single
+      (zerop (random least-positive-single-float)))
+
+(test-true random-double
+      (zerop (random least-positive-double-float)))
+
+(test-true random-long
+      (zerop (random least-positive-long-float)))


### PR DESCRIPTION
The `least-*` and `least-*-nomalized-*` constants we confused. `*denorm_min` is for the `least-*` constants, `<X>_MIN` for the normalized.

Added tests following the adpated test-framework