### PR TITLE
Add automatic detection of immutable ASDF systems

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -31,6 +31,16 @@
   Clasp source directory now points to directly to the source code directory,
   which is usually `/usr/clasp/share/`. The APP-BITCODE, APP-EXECUTABLE and
   APP-FASL hosts have been renamed BITCODE, EXECUTABLE and FASL respectively.
+* ASDF systems that are loaded as part the cclasp image are now marked as
+  immutable thereby preventing ASDF from overwriting them. These systems include
+  the systems acclimation, alexandria, clasp-cleavir, cleavir-ast-to-bir, 
+  cleavir-ast, cleavir-ast-transformations, cleavir-attributes, cleavir-bir, 
+  cleavir-bir-transformations, cleavir-compilation-policy, cleavir-conditions,
+  cleavir-cst-to-ast, cleavir-ctype, cleavir-environment, 
+  cleavir-io,cleavir-meter, cleavir-primop, cleavir-set, cleavir-stealth-mixins, 
+  closer-mop, concrete-syntax-tree, concrete-syntax-tree-base,
+  concrete-syntax-tree-destructuring, concrete-syntax-tree-lambda-list,
+  eclector, and eclector-concrete-syntax-tree. 
 
 ## Removed
 * `core:*extensions-startup-loads*` and `core:*extensions-startup-evals*`

--- a/src/koga/configure.lisp
+++ b/src/koga/configure.lisp
@@ -559,6 +559,10 @@ is not compatible with snapshots.")
                       :initform nil
                       :type list
                       :documentation "")
