### PR TITLE
Add source location for (setf foo), new regression-test-file and integrate

### DIFF
--- a/src/lisp/regression-tests/extensions.lisp
+++ b/src/lisp/regression-tests/extensions.lisp
@@ -1,0 +1,28 @@
+(in-package #:clasp-tests)
+
+(test-true clip-failure
+           (ext::source-location-p (first (ext:source-location '(setf find-class) :function))))
+
+(test-true source-location-function
+           (ext::source-location-p (first (ext:source-location 'find-class :function))))
+
+(test-true source-location-class-symbol
+           (ext::source-location-p (first (ext:source-location 'number :class))))
+
+(test-true source-location-class-object
+           (ext::source-location-p (first (ext:source-location (find-class 'number) t))))
+
+(test-true source-location-macro
+           (ext::source-location-p (first (ext:source-location 'defun :function))))
+
+(test-true source-location-special-from
+           (ext::source-location-p (first (ext:source-location 'progn :function))))
+
+(test-true source-location-generic-function
+           (ext::source-location-p (first (ext:source-location #'initialize-instance t))))
+
+(test-true source-location-type
+           (ext::source-location-p (first (ext:source-location 'fixnum :type))))
+
+(test-true source-location-variable
+           (ext::source-location-p (first (ext:source-location '*print-pretty* :variable))))

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -2,7 +2,12 @@
 
 (declaim (optimize (safety 3)))
 
-(load (compile-file "sys:regression-tests;framework.lisp"))
+(let ((compiled-file
+        (compile-file "sys:regression-tests;framework.lisp")))
+  (if compiled-file
+       (load compiled-file)
+       (error "Could not compile ~s~%" "sys:regression-tests;framework.lisp")))
+
 (load "sys:regression-tests;set-unexpected-failures.lisp")
 
 (in-package #:clasp-tests)
@@ -60,4 +65,5 @@
 ;;; system-construction should be last for now.
 ;;; When we have it before debug.lisp, debug.lisp will fail
 (load-if-compiled-correctly "sys:regression-tests;system-construction.lisp")
+(load-if-compiled-correctly "sys:regression-tests;extensions.lisp")
 (sys:quit (if (show-test-summary) 0 1))


### PR DESCRIPTION
* Problem came up when using staple to generate documentation for clasp packages
* `(ext:source-location '(setf find-class) :function)` woudn't work
*  fixed that
* added regression-tests for ext:source-location  in a new file
* added the new file to the regression-test runner
* additionally give an better error message if `(compile-file "sys:regression-tests;framework.lisp")` does not produce a fasl