### PR TITLE
Regression tests for wrong parameters for room

### DIFF
--- a/src/gctools/gcFunctions.cc
+++ b/src/gctools/gcFunctions.cc
@@ -494,7 +494,7 @@ CL_DEFUN core::T_mv cl__room(core::Symbol_sp x) {
   } else if (x.nilp()) {
     verb = room_min;
   } else {
-    SIMPLE_ERROR("You must provide t, nil or :default");
+    TYPE_ERROR(x, core::Cons_O::createList(cl::_sym_member, cl::_sym_T, cl::_sym_nil, kw::_sym_default));
   }
 #if defined(USE_BOEHM) || defined(USE_MPS)
   clasp_gc_room( OutputStream, verb );

--- a/src/lisp/regression-tests/environment.lisp
+++ b/src/lisp/regression-tests/environment.lisp
@@ -778,7 +778,7 @@ documentation (x symbol) (doc-type (eql 'variable))
                 COLLECT (LIST S DOC)))
       (nil))
 
-(test-expect-error room-1 (room 42) :type error)
-(test-expect-error room-2 (room (make-hash-table)) :type error)
-(test-expect-error room-3 (room :pepito) :type error)
+(test-expect-error room-1 (room 42) :type type-error)
+(test-expect-error room-2 (room (make-hash-table)) :type type-error)
+(test-expect-error room-3 (room :pepito) :type type-error)
                    

--- a/src/lisp/regression-tests/environment.lisp
+++ b/src/lisp/regression-tests/environment.lisp
@@ -777,3 +777,8 @@ documentation (x symbol) (doc-type (eql 'variable))
               UNLESS (OR (NULL DOC) (STRING DOC))
                 COLLECT (LIST S DOC)))
       (nil))
+
+(test-expect-error room-1 (room 42) :type error)
+(test-expect-error room-2 (room (make-hash-table)) :type error)
+(test-expect-error room-3 (room :pepito) :type error)
+                   


### PR DESCRIPTION
from clhs:
Arguments and Values:
* x - one of `t`, `nil` or `:default`.