### PR TITLE
Add script command line option

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,9 @@
   and `--eval` command line options are processed. The remaining two variables
   are lists of functions that are called to do initialization before a REPL is
   started and termination after the REPL exits.
+* `--script <file>` command line option which equivalent to passing `--norc`,
+  `--noinform` and `--non-interactive`. Any shebang in `<file>` will also be 
+  skipped.
 
 ## Changed
 * `core:lisp-implementation-id` and `core:clasp-git-full-commit` only return

--- a/include/clasp/core/commandLineOptions.h
+++ b/include/clasp/core/commandLineOptions.h
@@ -35,7 +35,7 @@ typedef void (*process_arguments_callback)(CommandLineOptions *);
 
 extern bool global_debug_byte_code;
 
-typedef enum { cloLoad, cloEval } LoadEvalEnum;
+typedef enum { cloLoad, cloEval, cloScript } LoadEvalEnum;
 
 typedef enum { cloDefault, cloImage, cloSnapshot } ImageTypeEnum;
 

--- a/include/clasp/core/load.h
+++ b/include/clasp/core/load.h
@@ -34,7 +34,7 @@ extern core::Symbol_sp& _sym_default;
 
 namespace core {
 
-T_sp core__load_source(T_sp source, bool verbose, bool print, T_sp externalFormat);
+T_sp core__load_source(T_sp source, bool verbose, bool print, T_sp externalFormat, bool skipShebang);
 
 T_sp core__load_no_package_set(T_sp source,
                                T_sp verbose = nil<T_O>(),

--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -321,6 +321,7 @@ SYMBOL_EXPORT_SC_(KeywordPkg, cst);
 SYMBOL_EXPORT_SC_(KeywordPkg, bclasp);
 SYMBOL_EXPORT_SC_(KeywordPkg, load);
 SYMBOL_EXPORT_SC_(KeywordPkg, eval);
+SYMBOL_EXPORT_SC_(KeywordPkg, script);
 SYMBOL_EXPORT_SC_(KeywordPkg, clasp_min);
 SYMBOL_EXPORT_SC_(KeywordPkg, use_mps);
 SYMBOL_EXPORT_SC_(KeywordPkg, use_boehmdc);

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -1258,19 +1258,6 @@ void Lisp::parseCommandLineArguments(const CommandLineOptions& options) {
   globals_->_IgnoreInitImage = options._DontLoadImage;
   globals_->_IgnoreInitLsp = options._DontLoadInitLsp;
 
-  SYMBOL_EXPORT_SC_(CorePkg, STARcommandLineLoadEvalSequenceSTAR);
-  List_sp loadEvals = nil<T_O>();
-  for (auto it : options._LoadEvalList) {
-    Cons_sp one;
-    if (it.first == cloEval) {
-      one = Cons_O::create(kw::_sym_eval, SimpleBaseString_O::make(it.second));
-    } else {
-      one = Cons_O::create(kw::_sym_load, SimpleBaseString_O::make(it.second));
-    }
-    loadEvals = Cons_O::create(one, loadEvals);
-  }
-  _sym_STARcommandLineLoadEvalSequenceSTAR->defparameter(cl__nreverse(loadEvals));
-
   globals_->_NoInform = options._NoInform;
   globals_->_NoPrint = options._NoPrint;
   globals_->_DebuggerDisabled = options._DebuggerDisabled;

--- a/src/lisp/kernel/init.lisp
+++ b/src/lisp/kernel/init.lisp
@@ -680,8 +680,9 @@ the stage, the +application-name+ and the +bitcode-name+"
   (mapcar #'(lambda (entry)
               (if (eq (car entry) :load)
                   (load (cdr entry))
-                  (let ((cmd (read-from-string (cdr entry))))
-                    (eval cmd))))
+                  (if (eq (car entry) :script)
+                    (core:load-source (cdr entry) nil nil nil t)
+                    (eval (read-from-string (cdr entry))))))
           (core:command-line-load-eval-sequence)))
 
 (export 'maybe-load-clasprc)


### PR DESCRIPTION
`--script <file>` command line option which is equivalent to passing `--norc`,  `--noinform` and `--non-interactive`. Any shebang in `<file>` will also be  skipped.

Resolves #150