### PR TITLE
Update for koga changes

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -9,16 +9,16 @@ DEB_BUILD_MAINT_OPTIONS=nocheck nostrip
 	dh $@
 
 override_dh_auto_clean:
-	echo rm -rf build
+	rm -rf build
 
 override_dh_auto_test:
 	echo ninja -C build test-boehmprecise
 
 override_dh_auto_configure:
-	sbcl --script configure.lisp --package-path $$(pwd)/debian/clasp/
+	./koga --package-path $$(pwd)/debian/clasp/
 
 override_dh_auto_build:
-	ninja -C build cclasp-boehmprecise
+	ninja -C build
 
 override_dh_auto_install:
-	ninja -C build install_cclasp-boehmprecise
+	ninja -C build install

--- a/repos.sexp
+++ b/repos.sexp
@@ -2,6 +2,10 @@
   :repository "https://github.com/scymtym/esrap.git"
   :directory "dependencies/esrap/"
   :branch "master")
+ (:name :quicklisp-client
+  :repository "https://github.com/quicklisp/quicklisp-client.git"
+  :directory "dependencies/quicklisp-client/"
+  :commit "version-2021-02-13")
  (:name :shasht
   :repository "https://github.com/yitzchak/shasht.git"
   :directory "dependencies/shasht/"

--- a/src/koga/ninja.lisp
+++ b/src/koga/ninja.lisp
@@ -6,6 +6,7 @@
 
 (defmethod print-prologue (configuration (name (eql :ninja)) output-stream)
   (ninja:write-bindings output-stream
+                        :quicklisp-client (make-source "dependencies/quicklisp-client/" :code)
                         :cflags (cflags configuration)
                         :cppflags (cppflags configuration)
                         :cxxflags (cxxflags configuration)
@@ -104,10 +105,10 @@
                     :command "$cxx $variant-ldflags $ldflags $ldflags-fasl -o$out $in $variant-ldlibs $ldlibs"
                     :description "Linking $out")
   (ninja:write-rule output-stream :jupyter-kernel
-                    :command "$clasp --non-interactive --load jupyter-kernel.lisp -- $name $bin-path $load-system $system"
+                    :command "CLASP_QUICKLISP_DIRECTORY=$quicklisp-client $clasp --non-interactive --load jupyter-kernel.lisp -- $name $bin-path $load-system $system"
                     :description "Installing jupyter kernel for $name")
   (ninja:write-rule output-stream :make-snapshot
-                    :command "$clasp --non-interactive $arguments --load snapshot.lisp -- $out"
+                    :command "CLASP_QUICKLISP_DIRECTORY=$quicklisp-client $clasp --non-interactive $arguments --load snapshot.lisp -- $out"
                     :description "Creating snapshot $out")
   (ninja:write-rule output-stream :make-snapshot-object
                     :command "$objcopy --input-target binary --output-target elf64-x86-64 --binary-architecture i386 $in $out --redefine-sym _binary_${mangled-name}_end=_binary_snapshot_end  --redefine-sym _binary_${mangled-name}_start=_binary_snapshot_start  --redefine-sym _binary_${mangled-name}_size=_binary_snapshot_size"

--- a/src/koga/ninja.lisp
+++ b/src/koga/ninja.lisp
@@ -294,7 +294,7 @@
                        :target (file-namestring (source-path exe-installed))
                        :outputs (list symlink-installed))
     (when (member :cando (extensions configuration))
-      (ninja:write-build output-stream :install-file
+      (ninja:write-build output-stream :install-binary
                                        :inputs (list clasp-sh)
                                        :outputs (list clasp-sh-installed)))
     (ninja:write-build output-stream :phony

--- a/src/lisp/kernel/lsp/epilogue-cclasp.lisp
+++ b/src/lisp/kernel/lsp/epilogue-cclasp.lisp
@@ -3,7 +3,18 @@
   (report-lexical-var-reference-depth))
 
 #+cclasp
+(cl:defun sys::cclasp-snapshot-load-foreign-libraries ()
+  (when (find-package :cffi)
+    (loop with list-foreign-libraries = (find-symbol "LIST-FOREIGN-LIBRARIES" :cffi)
+          with load-foreign-library = (find-symbol "LOAD-FOREIGN-LIBRARY" :cffi)
+          with foreign-library-name = (find-symbol "FOREIGN-LIBRARY-NAME" :cffi)
+          for lib in (ignore-errors (funcall list-foreign-libraries :loaded-only nil))
+          for name = (ignore-errors (funcall foreign-library-name lib))
+          do (ignore-errors (funcall load-foreign-library name)))))
+
+#+cclasp
 (cl:defun sys::cclasp-snapshot-load-top-level ()
+  (sys::cclasp-snapshot-load-foreign-libraries)
   (core:process-command-line-load-eval-sequence)
   (let ((core:*use-interpreter-for-eval* nil))
     (if (core:is-interactive-lisp)


### PR DESCRIPTION
Some random fixes.
- Update the debian scripts for the target and script name changes
- Fix permissions on clasp script
- Load foreign libraries in snapshot start. This was done in Cando but really needs to be in Clasp since it isn't a Cando specific issue. The code in Cando will have to be removed after this is merged. https://github.com/cando-developers/cando/blob/5d60f6d797c00bf3a48528ee2dc48ff10c20c34a/src/lisp/start-cando.lisp#L110-L116
- Add quicklisp-client so that Jupyter kernels can be created without relying on user's quicklisp installation or installing quicklisp to system directory.