### PR TITLE
 Fix some issues with source info

### DIFF
--- a/include/clasp/core/cons.h
+++ b/include/clasp/core/cons.h
@@ -352,152 +352,276 @@ struct StackAllocate<core::Cons_O> {
 };
 namespace core {
 
-CL_PKG_NAME(ClPkg,car);
- DOCGROUP(clasp)
-   CL_DEFUN inline core::T_sp oCar(T_sp obj) {
-   if (obj.consp())
-     return obj.unsafe_cons()->ocar();
-   if (obj.nilp())
-     return obj;
-   TYPE_ERROR(obj, cl::_sym_Cons_O);
- };
- CL_PKG_NAME(ClPkg,cdr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCdr(T_sp obj) {
+CL_PKG_NAME(ClPkg, car);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the first object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline core::T_sp oCar(T_sp obj) {
+ if (obj.consp())
+   return obj.unsafe_cons()->ocar();
+ if (obj.nilp())
+   return obj;
+ TYPE_ERROR(obj, cl::_sym_Cons_O);
+}
+
+CL_PKG_NAME(ClPkg, cdr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return all but the first object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCdr(T_sp obj) {
   if (obj.consp())
     return obj.unsafe_cons()->cdr();
   if (obj.nilp())
     return obj;
   TYPE_ERROR(obj, cl::_sym_Cons_O);
-};
+}
 
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp cl__rest(List_sp obj) {
-   return oCdr(obj);
-};
+CL_LAMBDA(list)
+CL_DOCSTRING("Return all but the first object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp cl__rest(List_sp obj) {
+  return oCdr(obj);
+}
 
- CL_PKG_NAME(ClPkg,caar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCaar(T_sp o) { return oCar(oCar(o)); };
- CL_PKG_NAME(ClPkg,cadr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCadr(T_sp o) { return oCar(oCdr(o)); };
- CL_PKG_NAME(ClPkg,cdar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCdar(T_sp o) { return oCdr(oCar(o)); };
- CL_PKG_NAME(ClPkg,cddr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCddr(T_sp o) { return oCdr(oCdr(o)); };
- CL_PKG_NAME(ClPkg,caaar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCaaar(T_sp o) { return oCar(oCar(oCar(o))); };
- CL_PKG_NAME(ClPkg,caadr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCaadr(T_sp o) { return oCar(oCar(oCdr(o))); };
- CL_PKG_NAME(ClPkg,cadar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCadar(T_sp o) { return oCar(oCdr(oCar(o))); };
- CL_PKG_NAME(ClPkg,caddr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCaddr(T_sp o) { return oCar(oCdr(oCdr(o))); };
- CL_PKG_NAME(ClPkg,cdaar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCdaar(T_sp o) { return oCdr(oCar(oCar(o))); };
- CL_PKG_NAME(ClPkg,cdadr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCdadr(T_sp o) { return oCdr(oCar(oCdr(o))); };
- CL_PKG_NAME(ClPkg,cddar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCddar(T_sp o) { return oCdr(oCdr(oCar(o))); };
- CL_PKG_NAME(ClPkg,cdddr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCdddr(T_sp o) { return oCdr(oCdr(oCdr(o))); };
- CL_PKG_NAME(ClPkg,caaaar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCaaaar(T_sp o) { return oCar(oCar(oCar(o))); };
- CL_PKG_NAME(ClPkg,caadar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCaadar(T_sp o) { return oCar(oCar(oCdr(oCar(o)))); };
- CL_PKG_NAME(ClPkg,cadaar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCadaar(T_sp o) { return oCar(oCdr(oCar(oCar(o)))); };
- CL_PKG_NAME(ClPkg,caddar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCaddar(T_sp o) { return oCar(oCdr(oCdr(oCar(o)))); };
- CL_PKG_NAME(ClPkg,cdaaar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCdaaar(T_sp o) { return oCdr(oCar(oCar(oCar(o)))); };
- CL_PKG_NAME(ClPkg,cdadar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCdadar(T_sp o) { return oCdr(oCar(oCdr(oCar(o)))); };
- CL_PKG_NAME(ClPkg,cddaar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCddaar(T_sp o) { return oCdr(oCdr(oCar(oCar(o)))); };
- CL_PKG_NAME(ClPkg,cdddar);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCdddar(T_sp o) { return oCdr(oCdr(oCdr(oCar(o)))); };
- CL_PKG_NAME(ClPkg,caaadr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCaaadr(T_sp o) { return oCar(oCar(oCar(oCar(o)))); };
- CL_PKG_NAME(ClPkg,caaddr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCaaddr(T_sp o) { return oCar(oCar(oCdr(oCdr(o)))); };
- CL_PKG_NAME(ClPkg,cadadr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCadadr(T_sp o) { return oCar(oCdr(oCar(oCdr(o)))); };
- CL_PKG_NAME(ClPkg,cadddr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCadddr(T_sp o) { return oCar(oCdr(oCdr(oCdr(o)))); };
- CL_PKG_NAME(ClPkg,cdaadr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCdaadr(T_sp o) { return oCdr(oCar(oCar(oCdr(o)))); };
- CL_PKG_NAME(ClPkg,cdaddr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCdaddr(T_sp o) { return oCdr(oCar(oCdr(oCdr(o)))); };
- CL_PKG_NAME(ClPkg,cddadr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCddadr(T_sp o) { return oCdr(oCdr(oCar(oCdr(o)))); };
- CL_PKG_NAME(ClPkg,cddddr);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oCddddr(T_sp o) { return oCdr(oCdr(oCdr(oCdr(o)))); };
- CL_PKG_NAME(ClPkg,First);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oFirst(T_sp o) { return oCar(o); };
- CL_PKG_NAME(ClPkg,Second);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oSecond(T_sp o) { return oCar(oCdr(o)); };
- CL_PKG_NAME(ClPkg,Third);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oThird(T_sp o) { return oCar(oCdr(oCdr(o))); };
- CL_PKG_NAME(ClPkg,Fourth);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oFourth(T_sp o) { return oCar(oCdr(oCdr(oCdr(o)))); };
- CL_PKG_NAME(ClPkg,Fifth);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oFifth(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(o))))); };
- CL_PKG_NAME(ClPkg,Sixth);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oSixth(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(oCdr(o)))))); };
- CL_PKG_NAME(ClPkg,Seventh);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oSeventh(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(o))))))); };
- CL_PKG_NAME(ClPkg,Eighth);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oEighth(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(o)))))))); };
- CL_PKG_NAME(ClPkg,Ninth);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oNinth(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(o))))))))); };
- CL_PKG_NAME(ClPkg,Tenth);
- DOCGROUP(clasp)
-   CL_DEFUN inline T_sp oTenth(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(o)))))))))); };
+CL_PKG_NAME(ClPkg, caar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the car of the first sublist.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCaar(T_sp o) { return oCar(oCar(o)); }
 
+CL_PKG_NAME(ClPkg, cadr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the second object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCadr(T_sp o) { return oCar(oCdr(o)); }
 
- inline T_sp cons_car(T_sp x) {ASSERT(x.consp());return gctools::reinterpret_cast_smart_ptr<Cons_O>(x)->ocar();};
- inline T_sp cons_cdr(T_sp x) {ASSERT(x.consp());return gctools::reinterpret_cast_smart_ptr<Cons_O>(x)->cdr();};
- inline T_sp cons_car(Cons_sp x) {ASSERT(x.consp());return x->ocar();};
- inline T_sp cons_cdr(Cons_sp x) {ASSERT(x.consp());return x->cdr();};
- inline T_sp cons_car(Cons_O* x) {return x->ocar();};
- inline T_sp cons_cdr(Cons_O* x) {return x->cdr();};
+CL_PKG_NAME(ClPkg, cdar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the first sublist.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCdar(T_sp o) { return oCdr(oCar(o)); }
+
+CL_PKG_NAME(ClPkg, cddr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return all but the first two objects of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCddr(T_sp o) { return oCdr(oCdr(o)); }
+
+CL_PKG_NAME(ClPkg, caaar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the first object in the caar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCaaar(T_sp o) { return oCar(oCar(oCar(o))); }
+
+CL_PKG_NAME(ClPkg, caadr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the first object in the cadr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCaadr(T_sp o) { return oCar(oCar(oCdr(o))); }
+
+CL_PKG_NAME(ClPkg, cadar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the car of the cdar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCadar(T_sp o) { return oCar(oCdr(oCar(o))); }
+
+CL_PKG_NAME(ClPkg, caddr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the first object in the cddr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCaddr(T_sp o) { return oCar(oCdr(oCdr(o))); }
+
+CL_PKG_NAME(ClPkg, cdaar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the caar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCdaar(T_sp o) { return oCdr(oCar(oCar(o))); }
+
+CL_PKG_NAME(ClPkg, cdadr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the cadr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCdadr(T_sp o) { return oCdr(oCar(oCdr(o))); }
+
+CL_PKG_NAME(ClPkg, cddar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the cdar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCddar(T_sp o) { return oCdr(oCdr(oCar(o))); }
+
+CL_PKG_NAME(ClPkg, cdddr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the cddr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCdddr(T_sp o) { return oCdr(oCdr(oCdr(o))); }
+
+CL_PKG_NAME(ClPkg, caaaar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the car of the caaar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCaaaar(T_sp o) { return oCar(oCar(oCar(o))); }
+
+CL_PKG_NAME(ClPkg, caadar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the car of the cadar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCaadar(T_sp o) { return oCar(oCar(oCdr(oCar(o)))); }
+
+CL_PKG_NAME(ClPkg, cadaar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the car of the cdaar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCadaar(T_sp o) { return oCar(oCdr(oCar(oCar(o)))); }
+
+CL_PKG_NAME(ClPkg, caddar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the car of the cddar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCaddar(T_sp o) { return oCar(oCdr(oCdr(oCar(o)))); }
+
+CL_PKG_NAME(ClPkg, cdaaar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the caaar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCdaaar(T_sp o) { return oCdr(oCar(oCar(oCar(o)))); }
+
+CL_PKG_NAME(ClPkg, cdadar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the cadar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCdadar(T_sp o) { return oCdr(oCar(oCdr(oCar(o)))); }
+
+CL_PKG_NAME(ClPkg, cddaar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the cdaar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCddaar(T_sp o) { return oCdr(oCdr(oCar(oCar(o)))); }
+
+CL_PKG_NAME(ClPkg, cdddar);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the cddar of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCdddar(T_sp o) { return oCdr(oCdr(oCdr(oCar(o)))); }
+
+CL_PKG_NAME(ClPkg, caaadr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the car of the caadr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCaaadr(T_sp o) { return oCar(oCar(oCar(oCar(o)))); }
+
+CL_PKG_NAME(ClPkg, caaddr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the car of the caddr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCaaddr(T_sp o) { return oCar(oCar(oCdr(oCdr(o)))); }
+
+CL_PKG_NAME(ClPkg, cadadr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the car of the cdadr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCadadr(T_sp o) { return oCar(oCdr(oCar(oCdr(o)))); }
+
+CL_PKG_NAME(ClPkg, cadddr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the car of the cdddr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCadddr(T_sp o) { return oCar(oCdr(oCdr(oCdr(o)))); }
+
+CL_PKG_NAME(ClPkg, cdaadr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the caadr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCdaadr(T_sp o) { return oCdr(oCar(oCar(oCdr(o)))); }
+
+CL_PKG_NAME(ClPkg, cdaddr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the caddr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCdaddr(T_sp o) { return oCdr(oCar(oCdr(oCdr(o)))); }
+
+CL_PKG_NAME(ClPkg, cddadr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the cdadr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCddadr(T_sp o) { return oCdr(oCdr(oCar(oCdr(o)))); }
+
+CL_PKG_NAME(ClPkg, cddddr);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the cdr of the cdddr of a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oCddddr(T_sp o) { return oCdr(oCdr(oCdr(oCdr(o)))); }
+
+CL_PKG_NAME(ClPkg, First);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the first object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oFirst(T_sp o) { return oCar(o); }
+
+CL_PKG_NAME(ClPkg, Second);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the secon object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oSecond(T_sp o) { return oCar(oCdr(o)); }
+
+CL_PKG_NAME(ClPkg, Third);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the third object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oThird(T_sp o) { return oCar(oCdr(oCdr(o))); }
+
+CL_PKG_NAME(ClPkg, Fourth);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the fourth object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oFourth(T_sp o) { return oCar(oCdr(oCdr(oCdr(o)))); }
+
+CL_PKG_NAME(ClPkg, Fifth);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the fifth object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oFifth(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(o))))); }
+
+CL_PKG_NAME(ClPkg, Sixth);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the sixth object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oSixth(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(oCdr(o)))))); }
+
+CL_PKG_NAME(ClPkg, Seventh);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the seventh object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oSeventh(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(o))))))); }
+
+CL_PKG_NAME(ClPkg, Eighth);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the eighth object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oEighth(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(o)))))))); }
+
+CL_PKG_NAME(ClPkg, Ninth);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the ninth object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oNinth(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(o))))))))); }
+
+CL_PKG_NAME(ClPkg, Tenth);
+CL_LAMBDA(list)
+CL_DOCSTRING("Return the tenth object in a list.")
+DOCGROUP(clasp)
+CL_DEFUN inline T_sp oTenth(T_sp o) { return oCar(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(oCdr(o)))))))))); }
+
+inline T_sp cons_car(T_sp x) {ASSERT(x.consp());return gctools::reinterpret_cast_smart_ptr<Cons_O>(x)->ocar();};
+
+inline T_sp cons_cdr(T_sp x) {ASSERT(x.consp());return gctools::reinterpret_cast_smart_ptr<Cons_O>(x)->cdr();};
+
+inline T_sp cons_car(Cons_sp x) {ASSERT(x.consp());return x->ocar();};
+
+inline T_sp cons_cdr(Cons_sp x) {ASSERT(x.consp());return x->cdr();};
+
+inline T_sp cons_car(Cons_O* x) {return x->ocar();};
+
+inline T_sp cons_cdr(Cons_O* x) {return x->cdr();};
 
 };
 

