### PR TITLE
Cleanup package cmp

### DIFF
--- a/src/core/compPackage.cc
+++ b/src/core/compPackage.cc
@@ -39,7 +39,6 @@ SYMBOL_SC_(CompPkg, aSingleCompilerSymbol);
 SYMBOL_EXPORT_SC_(CompPkg, STARlowLevelTraceSTAR);
 SYMBOL_EXPORT_SC_(CompPkg, STARthe_moduleSTAR);
 SYMBOL_EXPORT_SC_(CompPkg, STARlowLevelTracePrintSTAR);
-SYMBOL_EXPORT_SC_(CompPkg, jit_remove_module);
 SYMBOL_EXPORT_SC_(CompPkg, jit_register_symbol);
 SYMBOL_EXPORT_SC_(CompPkg, STARjit_saved_symbol_infoSTAR);
 SYMBOL_EXPORT_SC_(CompPkg, STARsave_module_for_disassembleSTAR);

--- a/src/core/compiler.cc
+++ b/src/core/compiler.cc
@@ -1453,7 +1453,6 @@ CL_DEFUN T_sp core__handle_creator( T_sp object ) {
 
  SYMBOL_EXPORT_SC_(CompPkg, STARimplicit_compile_hookSTAR);
  SYMBOL_EXPORT_SC_(CompPkg, implicit_compile_hook_default);
- SYMBOL_EXPORT_SC_(CompPkg, STARall_functions_for_one_compileSTAR);
  SYMBOL_SC_(CorePkg, dlopen);
  SYMBOL_SC_(CorePkg, dlsym);
  SYMBOL_SC_(CorePkg, dladdr);

--- a/src/lisp/kernel/cmp/cmpexports.lsp
+++ b/src/lisp/kernel/cmp/cmpexports.lsp
@@ -1,7 +1,6 @@
 (in-package :cmp)
 (eval-when (:compile-toplevel :load-toplevel :execute)
-  (export '(
-            with-debug-info-source-position
+  (export '(with-debug-info-source-position
             with-interpreter
             module-report
             codegen-startup-shutdown
@@ -18,7 +17,6 @@
             *default-linkage*
             *compile-file-parallel-write-bitcode*
             *default-compile-linkage*
-            *gcroots-in-module*
             quick-module-dump
             write-bitcode
             load-bitcode
@@ -37,29 +35,22 @@
             *cleavir-compile-file-hook*
             *cleavir-compile-hook*
             *compile-print*
-            *compile-counter*
-            *compile-duration-ns*
             *current-function*
             *current-function-name*
-            *current-function-description*
             *current-unwind-landing-pad-dest*
             *debug-compile-file*
             *debug-compile-file-counter*
             *generate-compile-file-load-time-values*
             module-literal-table
             *gv-current-function-name*
-            *gv-source-namestring*
             *implicit-compile-hook*
             *irbuilder*
-            llvm-context
             *thread-safe-context*
             thread-local-llvm-context
             *load-time-value-holder-global-var*
             *low-level-trace*
             *low-level-trace-print*
-            *run-time-literal-holder*
             *run-time-values-table-name*
-            ;;          *run-time-values-table*
             #+(or)*run-time-values-table-global-var*
             *the-module*
             +header-size+
@@ -69,12 +60,12 @@
             +fixnum-mask+
             +fixnum00-tag+
             +fixnum01-tag+
-            +fixnum10-tag+
-            +fixnum11-tag+
+            #+tag-bits4 +fixnum10-tag+
+            #+tag-bits4 +fixnum11-tag+
             +alignment+
-            +vaslist-ptag-mask+
+            #+tag-bits4 +vaslist-ptag-mask+
             +vaslist0-tag+
-            +vaslist1-tag+
+            #+tag-bits4 +vaslist1-tag+
             +single-float-tag+
             +character-tag+
             +general-tag+
@@ -114,17 +105,13 @@
             entry-point-reference-index
             function-type-create-on-the-fly
             evaluate-foreign-arguments
-            jit-remove-module
             calling-convention-closure
             calling-convention-use-only-registers
-            calling-convention-args
             calling-convention-args.va-arg
             calling-convention-va-list*
             calling-convention-register-save-area*
             calling-convention-nargs
             calling-convention-register-args
-            calling-convention-write-registers-to-multiple-values
-            describe-constants-table
             cmp-log
             cmp-log-dump-module
             cmp-log-dump-function
@@ -133,7 +120,6 @@
             function-info
             make-function-info
             irc-create-call-wft
-            irc-create-invoke
             irc-calculate-entry
             irc-calculate-real-args
             compile-file-to-module
@@ -145,14 +131,9 @@
             compile-lambda-function
             compile-lambda-list-code
             make-calling-convention-impl
-            bclasp-compile-form
-            compile-form
             compiler-error
             compiler-warn
             compiler-style-warn
-            compiler-fatal-error
-            compiler-message-file
-            compiler-message-file-position
             define-primitive
             warn-undefined-global-variable
             warn-undefined-type
@@ -161,7 +142,6 @@
             warn-icsp-iesp-both-specified
             register-global-function-def
             register-global-function-ref
-            analyze-top-level-form
             safe-system
             jit-constant-uintptr_t
             irc-sext
@@ -201,12 +181,10 @@
             irc-bit-cast
             irc-pointer-cast
             irc-maybe-cast-integer-to-t*
-            irc-create-invoke
             irc-create-invoke-default-unwind
             irc-create-landing-pad
             irc-exception-typeid*
             irc-extract-value
-            irc-generate-terminate-code
             irc-gep
             irc-gep-variable
             irc-smart-ptr-extract
@@ -325,12 +303,8 @@
             %vaslist%
             %register-save-area%
             null-t-ptr
-            compile-error-if-wrong-number-of-arguments
             compile-error-if-too-many-arguments
-            compile-throw-if-excess-keyword-arguments
             *irbuilder-function-alloca*
-            irc-get-terminate-landing-pad-block
-            irc-function-cleanup-and-return
             %RUN-AND-LOAD-TIME-VALUE-HOLDER-GLOBAL-VAR-TYPE%
             compute-rest-alloc
             compile-tag-check

--- a/src/lisp/kernel/cmp/jit-setup.lsp
+++ b/src/lisp/kernel/cmp/jit-setup.lsp
@@ -779,7 +779,7 @@ No DIBuilder is defined for the default module")
 ;;;(in-package :cmp)
 (defparameter *dump-compile-module* nil)
 (progn
-  (export '(jit-add-module-return-function jit-add-module-return-dispatch-function jit-remove-module))
+  (export '(jit-add-module-return-function))
   (defparameter *jit-lock* (mp:make-recursive-mutex 'jit-lock))
   (defun jit-add-module-return-function (original-module main-fn startup-shutdown-id literals-list
                                          &key output-path name)

--- a/src/lisp/kernel/cmp/runtime-info.lsp
+++ b/src/lisp/kernel/cmp/runtime-info.lsp
@@ -80,7 +80,8 @@
 (defvar +alignment+ (get-cxx-data-structure-info :alignment))
 (defvar +args-in-registers+ (get-cxx-data-structure-info :lcc-args-in-registers))
 (export '(+fixnum-mask+ +ptag-mask+ +immediate-mask+
-          +cons-tag+ +fixnum-tag+ +character-tag+ +single-float-tag+
+          +cons-tag+
+          +character-tag+ +single-float-tag+
           +general-tag+ +vaslist-size+ +void*-size+ +alignment+ ))
 (defvar +cons-car-offset+ (get-cxx-data-structure-info :cons-car-offset))
 (defvar +cons-cdr-offset+ (get-cxx-data-structure-info :cons-cdr-offset))


### PR DESCRIPTION
as with the other cleanups
* don't export symbols that don't need o be expored
   * do that in c++
   * do hat in lisp
   * also conditionalize some variables, that need to be e.g. `#+tag-bits4 +fixnum10-tag+`
* test with
   * regression tests
   * cando
   * ansi-tests
   * some quicklisp packages