### PR TITLE
Allow debugger.cc to compile on macos

### DIFF
--- a/src/core/debugger.cc
+++ b/src/core/debugger.cc
@@ -36,8 +36,7 @@ THE SOFTWARE.
 #include <libunwind.h>
 #endif
 #ifdef _TARGET_OS_DARWIN
-#import <mach-o/dyld.h>
-#import <mach-o/nlist.h>
+#include <dlfcn.h>
 #include <sys/mman.h>
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
w/o this change 2 errors would happen:
* A lot of dwarf symbols where defined twice (and second definition errors)
* `dlclose` was not defined