### PR TITLE
Use print-object even when *print-readable* is nil

### DIFF
--- a/src/core/object.cc
+++ b/src/core/object.cc
@@ -509,14 +509,12 @@ void General_O::describe(T_sp stream) {
 }
 
 void General_O::__write__(T_sp strm) const {
-  if (clasp_print_readably() && this->fieldsp()) {
-    if (_sym_STARliteral_print_objectSTAR->symbolValue().notnilp()) {
-      eval::funcall(_sym_STARliteral_print_objectSTAR->symbolValue(),this->asSmartPtr(),strm);
-    } else if (cl::_sym_printObject->fboundp()) {
-      core::eval::funcall(cl::_sym_printObject,this->asSmartPtr(),strm);
-    } else {
-      core__print_cxx_object(this->asSmartPtr(), strm);
-    }
+  if (_sym_STARliteral_print_objectSTAR->symbolValue().notnilp()) {
+    eval::funcall(_sym_STARliteral_print_objectSTAR->symbolValue(), this->asSmartPtr(), strm);
+  } else if (cl::_sym_printObject->fboundp()) {
+    core::eval::funcall(cl::_sym_printObject, this->asSmartPtr(), strm);
+  } else if (clasp_print_readably() && this->fieldsp()) {
+    core__print_cxx_object(this->asSmartPtr(), strm);
   } else {
     clasp_write_string(this->__repr__(), strm);
   }


### PR DESCRIPTION
The spec states that [`print-object`](http://www.lispworks.com/documentation/lw50/CLHS/Body/f_pr_obj.htm) must obey `*print-readably*` but `__write__` seems to prevent `PRINT-OBJECT` from being called when `*print-readably*` is NIL versus using `__repr__` as a fallback.

The current implementation of `__write__` makes it impossible to define `PRINT-OBJECT` methods for clbind extensions like seqan-clasp.