### PR TITLE
Cleanup Drop all exported symbols from ext that are not used

### DIFF
--- a/include/clasp/core/debugger.h
+++ b/include/clasp/core/debugger.h
@@ -47,9 +47,7 @@ int core__ihs_current_frame();
       If the idx is out of bounds then return a valid value */
 void core__gdb(T_sp msg);
 int core__set_ihs_current_frame(int idx);
-void core__btcl(T_sp stream, bool all, bool args, bool source_info);
-
-
+ 
 }; // namespace core
 
 namespace core {
@@ -201,14 +199,6 @@ DebugInfo& debugInfo();
 void executablePath( std::string& name);
 void executableTextSectionRange( gctools::clasp_ptr_t& start, gctools::clasp_ptr_t& end );
 void executableVtableSectionRange( gctools::clasp_ptr_t& start, gctools::clasp_ptr_t& end );
-
-
-};
-
-extern "C" {
-// Generate a backtrace with JIT symbols resolved 
-void c_bt();
-void c_btcl();
 
 
 };

--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -172,7 +172,6 @@ SYMBOL_EXPORT_SC_(ExtPkg, STARinvoke_debugger_hookSTAR);
 SYMBOL_EXPORT_SC_(CorePkg,variable_source_location)
 SYMBOL_EXPORT_SC_(CorePkg,class_source_location)
 SYMBOL_EXPORT_SC_(CorePkg,STARdebug_hash_tableSTAR)
-SYMBOL_EXPORT_SC_(CorePkg,btcl)
 SYMBOL_EXPORT_SC_(CorePkg,STARdebug_fastgfSTAR);
 SYMBOL_EXPORT_SC_(CorePkg,cxx_method_source_location);
 SYMBOL_EXPORT_SC_(CompPkg, STARcompile_file_parallelSTAR);
@@ -201,8 +200,6 @@ SYMBOL_EXPORT_SC_(ExtPkg,unix_signal_received);
 SYMBOL_EXPORT_SC_(KeywordPkg,process);
 SYMBOL_EXPORT_SC_(KeywordPkg,code);
 SYMBOL_EXPORT_SC_(KeywordPkg,handler);
-SYMBOL_EXPORT_SC_(ExtPkg,information_interrupt);
-
 
 SYMBOL_EXPORT_SC_(CorePkg, STARmpi_rankSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARmpi_sizeSTAR);
@@ -380,7 +377,6 @@ SYMBOL_EXPORT_SC_(ExtPkg, STARdefault_external_formatSTAR);
 SYMBOL_EXPORT_SC_(ExtPkg, specialVar);
 SYMBOL_EXPORT_SC_(ExtPkg, registerVar);
 SYMBOL_EXPORT_SC_(ExtPkg, lexicalVar);
-SYMBOL_EXPORT_SC_(ExtPkg, stackVar);
 SYMBOL_EXPORT_SC_(CorePkg, _PLUS_numberOfFixedArguments_PLUS_);
 SYMBOL_EXPORT_SC_(CorePkg, STARinterpreterTraceSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARdebugLoadTimeValuesSTAR);

--- a/src/core/debugger.cc
+++ b/src/core/debugger.cc
@@ -540,15 +540,6 @@ void tprint(void* ptr)
   core::dbg_printTPtr((uintptr_t) ptr,false);
 }
 