--- a/src/core/foundation.cc
+++ b/src/core/foundation.cc
@@ -1067,8 +1067,6 @@ void lisp_defun(Symbol_sp sym,
   if (docstring!="") tdocstring = core::SimpleBaseString_O::make(docstring);
   fc->setf_lambdaList(llh->lambdaList());
   fc->setf_docstring(tdocstring);
-  core::ext__annotate(sym,cl::_sym_documentation,cl::_sym_function, tdocstring);
-  core::ext__annotate(func,cl::_sym_documentation,cl::_sym_function, tdocstring);
 }
 
 // identical to above except for using setSetfFdefinition.
@@ -1101,8 +1099,6 @@ void lisp_defun_setf(Symbol_sp sym,
   Function_sp func = fc;
   sym->setSetfFdefinition(func);
   sym->exportYourself();
-  core::ext__annotate(sym,cl::_sym_documentation,cl::_sym_function, tdocstring);
-  core::ext__annotate(func,cl::_sym_documentation,cl::_sym_function, tdocstring);
 }
 
 void lisp_defmacro(Symbol_sp sym,

--- a/src/core/functor.cc
+++ b/src/core/functor.cc
@@ -635,11 +635,13 @@ CL_DEFMETHOD T_mv Function_O::functionSourcePos() const {
 }
 
 DOCGROUP(clasp)
+CL_DOCSTRING("Return the documentation string associated with the function.")
 CL_DEFUN T_sp core__function_docstring(Function_sp func) {
   return func->docstring();
 }
 
 CL_LISPIFY_NAME("core:function-docstring");
+CL_DOCSTRING("Set the documentation string associated with the function.")
 DOCGROUP(clasp)
 CL_DEFUN_SETF T_sp setf_function_docstring(T_sp doc, Function_sp func) {
   func->setf_docstring(doc);

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -1726,10 +1726,10 @@ namespace core {
 CL_LISPIFY_NAME("ext:function-lambda-list");
 CL_LAMBDA(function)
 CL_DECLARE();
-CL_DOCSTRING(R"dx(Return the lambda-list of a function designator. Note that "
-             "this is intended for human consumption and so may not "
-             "literally describe the function; e.g. macro and type expander "
-             "functions will have the defmacro/deftype lambda list.)dx")
+CL_DOCSTRING(R"dx(Return the lambda-list of a function designator. Note that
+this is intended for human consumption and so may not
+literally describe the function; e.g. macro and type expander
+functions will have the defmacro/deftype lambda list.)dx")
 DOCGROUP(clasp)
 CL_DEFUN T_mv ext__function_lambda_list(T_sp obj) {
   if (obj.nilp()) {

--- a/src/gctools/source_info.cc
+++ b/src/gctools/source_info.cc
@@ -8,45 +8,54 @@
 #include <clasp/core/sysprop.h>
 #include <clasp/core/array.h>
 
-typedef enum { code_kind, method_kind, class_kind, variable_kind, unknown_kind } source_info_kind;
-NOINLINE void define_source_info(source_info_kind kind,
-                        const string& lisp_name,
-                        const string& file, size_t character_offset,
-                        size_t line, const string& docstring ) {
+typedef enum { code_kind, setf_kind, method_kind, class_kind, variable_kind, unknown_kind } source_info_kind;
+
+NOINLINE void define_source_info(source_info_kind kind, const string &lisp_name, const string &file, size_t character_offset,
+                                 size_t line, const string &docstring) {
   std::string package_part, symbol_part;
-  core::colon_split(lisp_name,package_part,symbol_part);
-  core::Symbol_sp sym = core::lisp_intern(symbol_part,package_part);
+  core::colon_split(lisp_name, package_part, symbol_part);
+  core::Symbol_sp sym = core::lisp_intern(symbol_part, package_part);
   core::SimpleBaseString_sp sourceFile = core::SimpleBaseString_O::make(file);
   core::SimpleBaseString_sp docs;
+  core::Function_sp func;
   bool gotdocs = false;
+
   if (docstring != "") {
     docs = core::SimpleBaseString_O::make(docstring);
     gotdocs = true;
   }
-  if ( kind == code_kind ) {
-    core::Function_sp func = core::coerce::functionDesignator(sym);
-    func->setSourcePosInfo(sourceFile, character_offset, line, 0 );
+
+  switch (kind) {
+  case code_kind:
+  case setf_kind:
+    func = (kind == code_kind) ? sym->symbolFunction() : sym->getSetfFdefinition();
+    func->setSourcePosInfo(sourceFile, character_offset, line, 0);
     if (gotdocs) {
       func->setf_docstring(docs);
-      ext__annotate(sym,cl::_sym_documentation,cl::_sym_function, docs);
-      ext__annotate(func,cl::_sym_documentation,cl::_sym_function, docs);
-    };
-  } else if ( kind == method_kind ) {
-    core::List_sp info = core__get_sysprop(sym,core::_sym_cxx_method_source_location);
-    info = core::Cons_O::create(core::Cons_O::createList(sourceFile,core::clasp_make_fixnum((Fixnum)character_offset)),info);
-    core::core__put_sysprop(sym,core::_sym_cxx_method_source_location,info);
-    if (gotdocs) ext__annotate(sym,cl::_sym_documentation,cl::_sym_method, docs);
-  } else if ( kind == class_kind ) {
-    core::List_sp info = core::Cons_O::createList(sourceFile,core::clasp_make_fixnum((Fixnum)character_offset));
-    core::core__put_sysprop(sym,core::_sym_class_source_location,info);
-    if (gotdocs) {
-      core::Instance_sp class_ = gc::As<core::Instance_sp>(core::cl__find_class(sym));
-      class_->instanceSet(core::Instance_O::REF_CLASS_DOCSTRING,docs);
     }
-  } else if ( kind == variable_kind ) {
-    printf("%s:%d Handle setting source location of variable_kind\n", __FILE__, __LINE__ );
-  } else {
+    break;
+  case method_kind:
+    core::core__put_sysprop(
+        sym, core::_sym_cxx_method_source_location,
+        core::Cons_O::create(core::Cons_O::createList(sourceFile, core::clasp_make_fixnum((Fixnum)character_offset)),
+                             core__get_sysprop(sym, core::_sym_cxx_method_source_location)));
+    if (gotdocs) {
+      ext__annotate(sym, cl::_sym_documentation, cl::_sym_method, docs);
+    }
+    break;
+  case class_kind:
+    core::core__put_sysprop(sym, core::_sym_class_source_location,
+                            core::Cons_O::createList(sourceFile, core::clasp_make_fixnum((Fixnum)character_offset)));
+    if (gotdocs) {
+      gc::As<core::Instance_sp>(core::cl__find_class(sym))->instanceSet(core::Instance_O::REF_CLASS_DOCSTRING, docs);
+    }
+    break;
+  case variable_kind:
+    printf("%s:%d Handle setting source location of variable_kind\n", __FILE__, __LINE__);
+    break;
+  default:
     printf("%s:%d Could not set source-location for %d\n", __FILE__, __LINE__, kind);
+    break;
   }
 }
 

--- a/src/lisp/kernel/lsp/describe.lisp
+++ b/src/lisp/kernel/lsp/describe.lisp
@@ -566,7 +566,8 @@ Prints information about OBJECT to STREAM."
                              (first slot-d)(second slot-d)(fourth slot-d)(sixth slot-d))
                      (format t "~&Name: ~15a" slot-d)))))))
 
