### PR TITLE
Fix most cclasp compiler warnings

### DIFF
--- a/src/core/lispList.cc
+++ b/src/core/lispList.cc
@@ -458,6 +458,14 @@ List_sp remove_equal(T_sp element, List_sp alist) {
   return new_list.cons();
 };
 
+CL_LAMBDA(element alist)
+CL_DECLARE();
+CL_DOCSTRING(R"dx(remove an element from a list with test equall)dx")
+DOCGROUP(clasp)
+CL_DEFUN List_sp core__remove_equal(T_sp element, List_sp alist) {
+  return remove_equal(element, alist);
+};
+
   SYMBOL_EXPORT_SC_(ClPkg, revappend);
   SYMBOL_EXPORT_SC_(ClPkg, nreconc);
   SYMBOL_EXPORT_SC_(ClPkg, list);
@@ -468,11 +476,6 @@ List_sp remove_equal(T_sp element, List_sp alist) {
   SYMBOL_EXPORT_SC_(ClPkg, nthcdr);
   SYMBOL_EXPORT_SC_(ClPkg, copyList);
   SYMBOL_EXPORT_SC_(ClPkg, last);
-
-
-
-
-;
-
+  SYMBOL_EXPORT_SC_(CorePkg, remove_equal);
 
 }; /* core */

--- a/src/lisp/kernel/clasp-builder.lisp
+++ b/src/lisp/kernel/clasp-builder.lisp
@@ -30,11 +30,11 @@
   )
 
 