+   (target-systems :accessor target-systems
+                   :initform (make-hash-table)
+                   :type hash-table
+                   :documentation "")
    (default-stage :accessor default-stage
                   :initform :cclasp
                   :type (member :iclasp :aclasp :bclasp :cclasp :sclasp)
@@ -605,6 +609,8 @@ is not compatible with snapshots.")
                                                          (list (make-source #P"config.h" :variant))
                                                          :version-h
                                                          (list (make-source #P"version.h" :variant))
+                                                         :cclasp-immutable
+                                                         (list (make-source #P"generated/cclasp-immutable.lisp" :variant))
                                                          :compile-commands
                                                          (list (make-source #P"compile_commands.json" :variant)
                                                                :iclasp)))

--- a/src/koga/scripts.lisp
+++ b/src/koga/scripts.lisp
@@ -157,3 +157,10 @@ CLASP_FEATURES=ignore-extensions exec $(dirname \"$0\")/~a \"$@\""
 (unless (ql-dist:find-dist \"quickclasp\")
   (sleep 2) ; ensure that the sequence number if quickclasp is higher
   (ql-dist:install-dist \"http://thirdlaw.tech/quickclasp/quickclasp.txt\" :prompt nil))"))
+
+(defmethod print-prologue (configuration (name (eql :cclasp-immutable)) output-stream)
+  (format output-stream "(in-package \"SYSTEM\")
+
+(setq *immutable-systems*
+      (list* ~<~@{~(~s~)~13I ~:_~}~:>*immutable-systems*))"
+          (gethash :cclasp (target-systems configuration))))

--- a/src/koga/target-sources.lisp
+++ b/src/koga/target-sources.lisp
@@ -1,9 +1,13 @@
 (in-package #:koga)
 
 (defmethod add-target-source (configuration target (source symbol))
-  (loop for file in (asdf-groveler:grovel-source-files (list source)
-                                                       :root-path (truename (root :code)))
-        do (add-target-source configuration target (make-source file :code))))
+  (multiple-value-bind (systems files)
+      (asdf-groveler:grovel (list source) :root-path (truename (root :code)))
+    (loop for file in files
+          do (add-target-source configuration target (make-source file :code)))
+    (loop for system in systems
+          do (pushnew (intern (string-upcase (asdf:component-name system)) :keyword)
+                      (gethash target (target-systems configuration))))))
 
 ;; Sources that are added to iclasp also need to be installed and scanned for tags.
 (defmethod add-target-source :after (configuration (target (eql :iclasp)) (source source))

--- a/src/lisp/cscript.lisp
+++ b/src/lisp/cscript.lisp
@@ -164,6 +164,7 @@
              #~"kernel/lsp/generated-encodings.lisp"
              #~"kernel/lsp/encodings.lisp"
              #~"kernel/lsp/cltl2.lisp"
+             (k:make-source "generated/cclasp-immutable.lisp" :variant)
              #~"kernel/tag/pre-epilogue-cclasp.lisp"
              #~"kernel/lsp/epilogue-cclasp.lisp"
              #~"kernel/tag/cclasp.lisp"))

--- a/src/lisp/kernel/lsp/module.lisp
+++ b/src/lisp/kernel/lsp/module.lisp
@@ -26,6 +26,10 @@ It is used by PROVIDE and REQUIRE.")
 (defparameter ext:*module-provider-functions* nil
   "See function documentation for REQUIRE")
 
+(defparameter *immutable-systems* (list :asdf :asdf-package-system :uiop)
+  "The names of the immutable systems that should immediately be registered
+when ASDF has been initially provided.")
+
 ;;;; PROVIDE and REQUIRE
 
 (defun provide (module-name)
@@ -33,9 +37,11 @@ It is used by PROVIDE and REQUIRE.")
 Module-name is a string designator"
   (let ((module-as-string (string module-name)))
     (pushnew module-as-string *modules* :test #'string=)
-    (when (and (find-package :asdf)(string= "ASDF" (string-upcase module-as-string)))
-      (funcall (find-symbol (string-upcase "register-immutable-system") :asdf) :asdf))
-    )
+    (when (and (find-package :asdf)
+               (string= "ASDF" (string-upcase module-as-string)))
+      (let ((register-immutable-system (find-symbol "REGISTER-IMMUTABLE-SYSTEM" :asdf)))
+        (dolist (system *immutable-systems*)
+          (funcall register-immutable-system system)))))
   t)
 
 (defparameter *requiring* nil)

--- a/src/lisp/modules/asdf-groveler/groveler.lisp
+++ b/src/lisp/modules/asdf-groveler/groveler.lisp
@@ -25,14 +25,14 @@
   (loop with *all-systems* = nil
         with *all-source-files* = nil
         for system in systems
-        do (asdf:oos 'sticky-beak-op system :force t)
+        do (asdf:operate 'sticky-beak-op system :force :all)
         finally (return (nreverse *all-systems*))))
 
 (defun grovel-source-files (systems &key all-sources root-path)
   (loop with *all-systems* = nil
         with *all-source-files* = nil
         for system in systems
-        do (asdf:oos 'sticky-beak-op system :force t)
+        do (asdf:operate 'sticky-beak-op system :force :all)
         finally (return (loop for source in (nreverse *all-source-files*)
                               for path = (asdf/component:component-pathname source)
                               when (or all-sources
@@ -40,3 +40,17 @@
                                 collect (if root-path
                                             (uiop:subpathp path root-path)
                                             path)))))
+
+(defun grovel (systems &key all-sources root-path)
+  (loop with *all-systems* = nil
+        with *all-source-files* = nil
+        for system in systems
+        do (asdf:operate 'sticky-beak-op system :force :all)
+        finally (return (values (nreverse *all-systems*)
+                                (loop for source in (nreverse *all-source-files*)
+                                      for path = (asdf/component:component-pathname source)
+                                      when (or all-sources
+                                               (typep source 'asdf/lisp-action:cl-source-file))
+                                        collect (if root-path
+                                                    (uiop:subpathp path root-path)
+                                                    path))))))

--- a/src/lisp/modules/asdf-groveler/packages.lisp
+++ b/src/lisp/modules/asdf-groveler/packages.lisp
@@ -1,4 +1,5 @@
 (defpackage #:asdf-groveler
   (:use #:common-lisp)
-  (:export #:grovel-source-files
+  (:export #:grovel
+           #:grovel-source-files
            #:grovel-systems))


### PR DESCRIPTION
Uses the results from groveling clasp-cleavir to also initialize the list of immutable ASDF systems if and when ASDF is loaded as a module. This protects against user systems that depend on things like eclector. Note that eclector used to be marked immutable in Cando, https://github.com/cando-developers/cando/blob/ed8c76a9d024951488f3902f512a84ed2d12f5dd/src/lisp/start-cando.lisp#L46

Marking ASDF systems that are contained in an image as immutable will be needed if we attempt to make an "eclasp" image for extensions such as Cando.