### PR TITLE
Feature small clos fixes

### DIFF
--- a/src/lisp/kernel/clos/conditions.lsp
+++ b/src/lisp/kernel/clos/conditions.lsp
@@ -682,7 +682,7 @@ This is due to either a problem in foreign code (e.g., C++), or a bug in Clasp i
    (arguments :initarg :arguments :reader no-applicable-method-arguments))
   (:report
    (lambda (condition stream)
-     (format stream "No applicable method for ~A with ~
+     (format stream "No applicable method for ~S with ~
                   ~:[no arguments.~;arguments~%~t~:*(~{~S~^ ~})~]"
              (clos:generic-function-name
               (no-applicable-method-generic-function condition))

--- a/src/lisp/kernel/clos/standard.lsp
+++ b/src/lisp/kernel/clos/standard.lsp
@@ -222,8 +222,9 @@
 
 (defmethod initialize-instance :after
     ((class class) &rest initargs &key direct-slots)
-  (declare (dynamic-extent initargs)) ; see NOTE in reinitialize-instance/T
-  (dbg-standard "standard.lsp:226  initialize-instance class->~a~%" class)
+  (declare (dynamic-extent initargs) ; see NOTE in reinitialize-instance/T
+           (ignore initargs direct-slots))
+  (dbg-standard "standard.lsp:227  initialize-instance class->~a~%" class)
   (finalize-unless-forward class)
   ;; In this case we are assigning the stamp for the first time.
   (core:class-new-stamp class))


### PR DESCRIPTION
* Show package of symbol in clos:no-applicable-method-error, show that it is easier to identify
* Ignore unused variables to avoid cluttering the compiler output