### PR TITLE
add test-random-integer

### DIFF
--- a/src/koga/ninja.lisp
+++ b/src/koga/ninja.lisp
@@ -107,6 +107,10 @@
                     :command "$clasp --norc --feature ignore-extensions --load \"../dependencies/ansi-test/doit-clasp.lsp\""
                     :description "Running ANSI tests"
                     :pool "console")
+  (ninja:write-rule output-stream :test-random-integer
+                    :command "$clasp --norc --feature ignore-extensions --load \"../dependencies/ansi-test/run-random-type-tests.lisp\""
+                    :description "Running pfdietz test-random-integer-forms"
+                    :pool "console")
   (ninja:write-rule output-stream :link-fasl
                     :command "$clasp --norc --type image --disable-mpi --ignore-image --feature clasp-min --load link-fasl.lisp -- $out $in"
                     :restat 1
@@ -664,13 +668,20 @@
                      :clasp (make-source (build-name :iclasp) :variant)
                      :inputs (list (build-name "cclasp"))
                      :outputs (list (build-name "ansi-test")))
+  (ninja:write-build output-stream :test-random-integer
+                     :clasp (make-source (build-name :iclasp) :variant)
+                     :inputs (list (build-name "cclasp"))
+                     :outputs (list (build-name "test-random-integer")))
   (when *variant-default*
     (ninja:write-build output-stream :phony
                        :inputs (list (build-name "test"))
                        :outputs (list "test"))
     (ninja:write-build output-stream :phony
                        :inputs (list (build-name "ansi-test"))
-                       :outputs (list "ansi-test"))))
+                       :outputs (list "ansi-test"))
+    (ninja:write-build output-stream :phony
+                       :inputs (list (build-name "test-random-integer"))
+                       :outputs (list "test-random-integer"))))
 
 (defmethod print-variant-target-sources
     (configuration (name (eql :ninja)) output-stream (target (eql :static-analyzer)) sources


### PR DESCRIPTION
* run pf dietz random integer test
* run as `ninja -C build test-random-integer` i default configuration
* or run as e.g. `random_int_size=5 random_int_variables=2 random_int_iterations=1000 ninja -C build test-random-integer`specifying:
    * the size of the expression
    * the number of variables
    * the number of iterations

* currently finds compiler errors in clasp in every run
* outputs e.g. the following as an error (I did report them)
```lisp
(:VARS (A B) :FORM
 (IF T
     (IF B -311 -359726514120)
     (LOOP FOR
           LV2
           BELOW
           3
           SUM
           (BLOCK B6
             (BLOCK B8
               (IF B 258 (LOGNAND 2199023255557 (RETURN-FROM B6 A)))))))
 :VAR-TYPES ((INTEGER 1 14) BOOLEAN) :VALS (3 NIL) :LAMBDA-FORM
 (LAMBDA (A B)
   (DECLARE (TYPE (INTEGER 1 14) A))
   (DECLARE (TYPE BOOLEAN B))
   (DECLARE (IGNORABLE A B))
   (DECLARE
    (OPTIMIZE (COMPILATION-SPEED 0) (SPACE 1) (DEBUG 0) (SPEED 1) (SAFETY 3)))
   (IF T
       (IF B -311 -359726514120)
       (LOOP FOR
             LV2
             BELOW
             3
             SUM
             (BLOCK B6
               (BLOCK B8
                 (IF B 258 (LOGNAND 2199023255557 (RETURN-FROM B6 A))))))))
 :DECLS1 ((COMPILATION-SPEED 0) (SPACE 1) (DEBUG 0) (SPEED 1) (SAFETY 3))
 :DECLS2 ((SAFETY 3) (DEBUG 1) (COMPILATION-SPEED 0) (SPEED 3) (SPACE 3))
 :COMPILER-CONDITION "#<CLEAVIR-BIR::VERIFICATION-FAILED>")
````
* the expression in the `:LAMBDA-FORM`gives the form that gives an error - here #<CLEAVIR-BIR::VERIFICATION-FAILED>