-
+;;; Fixme probably #+(not bclasp cclasp) is not what is meant
 #+(not bclasp cclasp)
 (core:fset 'cmp::with-compiler-timer
            (let ((body (gensym)))
-             (core:fmt t "body = {}%N" body)
+             #+(or)(core:fmt t "body = {}%N" body)
              #'(lambda (whole env)
                  (let ((body (cddr whole)))
                    `(progn
@@ -262,7 +262,7 @@ Return files."
         (core:fmt t "Loading/compiling source: {}%N" (namestring name))
         (core:fmt t "Loading/interpreting source: {}%N" (namestring name)))
     (cmp::with-compiler-timer (:message "Compiler" :verbose t)
-     (load pathname))))
+      (load pathname))))
 
 (defun iload (entry &key load-bitcode )
   #+dbg-print(core:fmt t "DBG-PRINT iload fn: {}%N" fn)
@@ -619,26 +619,18 @@ Return files."
     result))
 (export 'command-line-arguments-as-list)           
 
-(defun recursive-remove-from-list (item list)
-  (if list
-      (if (equal item (car list))
-          (recursive-remove-from-list item (cdr list))
-          (list* (car list) (recursive-remove-from-list item (cdr list))))
-      nil))
-(export 'recursive-remove-from-list)
-
-
 (defun remove-stage-features ()
-  (setq *features* (recursive-remove-from-list :clasp-min *features*))
-  (setq *features* (recursive-remove-from-list :clos *features*))
-  (setq *features* (recursive-remove-from-list :aclasp *features*))
-  (setq *features* (recursive-remove-from-list :bclasp *features*))
-  (setq *features* (recursive-remove-from-list :cclasp *features*)))
+  (setq *features* (core:remove-equal :clasp-min *features*))
+  (setq *features* (core:remove-equal :clos *features*))
+  (setq *features* (core:remove-equal :aclasp *features*))
+  (setq *features* (core:remove-equal :bclasp *features*))
+  (setq *features* (core:remove-equal :cclasp *features*)))
 
 (export '(aclasp-features with-aclasp-features))
 (defun aclasp-features ()
   (remove-stage-features)
   (setq *features* (list* :aclasp :clasp-min *features*))
+  (core:fmt t "Aclasp *features* -> {}%N" *features*)
   (setq *target-backend* (default-target-backend)))
 (core:fset 'with-aclasp-features
             #'(lambda (whole env)
@@ -735,7 +727,8 @@ Return files."
   (cond
     ((eq core:*clasp-build-mode* :bitcode)
      ;; FIXME all-modules is not defined here, this will error if called
-     (cmp:link-bitcode-modules output-file all-modules))
+     ;; assume that system is meant here
+     (cmp:link-bitcode-modules output-file system))
     ((eq core:*clasp-build-mode* :object)
      ;; Do nothing - object files are the result
      )
@@ -755,6 +748,7 @@ Return files."
 (defun bclasp-features()
   (remove-stage-features)
   (setq *features* (list* :optimize-bclasp :clos :bclasp *features*))
+  (core:fmt t "Bclasp *features* -> {}%N" *features*)
   (setq *target-backend* (default-target-backend)))
 (core:fset 'with-bclasp-features
             #'(lambda (whole env)
@@ -767,6 +761,7 @@ Return files."
 (defun cclasp-features ()
   (remove-stage-features)
   (setq *features* (list* :clos :cclasp *features*))
+  (core:fmt t "Cclasp *features* -> {}%N" *features*)
   (setq *target-backend* (default-target-backend)))
 (core:fset 'with-cclasp-features
             #'(lambda (whole env)
@@ -850,7 +845,8 @@ Return files."
                                       "src/lisp/kernel/contrib/Eclector/code/reader/read-common"
                                       "src/lisp/kernel/contrib/Eclector/code/reader/macro-functions"
                                       "src/lisp/kernel/contrib/Eclector/code/reader/read")))
-                (load-system files)))
+                (with-compilation-unit ()
+                  (load-system files))))
          (pop *features*))
        (push :cleavir *features*)
        (handler-bind

--- a/src/lisp/kernel/cleavir/system.lisp
+++ b/src/lisp/kernel/cleavir/system.lisp
@@ -38,6 +38,8 @@
 (defvar *debug-log-index* 0)
 (defvar *debug-ownerships*)
 
+(declaim (special *cst-client* *additional-clasp-character-names*))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Stealth mixins

--- a/src/lisp/kernel/cmp/codegen-special-form.lisp
+++ b/src/lisp/kernel/cmp/codegen-special-form.lisp
@@ -412,6 +412,7 @@ and put the values into the activation frame for new-env."
                  (dynenv-cons-mems nil)
                  (dynenv-conses nil)
                  (*notinlines* (new-notinlines declares)))
+            (declare (ignore dynenv-conses))
             ;; alloca dynenv space for each special.
             (dolist (target (rest reqvars))
               (when (eq (car target) 'ext:special-var)

--- a/src/lisp/kernel/lsp/describe.lisp
+++ b/src/lisp/kernel/lsp/describe.lisp
@@ -77,7 +77,7 @@
     (return-from read-inspect-command nil))
   (let* ((*quit-tags* (cons *quit-tag* *quit-tag*)) ;; as seen in top.lisp
 	 (*quit-tag* *quit-tags*))
-    (declare (special *quit-tags* *quit-tags*))
+    (declare (special *quit-tag* *quit-tags*))
     (loop
        (when
 	   (catch *quit-tag* ;; as seen in top.lisp

--- a/src/lisp/kernel/lsp/sharpmacros.lisp
+++ b/src/lisp/kernel/lsp/sharpmacros.lisp
@@ -136,7 +136,7 @@
 
 (defun sharpmacros-lisp-redefine (readtable)
   (cond ((boundp '*read-hook*)
-         (set-eclector-reader-readmacros readtable))
+         #+cclasp (set-eclector-reader-readmacros readtable))
         (t
          (set-dispatch-macro-character #\# #\= #'sharp-equal readtable)
          (set-dispatch-macro-character #\# #\# #'sharp-sharp readtable)


### PR DESCRIPTION
* Fix warnings generated from clasp-builder
* Fix warnings building cclasp both loading and compiling
* Fix typo in `src/lisp/kernel/lsp/describe.lisp` declaring the same variable twice special