-    (cond ((ext:setf-expander symbol)
+    (cond ((or (fboundp (list 'setf symbol))
+               (ext:setf-expander symbol))
            (doc-separation "[Setf]")
            (doc-value (documentation symbol 'setf) "Documentation:"))))
   

--- a/src/lisp/kernel/lsp/direct-calls.lisp
+++ b/src/lisp/kernel/lsp/direct-calls.lisp
@@ -21,16 +21,18 @@
                ;; Preserve source info - we want the original C++ definitions,
                ;; not the wrappers
                (core:function-source-pos (fdefinition ',lisp-name))
-             (defun ,lisp-name ,lambda-list
-               (declare (optimize (debug 0)))
-               ,@(if declare-forms
-                     (list `(declare ,@declare-forms))
-                     nil)
-               (core:multiple-value-foreign-call ,c-name ,@(core:names-of-lexical-variables
-                                                            (core:make-lambda-list-handler
-                                                             lambda-list nil 'function))))
-             (core:set-source-pos-info (fdefinition ',lisp-name)
-                                       pathname pos lineno column))
+             (let ((docstring (core:function-docstring (fdefinition ',lisp-name))))
+               (defun ,lisp-name ,lambda-list
+                 (declare (optimize (debug 0)))
+                 ,@(if declare-forms
+                       (list `(declare ,@declare-forms))
+                       nil)
+                 (core:multiple-value-foreign-call ,c-name ,@(core:names-of-lexical-variables
+                                                              (core:make-lambda-list-handler
+                                                               lambda-list nil 'function))))
+               (setf (core:function-docstring (fdefinition ',lisp-name)) docstring)
+               (core:set-source-pos-info (fdefinition ',lisp-name)
+                                         pathname pos lineno column)))
           `(unless core:*silent-startup*
              (core:fmt t "Will not generate wrapper for {} - the symbol is not available or set up for CL inlining%N" ',lisp-name))))))
 
@@ -48,15 +50,17 @@
                (fboundp lisp-name))
           `(multiple-value-bind (pathname pos lineno column)
                (core:function-source-pos (fdefinition ',lisp-name))
-             (defun ,lisp-name ,lambda-list
-               (declare (optimize (debug 0)))
-               ,@(if declare-forms
-                     (list `(declare ,@declare-forms))
-                     nil)
-               (core:multiple-value-foreign-call ,c-name ,@(core:names-of-lexical-variables
-                                                            (core:make-lambda-list-handler
-                                                             lambda-list nil 'function))))
-             (core:set-source-pos-info (fdefinition ',lisp-name)
-                                       pathname pos lineno column))
+             (let ((docstring (core:function-docstring (fdefinition ',lisp-name))))
+               (defun ,lisp-name ,lambda-list
+                 (declare (optimize (debug 0)))
+                 ,@(if declare-forms
+                       (list `(declare ,@declare-forms))
+                       nil)
+                 (core:multiple-value-foreign-call ,c-name ,@(core:names-of-lexical-variables
+                                                              (core:make-lambda-list-handler
+                                                               lambda-list nil 'function))))
+               (setf (core:function-docstring (fdefinition ',lisp-name)) docstring)
+               (core:set-source-pos-info (fdefinition ',lisp-name)
+                                         pathname pos lineno column)))
           `(unless core:*silent-startup*
              (core:fmt t "Will not generate wrapper for {} - the symbol is not available or set up for CL inlining%N" ',lisp-name))))))

--- a/src/lisp/kernel/lsp/setf.lisp
+++ b/src/lisp/kernel/lsp/setf.lisp
@@ -205,47 +205,170 @@ by (DOCUMENTATION 'SYMBOL 'SETF)."
 ;;;
 ;;; Built-in SETF expansions.
 
-(defsetf car (x) (y) `(progn (rplaca ,x ,y) ,y))
-(defsetf cdr (x) (y) `(progn (rplacd ,x ,y), y))
-(defsetf caar (x) (y) `(progn (rplaca (car ,x) ,y) ,y))
-(defsetf cdar (x) (y) `(progn (rplacd (car ,x) ,y) ,y))
-(defsetf cadr (x) (y) `(progn (rplaca (cdr ,x) ,y) ,y))
-(defsetf cddr (x) (y) `(progn (rplacd (cdr ,x) ,y) ,y))
-(defsetf caaar (x) (y) `(progn (rplaca (caar ,x) ,y) ,y))
-(defsetf cdaar (x) (y) `(progn (rplacd (caar ,x) ,y) ,y))
-(defsetf cadar (x) (y) `(progn (rplaca (cdar ,x) ,y) ,y))
-(defsetf cddar (x) (y) `(progn (rplacd (cdar ,x) ,y) ,y))
-(defsetf caadr (x) (y) `(progn (rplaca (cadr ,x) ,y) ,y))
-(defsetf cdadr (x) (y) `(progn (rplacd (cadr ,x) ,y) ,y))
-(defsetf caddr (x) (y) `(progn (rplaca (cddr ,x) ,y) ,y))
-(defsetf cdddr (x) (y) `(progn (rplacd (cddr ,x) ,y) ,y))
-(defsetf caaaar (x) (y) `(progn (rplaca (caaar ,x) ,y) ,y))
-(defsetf cdaaar (x) (y) `(progn (rplacd (caaar ,x) ,y) ,y))
-(defsetf cadaar (x) (y) `(progn (rplaca (cdaar ,x) ,y) ,y))
-(defsetf cddaar (x) (y) `(progn (rplacd (cdaar ,x) ,y) ,y))
-(defsetf caadar (x) (y) `(progn (rplaca (cadar ,x) ,y) ,y))
-(defsetf cdadar (x) (y) `(progn (rplacd (cadar ,x) ,y) ,y))
-(defsetf caddar (x) (y) `(progn (rplaca (cddar ,x) ,y) ,y))
-(defsetf cdddar (x) (y) `(progn (rplacd (cddar ,x) ,y) ,y))
-(defsetf caaadr (x) (y) `(progn (rplaca (caadr ,x) ,y) ,y))
-(defsetf cdaadr (x) (y) `(progn (rplacd (caadr ,x) ,y) ,y))
-(defsetf cadadr (x) (y) `(progn (rplaca (cdadr ,x) ,y) ,y))
-(defsetf cddadr (x) (y) `(progn (rplacd (cdadr ,x) ,y) ,y))
-(defsetf caaddr (x) (y) `(progn (rplaca (caddr ,x) ,y) ,y))
-(defsetf cdaddr (x) (y) `(progn (rplacd (caddr ,x) ,y) ,y))
-(defsetf cadddr (x) (y) `(progn (rplaca (cdddr ,x) ,y) ,y))
-(defsetf cddddr (x) (y) `(progn (rplacd (cdddr ,x) ,y) ,y))
-(defsetf first (x) (y) `(progn (rplaca ,x ,y) ,y))
-(defsetf second (x) (y) `(progn (rplaca (cdr ,x) ,y) ,y))
-(defsetf third (x) (y) `(progn (rplaca (cddr ,x) ,y) ,y))
-(defsetf fourth (x) (y) `(progn (rplaca (cdddr ,x) ,y) ,y))
-(defsetf fifth (x) (y) `(progn (rplaca (cddddr ,x) ,y) ,y))
-(defsetf sixth (x) (y) `(progn (rplaca (nthcdr 5 ,x) ,y) ,y))
-(defsetf seventh (x) (y) `(progn (rplaca (nthcdr 6 ,x) ,y) ,y))
-(defsetf eighth (x) (y) `(progn (rplaca (nthcdr 7 ,x) ,y) ,y))
-(defsetf ninth (x) (y) `(progn (rplaca (nthcdr 8 ,x) ,y) ,y))
-(defsetf tenth (x) (y) `(progn (rplaca (nthcdr 9 ,x) ,y) ,y))
-(defsetf rest (x) (y) `(progn (rplacd ,x ,y) ,y))
+(defsetf car (x) (y)
+  "Set the first object in a list."
+  `(progn (rplaca ,x ,y) ,y))
+
+(defsetf cdr (x) (y)
+  "Set the cdr in a list."
+  `(progn (rplacd ,x ,y), y))
+
+(defsetf caar (x) (y)
+  "Set the car of the first sublist."
+  `(progn (rplaca (car ,x) ,y) ,y))
+
+(defsetf cdar (x) (y)
+  "Set the cdr of the first sublist."
+  `(progn (rplacd (car ,x) ,y) ,y))
+
+(defsetf cadr (x) (y)
+  "Set the second object in a list."
+  `(progn (rplaca (cdr ,x) ,y) ,y))
+
+(defsetf cddr (x) (y)
+  "Set the cdr in the cdr of a list."
+  `(progn (rplacd (cdr ,x) ,y) ,y))
+
+(defsetf caaar (x) (y)
+  "Set the first object in the caar of a list."
+  `(progn (rplaca (caar ,x) ,y) ,y))
+
+(defsetf cdaar (x) (y)
+  "Set the cdr of the caar of a list."
+  `(progn (rplacd (caar ,x) ,y) ,y))
+
+(defsetf cadar (x) (y)
+  "Set the car of the cdar of a list."
+  `(progn (rplaca (cdar ,x) ,y) ,y))
+
+(defsetf cddar (x) (y)
+  "Set the cdr of the cdar of a list."
+  `(progn (rplacd (cdar ,x) ,y) ,y))
+
+(defsetf caadr (x) (y)
+  "Set the first object in the cadr of a list."
+  `(progn (rplaca (cadr ,x) ,y) ,y))
+
+(defsetf cdadr (x) (y)
+  "Set the cdr of the cadr of a list."
+  `(progn (rplacd (cadr ,x) ,y) ,y))
+
+(defsetf caddr (x) (y)
+  "Set the first object in the cddr of a list."
+  `(progn (rplaca (cddr ,x) ,y) ,y))
+
+(defsetf cdddr (x) (y)
+  "Set the cdr of the cddr of a list."
+  `(progn (rplacd (cddr ,x) ,y) ,y))
+
+(defsetf caaaar (x) (y)
+  "Set the car of the caaar of a list."
+  `(progn (rplaca (caaar ,x) ,y) ,y))
+
+(defsetf cdaaar (x) (y)
+  "Set the cdr of the caaar of a list."
+  `(progn (rplacd (caaar ,x) ,y) ,y))
+
+(defsetf cadaar (x) (y)
+  "Set the car of the cdaar of a list."
+  `(progn (rplaca (cdaar ,x) ,y) ,y))
+
+(defsetf cddaar (x) (y)
+  "Set the cdr of the cdaar of a list."
+  `(progn (rplacd (cdaar ,x) ,y) ,y))
+
+(defsetf caadar (x) (y)
+  "Set the car of the cadar of a list."
+  `(progn (rplaca (cadar ,x) ,y) ,y))
+
+(defsetf cdadar (x) (y)
+  "Set the cdr of the cadar of a list."
+  `(progn (rplacd (cadar ,x) ,y) ,y))
+
+(defsetf caddar (x) (y)
+  "Set the car of the cddar of a list."
+  `(progn (rplaca (cddar ,x) ,y) ,y))
+
+(defsetf cdddar (x) (y)
+  "Set the cdr of the cddar of a list."
+  `(progn (rplacd (cddar ,x) ,y) ,y))
+
+(defsetf caaadr (x) (y)
+  "Set the car of the caadr of a list."
+  `(progn (rplaca (caadr ,x) ,y) ,y))
+
+(defsetf cdaadr (x) (y)
+  "Set the cdr of the caadr of a list."
+  `(progn (rplacd (caadr ,x) ,y) ,y))
+
+(defsetf cadadr (x) (y)
+  "Set the car of the cdadr of a list."
+  `(progn (rplaca (cdadr ,x) ,y) ,y))
+
+(defsetf cddadr (x) (y)
+  "Set the cdr of the cdadr of a list."
+  `(progn (rplacd (cdadr ,x) ,y) ,y))
+
+(defsetf caaddr (x) (y)
+  "Set the car of the caddr of a list."
+  `(progn (rplaca (caddr ,x) ,y) ,y))
+
+(defsetf cdaddr (x) (y)
+  "Set the cdr of the caddr of a list."
+  `(progn (rplacd (caddr ,x) ,y) ,y))
+
+(defsetf cadddr (x) (y)
+  "Set the car of the cdddr of a list."
+  `(progn (rplaca (cdddr ,x) ,y) ,y))
+
+(defsetf cddddr (x) (y)
+  "Set the cdr of the cdddr of a list."
+  `(progn (rplacd (cdddr ,x) ,y) ,y))
+
+(defsetf first (x) (y)
+  "Set the first object in a list."
+  `(progn (rplaca ,x ,y) ,y))
+
+(defsetf second (x) (y)
+  "Set the second object in a list."
+  `(progn (rplaca (cdr ,x) ,y) ,y))
+
+(defsetf third (x) (y)
+  "Set the third object in a list."
+  `(progn (rplaca (cddr ,x) ,y) ,y))
+
+(defsetf fourth (x) (y)
+  "Set the fourth object in a list."
+  `(progn (rplaca (cdddr ,x) ,y) ,y))
+
+(defsetf fifth (x) (y)
+  "Set the fifth object in a list."
+  `(progn (rplaca (cddddr ,x) ,y) ,y))
+
+(defsetf sixth (x) (y)
+  "Set the sixth object in a list."
+  `(progn (rplaca (nthcdr 5 ,x) ,y) ,y))
+
+(defsetf seventh (x) (y)
+  "Set the seventh object in a list."
+  `(progn (rplaca (nthcdr 6 ,x) ,y) ,y))
+
+(defsetf eighth (x) (y)
+  "Set the eightheighth object in a list."
+  `(progn (rplaca (nthcdr 7 ,x) ,y) ,y))
+
+(defsetf ninth (x) (y)
+  "Set the ninth object in a list."
+  `(progn (rplaca (nthcdr 8 ,x) ,y) ,y))
+
+(defsetf tenth (x) (y)
+  "Set the tenth object in a list."
+  `(progn (rplaca (nthcdr 9 ,x) ,y) ,y))
+
+(defsetf rest (x) (y)
+  "Set the cdr of a list."
+  `(progn (rplacd ,x ,y) ,y))
+
 (defsetf bit (array &rest indices) (value) `(setf (aref ,array ,@indices) ,value))
 (defsetf sbit (array &rest indices) (value) `(setf (aref ,array ,@indices) ,value))
 (defsetf elt setf-elt)

--- a/src/lisp/regression-tests/environment.lisp
+++ b/src/lisp/regression-tests/environment.lisp
@@ -57,17 +57,20 @@ documentation (x symbol) (doc-type (eql 'variable))
   "to test describe"
   (list a b c))
 
-(defun test-documentation-with-args (object &optional (doc-category 'function))
+(defun test-documentation-with-args (object &optional (doc-category 'function) requiredp)
   (let ((doc (documentation object doc-category)))
-    (if doc
-        (let ((describe-string 
-               (with-output-to-string (*standard-output*)
-                 (describe object)))
-              (args (ext:function-lambda-list object)))
-          (and (search doc describe-string)
-               (search (write-to-string args :escape t :readably t) describe-string)))
-        (with-output-to-string (*standard-output*)
-          (describe object)))))
+    (cond (doc
+           (let ((describe-string
+                  (with-output-to-string (*standard-output*)
+                    (describe object)))
+                 (args (ext:function-lambda-list object)))
+             (and (search doc describe-string)
+                  (search (write-to-string args :escape t :readably t) describe-string))))
+          (requiredp
+           nil)
+          (t
+           (with-output-to-string (*standard-output*)
+             (describe object))))))
 
 (defun test-documentation-without-args (object &optional (doc-category 'function))
   (let ((doc (documentation object doc-category)))
@@ -87,6 +90,18 @@ documentation (x symbol) (doc-type (eql 'variable))
 
 (test-true describe-function-documentation-macro
            (test-documentation-with-args 'cl:defconstant))
+
+(test-true describe-function-documentation-function-docstring
+           (test-documentation-with-args 'core:function-docstring 'function t))
+
+(test-true describe-function-documentation-setf-function-docstring
+           (test-documentation-with-args 'core:function-docstring 'setf t))
+
+(test-true describe-function-documentation-car
+           (test-documentation-with-args 'cl:car 'function t))
+
+(test-true describe-function-documentation-setf-car
+           (test-documentation-with-args 'cl:car 'setf t))
 
 (defun stupid-function (a) a)
 

--- a/src/scraper/code-generator.lisp
+++ b/src/scraper/code-generator.lisp
@@ -157,11 +157,11 @@
                               (princ docstring sout)
                               (terpri sout)
                               (princ docstring-long sout))))
-         (kind (cond
-                 ((typep obj 'function-mixin) "code_kind")
-                 ((typep obj 'class-method-mixin) "code_kind")
-                 ((typep obj 'method-mixin) "method_kind")
-                 ((typep obj 'exposed-class) "class_kind")
+         (kind (typecase obj
+                 (expose-defun-setf "setf_kind")
+                 ((or function-mixin class-method-mixin) "code_kind")
+                 (method-mixin "method_kind")
+                 (exposed-class "class_kind")
                  (t "unknown_kind")))
          (helper-name (format nil "source_info_~d_helper" idx)))
     (format sout "NOINLINE void source_info_~d_helper() {~%" idx)

--- a/src/scraper/code-generator.lisp
+++ b/src/scraper/code-generator.lisp
@@ -2,6 +2,7 @@
 
 (define-constant *batch-classes* 3)
 (defparameter *function-partitions* 3)
+(defparameter *clasp-home* #P"")
 
 (define-constant +root-dummy-class+ "RootClass" :test 'equal)
 
@@ -144,7 +145,8 @@
 (defun generate-expose-one-source-info-helper (sout obj idx)
   (let* ((lisp-name (lisp-name% obj))
          (absolute-file (truename (pathname (file% obj))))
-         (file (enough-namestring absolute-file (pathname (format nil "~a/" (uiop:getenv "CLASP_HOME")))))
+         (file (concatenate 'string "sys:"
+                            (substitute #\; #\/ (enough-namestring absolute-file *clasp-home*))))
          (line (line% obj))
          (char-offset (character-offset% obj))
          (docstring (docstring% obj))

--- a/src/scraper/scraper.lisp
+++ b/src/scraper/scraper.lisp
@@ -90,6 +90,7 @@
   (format t "*default-pathname-defaults* -> ~a~%" *default-pathname-defaults*)
   (assert (every 'uiop:directory-pathname-p (list clasp-home-path build-path)))
   (assert sif-files)
-  (process-all-sif-files clasp-home-path build-path sif-files :use-precise use-precise))
+  (let ((*clasp-home* (truename clasp-home-path)))
+    (process-all-sif-files clasp-home-path build-path sif-files :use-precise use-precise)))
 
 (export '(generate-sif-files generate-headers-from-all-sifs))


### PR DESCRIPTION
- Use SYS logical host for source info pathnames. There are some non-permitted characters such as underscores, but they don't seem to cause an error.
- Transfer docstrings for wrapped functions
- Add SETF support to scraper
- Improve SETF support in DESCRIBE and DOCUMENTATION
- Add regression tests for scaper docstrings and SETF functions