### PR TITLE
drop not needed exports from lisp or c++

### DIFF
--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -291,7 +291,6 @@ SYMBOL_EXPORT_SC_(CorePkg, STARdebugByteCodeSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARdebugSourcePosInfoSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARdebugVaslistSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, _BANG_unbound_BANG_);
-SYMBOL_EXPORT_SC_(CorePkg, bitArrayOp);
 SYMBOL_EXPORT_SC_(CorePkg, lambdaName);
 SYMBOL_EXPORT_SC_(CorePkg, dump_module);
 SYMBOL_EXPORT_SC_(CorePkg, STARfunctions_to_inlineSTAR);

--- a/src/core/functor.cc
+++ b/src/core/functor.cc
@@ -633,10 +633,9 @@ CL_DEFUN_SETF T_sp setf_function_docstring(T_sp doc, Function_sp func) {
 SYMBOL_SC_(CompPkg,vtable);
 SYMBOL_SC_(CompPkg,entry);
 SYMBOL_EXPORT_SC_(CorePkg,entry_point);
-SYMBOL_EXPORT_SC_(CorePkg,object_file);
-SYMBOL_EXPORT_SC_(CompPkg,closure_type);
-SYMBOL_EXPORT_SC_(CompPkg,data_length);
-SYMBOL_EXPORT_SC_(CompPkg,data0);
+SYMBOL_SC_(CompPkg,closure_type);
+SYMBOL_SC_(CompPkg,data_length);
+SYMBOL_SC_(CompPkg,data0);
 
 
 DOCGROUP(clasp)

--- a/src/lisp/kernel/cmp/cmpexports.lsp
+++ b/src/lisp/kernel/cmp/cmpexports.lsp
@@ -31,9 +31,7 @@
             irc-xep-functions-create
             xep-arity-arity
             xep-arity-function-or-placeholder
-            xep-arity-entry-point-reference
             xep-group-lookup
-            xep-group
             xep-group-p
             xep-group-arities
             xep-group-name
@@ -119,7 +117,6 @@
             function-type-create-on-the-fly
             evaluate-foreign-arguments
             calling-convention-closure
-            calling-convention-args
             calling-convention-vaslist*
             calling-convention-vaslist.va-arg
             calling-convention-nargs
@@ -145,8 +142,6 @@
             compile-lambda-function
             compile-lambda-list-code
             make-calling-convention
-            bclasp-compile-form
-            compile-form
             compiler-error
             compiler-warn
             compiler-style-warn
@@ -261,7 +256,6 @@
             irc-array-total-size
             irc-array-rank
             gen-%array-dimension
-            irc-vaslist-vaslist-address
             irc-vaslist-nargs-address
             gen-instance-rack
             gen-instance-rack-set
@@ -332,8 +326,6 @@
             null-t-ptr
             compile-error-if-too-many-arguments
             *irbuilder-function-alloca*
-            irc-get-terminate-landing-pad-block
-            irc-function-cleanup-and-return
             irc-calculate-call-info
             %RUN-AND-LOAD-TIME-VALUE-HOLDER-GLOBAL-VAR-TYPE%
             compute-rest-alloc
@@ -372,7 +364,6 @@
           *byte-codes*
           add-creator
           next-value-table-holder-name
-          general-entry-placeholder
           general-entry-placeholder-p
           ensure-not-placeholder
           make-general-entry-placeholder
@@ -384,11 +375,9 @@
           register-local-function-index
           register-xep-function-indices
           literal-node-runtime-p
-          literal-node-runtime-index
           literal-node-runtime-object
           literal-node-closure-p
           literal-node-creator-p
-          literal-node-creator-index
           literal-node-creator-object
           literal-node-creator-name
           literal-node-creator-arguments
@@ -399,7 +388,6 @@
           literal-node-call-function
           literal-node-call-source-pos-info
           literal-node-call-holder
-          number-of-entries
           lookup-literal-index
           reference-literal
           load-time-reference-literal


### PR DESCRIPTION
* dropped symbols exported from lisp that are not used
* dropped symbols exported from c++ that are not used
* just `SYMBOL_SC_` symbols that are used in c++, but not in lisp

* tested by
  * build cando incl. starting icando-boehm
  * regression tests
  * ansi-tests 