### PR TITLE
Add cl-bench support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,4 @@ src/lisp/regression-tests/*.bc
 src/lisp/regression-tests/*.newfasl
 src/analysis/*.lst
 src/analysis/*.cc
+bench/

--- a/repos.sexp
+++ b/repos.sexp
@@ -8,6 +8,14 @@
   :repository "https://gitlab.common-lisp.net/kpoeck/ansi-test.git"
   :directory "dependencies/ansi-test/"
   :branch "feature-clasp-changes")
+ (:name :cl-bench
+  :repository "https://gitlab.common-lisp.net/ansi-test/cl-bench.git"
+  :directory "dependencies/cl-bench/"
+  :branch "master")
+ (:name :cl-who
+  :repository "https://github.com/edicl/cl-who.git"
+  :directory "dependencies/cl-who/"
+  :branch "master")
  (:name :quicklisp-client
   :repository "https://github.com/quicklisp/quicklisp-client.git"
   :directory "dependencies/quicklisp-client/"

--- a/src/koga/configure.lisp
+++ b/src/koga/configure.lisp
@@ -616,6 +616,8 @@ is not compatible with snapshots.")
                                                          (list (make-source #P"clasprc.lisp" :variant))
                                                          :jupyter-kernel
                                                          (list (make-source #P"jupyter-kernel.lisp" :variant))
+                                                         :bench
+                                                         (list (make-source #P"bench.lisp" :build))
                                                          :ninja
                                                          (list (make-source #P"build.ninja" :build)
                                                                :bitcode :iclasp :aclasp :bclasp :cclasp

--- a/src/koga/ninja.lisp
+++ b/src/koga/ninja.lisp
@@ -116,6 +116,10 @@
                     :command "$clasp --norc --non-interactive --load \"sys:extensions;cando;src;lisp;regression-tests;run-all.lisp\""
                     :description "Running Cando regression tests"
                     :pool "console")
+  (ninja:write-rule output-stream :bench
+                    :command "$clasp --norc -t c --feature ignore-extensions --load bench.lisp"
+                    :description "Running benchmarks"
+                    :pool "console")
   (ninja:write-rule output-stream :ansi-test
                     :command "$clasp --norc -t c --feature ignore-extensions --load \"../dependencies/ansi-test/doit-clasp.lsp\""
                     :description "Running ANSI tests"
@@ -811,6 +815,10 @@
                      :clasp (make-source (build-name :iclasp) :variant)
                      :inputs (list (build-name "cclasp"))
                      :outputs (list (build-name "test")))
+  (ninja:write-build output-stream :bench
+                     :clasp (make-source (build-name :iclasp) :variant)
+                     :inputs (list (build-name "cclasp"))
+                     :outputs (list (build-name "bench")))
   (ninja:write-build output-stream :ansi-test
                      :clasp (make-source (build-name :iclasp) :variant)
                      :inputs (list (build-name "cclasp"))
@@ -828,6 +836,9 @@
     (ninja:write-build output-stream :phony
                        :inputs (list (build-name "test"))
                        :outputs (list "test"))
+    (ninja:write-build output-stream :phony
+                       :inputs (list (build-name "bench"))
+                       :outputs (list "bench"))
     (ninja:write-build output-stream :phony
                        :inputs (list (build-name "ansi-test"))
                        :outputs (list "ansi-test"))


### PR DESCRIPTION
Currently the STAK benchmark crashes. To run without the benchmark do `CLASP_BENCH=^stak ninja -C build bench`. To specify specify tests *TO* run do `CLASP_BENCH=fu,bar ninja -C build bench`. Leading with a carat symbol will skip those tests.