### PR TITLE
Allow dolist with declarations for the loopvar

### DIFF
--- a/src/lisp/kernel/lsp/export.lisp
+++ b/src/lisp/kernel/lsp/export.lisp
@@ -57,15 +57,18 @@
                (multiple-value-bind (declarations body)
                    (process-declarations body nil)
                  `(block nil
-                    (let* ((%dolist-var ,expr)
-                           ,var)
-                      (declare ,@declarations)
+                    (let* ((%dolist-var ,expr))
                       (si::while %dolist-var
-                                 (setq ,var (first %dolist-var))
-                                 ,@body
-                                 (setq %dolist-var (cdr %dolist-var)))
-                      ,(when exit `(setq ,var nil))
-                      ,@exit)))))))
+                        (let ((,var (first %dolist-var)))
+                          (declare ,@declarations)
+                          (tagbody
+                             ,@body
+                             (setq %dolist-var (cdr %dolist-var))))))
+                    ,(when exit
+                       `(let ((,var nil))
+                          (declare (ignorable ,var)
+                                   ,@(filter-dolist-declarations declarations))
+                          ,@exit))))))))
   (si::fset 'dolist f t '((var list-form &optional result-form) &body body)))
 
 (let ((f #'(lambda (whole env)

--- a/src/lisp/regression-tests/iteration.lisp
+++ b/src/lisp/regression-tests/iteration.lisp
@@ -1,0 +1,22 @@
+(in-package #:clasp-tests)
+
+(test-true dolist-declare-elements
+           (let ((did-warn nil))
+             (flet ((catch-warnings (&optional condition)
+                      (setq did-warn t)
+                      (muffle-warning condition)))
+               (handler-bind ((warning #'catch-warnings))
+                 (compile nil
+                          '(lambda()
+                            (let ((sum 0))
+                              (dolist (a (list 1 2 3) sum)
+                                (declare (type fixnum a))
+                                (incf sum a)))))))
+             (not did-warn)))
+
+
+(test-true dolist-var-nil-at-return
+           (let ((sum 0))
+             (null
+              (dolist (a (list 1 2 3) a)
+                (incf sum a)))))

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -46,6 +46,7 @@
 (load-if-compiled-correctly "sys:src;lisp;regression-tests;environment01.lisp")
 (load-if-compiled-correctly "sys:src;lisp;regression-tests;types01.lisp")
 (load-if-compiled-correctly "sys:src;lisp;regression-tests;control01.lisp")
+(load-if-compiled-correctly "sys:src;lisp;regression-tests;iteration.lisp")
 (load-if-compiled-correctly "sys:src;lisp;regression-tests;loop.lisp")
 (load-if-compiled-correctly "sys:src;lisp;regression-tests;numbers-core.lisp")
 (load-if-compiled-correctly "sys:src;lisp;regression-tests;unwind.lisp")


### PR DESCRIPTION
Fix dolist to that the loopvar can be declared as having a type
* allows to further cross-compile sbcl with clasp (fails later anyhow)
explanation:
```lisp
(macroexpand '(dolist (a (list 1 2 3) sum)
                     (declare (type fixnum a))
                     (incf sum a)))
````
used to expand to
```lisp
(BLOCK NIL
  (LET* ((%DOLIST-VAR (LIST 1 2 3)) A)
    (DECLARE (TYPE FIXNUM A))
    (WHILE %DOLIST-VAR
           (SETQ A (FIRST %DOLIST-VAR))
           (INCF SUM A)
           (SETQ %DOLIST-VAR (CDR %DOLIST-VAR)))
    (SETQ A NIL)
    SUM))
`````

which obviously is wrong, since a is initialized to nil and later declared as fixnum    
    
with the fix:
```lisp
(BLOCK NIL
  (LET* ((%DOLIST-VAR (LIST 1 2 3)))
    (WHILE %DOLIST-VAR
           (LET ((A (FIRST %DOLIST-VAR)))
             (DECLARE (TYPE FIXNUM A))
             (TAGBODY (INCF SUM A) (SETQ %DOLIST-VAR (CDR %DOLIST-VAR))))))
  (LET ((A NIL))
    (DECLARE (IGNORABLE A))
    SUM))
````
coments:
* A is allowed to be locally definde in the `while``
* Special care needs to be applied, so that
   * A finally is bound to nil
   * tagbodies are still respected
   * parat from regression tests and ansi tests I tested over 100 quicklisp systes with the change