### PR TITLE
Don't export unused with-simple-sequence-iterator

### DIFF
--- a/src/lisp/kernel/lsp/packages.lsp
+++ b/src/lisp/kernel/lsp/packages.lsp
@@ -94,7 +94,6 @@
                ;; helper macros
                dosequence
                with-sequence-iterator
-               with-simple-sequence-iterator
                ;; clasp extensions
                protocol-unimplemented
                protocol-unimplemented-operation


### PR DESCRIPTION
Symbol is exported, but not used for anything