### PR TITLE
Allow real-valued columns in Gray stream methods

### DIFF
--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -1569,7 +1569,7 @@ clos_stream_column(T_sp strm) {
   /* FIXME! The Gray streams specifies NIL is a valid
 	 * value but means "unknown". Should we make it
 	 * zero? */
-  return col.nilp() ? 0 : clasp_to_integral<int>(col);
+  return col.nilp() ? -1 : clasp_to_integral<int>(clasp_floor1(col));
 }
 
 static T_sp

--- a/src/lisp/kernel/clos/streams.lsp
+++ b/src/lisp/kernel/clos/streams.lsp
@@ -275,7 +275,7 @@
 				     column)
   (let ((current-column (stream-line-column stream)))
     (when current-column
-      (let ((fill (- column current-column)))
+      (let ((fill (floor (- column current-column))))
 	(dotimes (i fill)
 	  (stream-write-char stream #\Space)))
       T)))


### PR DESCRIPTION
`pprint-indent` allows real column values not just integers. Most print printers assume integers though since they were built for monospaced fonts. The Gray stream methods are ambiguous about the allowed values but should deal with real values to make `stream-advance-to-column` work for a proportional pretty printer.

Corresponding ECL PR: https://gitlab.com/embeddable-common-lisp/ecl/-/merge_requests/264
McCLIM PR that is currently reverted until issue is resolved in important implementations: McCLIM/McCLIM#1248
Some discussion here: https://irclog.tymoon.eu/libera/%23clim?around=1639832373#1639832373

FYI @dkochmanski 