-void c_bt() {
-  core::eval::funcall(core::_sym_btcl->symbolFunction(),
-                      INTERN_(kw,all),_lisp->_true());
-};
-
-void c_btcl() {
-  core::eval::funcall(core::_sym_btcl->symbolFunction());
-};
-
 void tsymbol(void* ptr)
 {
   printf("%s:%d Looking up symbol at ptr->%p\n", __FILE__, __LINE__, ptr);

--- a/src/core/instance.cc
+++ b/src/core/instance.cc
@@ -189,21 +189,26 @@ CL_DEFUN Instance_sp core__allocate_raw_general_instance(Instance_sp cl, Rack_sp
   return obj;
 }
 
-SYMBOL_EXPORT_SC_(ExtPkg,fieldsp);
-SYMBOL_EXPORT_SC_(ExtPkg,fields);
-
+SYMBOL_EXPORT_SC_(CorePkg, fieldsp);
 
 bool Instance_O::fieldsp() const {
-  if (ext::_sym_fieldsp->fboundp()) {
-    T_sp result = eval::funcall(ext::_sym_fieldsp,this->asSmartPtr());
+  if (core::_sym_fieldsp->fboundp()) {
+    T_sp result = eval::funcall(core::_sym_fieldsp,this->asSmartPtr());
     return result.notnilp();
   }
   return false;
 }
 
+// funcalling ext::fields can't work, since ext::fields is unbound
+// so at least let protect it
+// and export it from core to be consistent 
+SYMBOL_EXPORT_SC_(CorePkg,fields);
 void Instance_O::fields(Record_sp node) {
-  eval::funcall(ext::_sym_fields,this->asSmartPtr(),node);
+  if (core::_sym_fields->fboundp()) {
+    eval::funcall(core::_sym_fields,this->asSmartPtr(),node);
+  }
 }
+
 
 DOCGROUP(clasp)
 CL_DEFUN Rack_sp core__instance_rack(Instance_sp instance) {

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -2099,8 +2099,6 @@ CL_DEFUN T_mv core__universal_error_handler(T_sp continueString, T_sp datum, Lis
   dbg_hook("universalErrorHandler");
   if (globals_->_Interactive) {
     core__invoke_internal_debugger(nil<T_O>());
-  } else {
-    c_bt();
   }
   abort();
 };

--- a/src/gctools/interrupt.cc
+++ b/src/gctools/interrupt.cc
@@ -709,9 +709,12 @@ void initialize_unix_signal_handlers() {
 #ifdef SIGWINCH
         ADD_SIGNAL( SIGWINCH, "SIGWINCH", nil<core::T_O>());
 #endif
+/*
+ext::_sym_information_interrupt is undefined
 #ifdef SIGINFO
         ADD_SIGNAL( SIGINFO, "SIGINFO", ext::_sym_information_interrupt);
 #endif
+*/
 #if 0
 #ifdef SIGUSR1
         ADD_SIGNAL( SIGUSR1, "SIGUSR1", nil<core::T_O>());
@@ -721,9 +724,11 @@ void initialize_unix_signal_handlers() {
 #ifdef _TARGET_OS_DARWIN
         ADD_SIGNAL( SIGUSR2, "SIGUSR2", nil<core::T_O>());
 #endif
+/*
 #ifdef _TARGET_OS_LINUX
         ADD_SIGNAL( SIGUSR2, "SIGUSR2", ext::_sym_information_interrupt);
 #endif
+*/
 #endif
 #ifdef SIGTHR
         ADD_SIGNAL( SIGTHR, "SIGTHR", nil<core::T_O>());

--- a/src/lisp/kernel/clos/closfastgf.lsp
+++ b/src/lisp/kernel/clos/closfastgf.lsp
@@ -722,7 +722,6 @@ Return true iff a new entry was added; so for example it will return false if an
   (when (find (cons generic-function (core:list-from-va-list valist-args)) *dispatch-miss-recursion-check*
               :test #'equal)
     (format t "~&Recursive dispatch miss detected~%")
-    (ext:btcl)
     (ext:quit 1))
   (let (#+debug-fastgf
         (*dispatch-miss-recursion-check* (cons (cons generic-function

--- a/src/lisp/kernel/init.lsp
+++ b/src/lisp/kernel/init.lsp
@@ -183,7 +183,6 @@
 
 ;;; Imports
 (import 'core:quit :ext)
-(import 'core:btcl :ext)
 (import 'core:getpid :ext)
 (import 'core:argc :ext)
 (import 'core:argv :ext)
@@ -217,11 +216,9 @@
           integer32
           byte64
           integer64
-          cl-fixnum
           assume-no-errors
           sequence-stream
           all-encodings
-          load-encoding
           make-encoding
           assume-right-type
           assert-error
@@ -234,7 +231,6 @@
           stream-decoding-error
           generate-encoding-hashtable
           quit
-          btcl
           with-float-traps-masked
           enable-interrupt default-interrupt ignore-interrupt
           get-signal-handler set-signal-handler

--- a/src/lisp/kernel/lsp/encodings.lsp
+++ b/src/lisp/kernel/lsp/encodings.lsp
@@ -72,8 +72,6 @@
             (setf all-encodings (append all-encodings unicode-encodings)))
           all-encodings))))
 
-(export 'ext:all-encodings :ext)
-
 (defun ext:make-encoding (encoding)
   (ecase encoding
     ((:US-ASCII

--- a/src/lisp/kernel/lsp/packages.lsp
+++ b/src/lisp/kernel/lsp/packages.lsp
@@ -151,7 +151,6 @@
             assume-no-errors
             sequence-stream
             all-encodings
-            load-encoding
             make-encoding
             assume-right-type
             segmentation-violation
@@ -165,12 +164,9 @@
             unix-signal-received-handler
             interactive-interrupt
             compiled-function-file
-            lisp-implementation-vcs-id
             getcwd
             chdir
             +process-standard-input+
-            external-process-wait
-            external-process-status
             compiled-function-name
             system
             float-nan-string


### PR DESCRIPTION
* ext:core__btcl
* ext:c_bt
* ext:c_btcl
* ext:information_interrupt
* ext: stackVar
* ext:fieldsp (is defined in core)
* ext:fields (renamed to core:fields for consistency)
* ext:cl-fixnum
* ext:load-encoding
* ext:lisp-implementation-vcs-id
* ext:external-process-wait
* ext:external-process-status
* droped some double exports
* 
rebuild all including cando, icando-boehm startsup fine