### PR TITLE
Assure that unsafe_write_SimpleBaseString uses claspCharacter and not char

### DIFF
--- a/src/core/write_array.cc
+++ b/src/core/write_array.cc
@@ -226,12 +226,13 @@ void unsafe_write_SimpleBaseString(SimpleBaseString_sp str, size_t start, size_t
   cl_index ndx;
   if (!clasp_print_escape() && !clasp_print_readably()) {
     for (ndx = start; ndx < end; ndx++) {
-      clasp_write_char((*str)[ndx], stream);
+      claspCharacter c = (*str)[ndx];
+      clasp_write_char(c, stream);
     }
   } else {
     clasp_write_char('"', stream);
     for (ndx = start; ndx < end; ndx++) {
-      char c = (*str)[ndx];
+      claspCharacter c = (*str)[ndx];
       if (c == '"' || c == '\\')
         clasp_write_char('\\', stream);
       clasp_write_char(c, stream);


### PR DESCRIPTION
Fixes #1294 

Before the fix, the following in a repl lead to a segmentation fault in the printing of the result
```lisp
(make-array 2
                    :element-type 'base-char
                    :initial-contents
                    (list #\LATIN_CAPITAL_LETTER_I_WITH_CIRCUMFLEX
                          #\RIGHT-POINTING_DOUBLE_ANGLE_QUOTATION_MARK))
```

also works - but did before - for SimpleCharacterString_sp e.g.
```lisp
(make-array 2
            :element-type 'base-char
            :adjustable t
            :initial-contents
            (list #\LATIN_CAPITAL_LETTER_I_WITH_CIRCUMFLEX
                  #\RIGHT-POINTING_DOUBLE_ANGLE_QUOTATION_MARK))
```