### PR TITLE
FD_SET FD_ISSET FD_CLR work again on darwin

### DIFF
--- a/src/serveEvent/serveEvent.cc
+++ b/src/serveEvent/serveEvent.cc
@@ -45,18 +45,12 @@ CL_DEFUN void serve_event_internal__ll_fd_zero(clasp_ffi::ForeignData_sp fdset) 
 
 DOCGROUP(clasp)
 CL_DEFUN void serve_event_internal__ll_fd_set(int fd, clasp_ffi::ForeignData_sp fdset) {
-  SIMPLE_ERROR(("FD_SET causes problems with Xcode 11.4 so I'm commenting it out for now"));
-#if 0
  FD_SET(fd, fdset->data<fd_set *>());
-#endif
 }
 
 DOCGROUP(clasp)
 CL_DEFUN int serve_event_internal__ll_fd_isset(int fd, clasp_ffi::ForeignData_sp fdset) {
-  SIMPLE_ERROR(("FD_ISSET causes problems with Xcode 11.4 so I'm commenting it out for now"));
-#if 0
   return FD_ISSET(fd, fdset->data<fd_set *>());
-#endif
 }
 
 DOCGROUP(clasp)

--- a/src/sockets/sockets.cc
+++ b/src/sockets/sockets.cc
@@ -829,26 +829,17 @@ CL_DEFUN void sockets_internal__fdset_zero(core::Pointer_sp p)
 
 DOCGROUP(clasp)
 CL_DEFUN void sockets_internal__fdset_set(gc::Fixnum fd, core::Pointer_sp fdset) {
-  SIMPLE_ERROR(("FD_SET causes problems with Xcode 11.4 - remove this error message once it's working again"));
-#if 0
   FD_SET(fd,(fd_set*)fdset->ptr());
-#endif
 }
 
 DOCGROUP(clasp)
 CL_DEFUN void sockets_internal__fdset_clr(gc::Fixnum fd, core::Pointer_sp fdset) {
-  SIMPLE_ERROR(("FD_SET causes problems with Xcode 11.4 - remove this error message once it's working again"));
-#if 0
   FD_CLR(fd,(fd_set*)fdset->ptr());
-#endif
 }
 
 DOCGROUP(clasp)
 CL_DEFUN bool sockets_internal__fdset_isset(gc::Fixnum fd, core::Pointer_sp fdset) {
-  SIMPLE_ERROR(("FD_SET causes problems with Xcode 11.4 - remove this error message once it's working again"));
-#if 0
   return FD_ISSET(fd,(fd_set*)fdset->ptr());
-#endif
 }
 
 DOCGROUP(clasp)


### PR DESCRIPTION
* undo FD_SET causes problems with Xcode 11.4 - remove this error message once it's working again