### PR TITLE
Tweaks for clbind and koga

### DIFF
--- a/include/clasp/clbind/class.h
+++ b/include/clasp/clbind/class.h
@@ -4,14 +4,14 @@
 
 /*
 Copyright (c) 2014, Christian E. Schafmeister
- 
+
 CLASP is free software; you can redistribute it and/or
 modify it under the terms of the GNU Library General Public
 License as published by the Free Software Foundation; either
 version 2 of the License, or (at your option) any later version.
- 
+
 See directory 'clasp/licenses' for full details.
- 
+
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
@@ -54,46 +54,46 @@ THE SOFTWARE.
 #include <boost/mpl/vector.hpp>
 
 /*
-	ISSUES:
-	------------------------------------------------------
+        ISSUES:
+        ------------------------------------------------------
 
-	* solved for member functions, not application operator *
-	if we have a base class that defines a function a derived class must be able to
-	override that function (not just overload). Right now we just add the other overload
-	to the overloads list and will probably get an ambiguity. If we want to support this
-	each method_rep must include a vector of type_info pointers for each parameter.
-	Operators do not have this problem, since operators always have to have
-	it's own type as one of the arguments, no ambiguity can occur. Application
-	operator, on the other hand, would have this problem.
-	Properties cannot be overloaded, so they should always be overridden.
-	If this is to work for application operator, we really need to specify if an application
-	operator is const or not.
+        * solved for member functions, not application operator *
+        if we have a base class that defines a function a derived class must be able to
+        override that function (not just overload). Right now we just add the other overload
+        to the overloads list and will probably get an ambiguity. If we want to support this
+        each method_rep must include a vector of type_info pointers for each parameter.
+        Operators do not have this problem, since operators always have to have
+        it's own type as one of the arguments, no ambiguity can occur. Application
+        operator, on the other hand, would have this problem.
+        Properties cannot be overloaded, so they should always be overridden.
+        If this is to work for application operator, we really need to specify if an application
+        operator is const or not.
 
-	If one class registers two functions with the same name and the same
-	signature, there's currently no error. The last registered function will
-	be the one that's used.
-	How do we know which class registered the function? If the function was
-	defined by the base class, it is a legal operation, to override it.
-	we cannot look at the pointer offset, since it always will be zero for one of the bases.
+        If one class registers two functions with the same name and the same
+        signature, there's currently no error. The last registered function will
+        be the one that's used.
+        How do we know which class registered the function? If the function was
+        defined by the base class, it is a legal operation, to override it.
+        we cannot look at the pointer offset, since it always will be zero for one of the bases.
 
 
 
-	TODO:
-	------------------------------------------------------
+        TODO:
+        ------------------------------------------------------
 
- 	finish smart pointer support
-		* the adopt policy should not be able to adopt pointers to held_types. This
-		must be prohibited.
-		* name_of_type must recognize holder_types and not return "custom"
+        finish smart pointer support
+                * the adopt policy should not be able to adopt pointers to held_types. This
+                must be prohibited.
+                * name_of_type must recognize holder_types and not return "custom"
 
-	document custom policies, custom converters
+        document custom policies, custom converters
 
-	store the instance object for policies.
+        store the instance object for policies.
 
-	support the __concat metamethod. This is a bit tricky, since it cannot be
-	treated as a normal operator. It is a binary operator but we want to use the
-	__tostring implementation for both arguments.
-	
+        support the __concat metamethod. This is a bit tricky, since it cannot be
+        treated as a normal operator. It is a binary operator but we want to use the
+        __tostring implementation for both arguments.
+
 */
 
 //#include <clbind/prefix.hpp>
@@ -117,7 +117,6 @@ THE SOFTWARE.
 #include <boost/mpl/eval_if.hpp>
 #include <boost/mpl/logical.hpp>
 #pragma GCC diagnostic pop
-
 
 #include <clasp/clbind/config.h>
 #include <clasp/clbind/names.h>
@@ -156,58 +155,51 @@ THE SOFTWARE.
 
 namespace boost {
 
-template <class T>
-class shared_ptr;
+template <class T> class shared_ptr;
 
 } // namespace boost
 
 namespace clbind {
 
 class DummyCreator_O : public core::Creator_O {
-  LISP_CLASS(clbind,ClbindPkg,DummyCreator_O,"DummyCreator",core::Creator_O);
+  LISP_CLASS(clbind, ClbindPkg, DummyCreator_O, "DummyCreator", core::Creator_O);
   core::T_sp _name;
+
 public:
   DummyCreator_O(core::GlobalSimpleFun_sp ep, core::T_sp name) : core::Creator_O(ep), _name(name){};
+
 public:
-  virtual size_t templatedSizeof() const  override{ return sizeof(*this); };
-  virtual bool allocates() const  override{ return false; };
-  virtual core::T_sp creator_allocate()  override{
+  virtual size_t templatedSizeof() const override { return sizeof(*this); };
+  virtual bool allocates() const override { return false; };
+  virtual core::T_sp creator_allocate() override {
     SIMPLE_ERROR_SPRINTF("This class named: %s cannot allocate instances", core::_rep_(this->_name).c_str());
-  } //return _Nil<core::T_O>(); };
-  core::Creator_sp duplicateForClassName(core::Symbol_sp className)  override{
-    core::GlobalSimpleFun_sp entryPoint = core::makeGlobalSimpleFunAndFunctionDescription<DummyCreator_O>(nil<T_O>(),nil<core::T_O>());
-    return gc::GC<DummyCreator_O>::allocate(entryPoint,className);
+  } // return _Nil<core::T_O>(); };
+  core::Creator_sp duplicateForClassName(core::Symbol_sp className) override {
+    core::GlobalSimpleFun_sp entryPoint =
+        core::makeGlobalSimpleFunAndFunctionDescription<DummyCreator_O>(nil<T_O>(), nil<core::T_O>());
+    return gc::GC<DummyCreator_O>::allocate(entryPoint, className);
   }
 };
 
 namespace detail {
 struct unspecified {};
 
-template <class Derived>
-struct operator_;
+template <class Derived> struct operator_;
 
 struct you_need_to_define_a_get_const_holder_function_for_your_smart_ptr {};
-}
+} // namespace detail
 
 extern constructor<> globalDefaultConstructorSignature;
 
-template <class T, class X1 = detail::unspecified, class X2 = detail::unspecified, class X3 = detail::unspecified>
-struct class_;
+template <class T, class X1 = detail::unspecified, class X2 = detail::unspecified, class X3 = detail::unspecified> struct class_;
 
 // TODO: this function will only be invoked if the user hasn't defined a correct overload
 // maybe we should have a static assert in here?
-inline detail::you_need_to_define_a_get_const_holder_function_for_your_smart_ptr *
-get_const_holder(...) {
-  return 0;
-}
+inline detail::you_need_to_define_a_get_const_holder_function_for_your_smart_ptr *get_const_holder(...) { return 0; }
 
-template <class T>
-boost::shared_ptr<T const> *get_const_holder(boost::shared_ptr<T> *) {
-  return 0;
-}
+template <class T> boost::shared_ptr<T const> *get_const_holder(boost::shared_ptr<T> *) { return 0; }
 
-template <typename... Bases>
-struct bases {};
+template <typename... Bases> struct bases {};
 
 typedef bases<reg::null_type> no_bases;
 
@@ -215,68 +207,44 @@ namespace detail {
 
 namespace mpl = boost::mpl;
 
-template <class T>
-struct is_bases
-  : mpl::false_ {};
+template <class T> struct is_bases : mpl::false_ {};
 
-template <typename Base0, typename... Bases>
-struct is_bases<bases<Base0, Bases...>>
-  : mpl::true_ {};
+template <typename Base0, typename... Bases> struct is_bases<bases<Base0, Bases...>> : mpl::true_ {};
 
-template <class T, class P>
-struct is_unspecified
-  : mpl::apply1<P, T> {};
+template <class T, class P> struct is_unspecified : mpl::apply1<P, T> {};
 
-template <class P>
-struct is_unspecified<unspecified, P>
-  : mpl::true_ {};
+template <class P> struct is_unspecified<unspecified, P> : mpl::true_ {};
 
-template <class P>
-struct is_unspecified_mfn {
-  template <class T>
-  struct apply
-    : is_unspecified<T, P> {};
+template <class P> struct is_unspecified_mfn {
+  template <class T> struct apply : is_unspecified<T, P> {};
 };
 
-template <class Predicate>
-struct get_predicate {
-  typedef mpl::protect<is_unspecified_mfn<Predicate>> type;
-};
+template <class Predicate> struct get_predicate { typedef mpl::protect<is_unspecified_mfn<Predicate>> type; };
 
-template <class Result, class Default>
-struct result_or_default {
-  typedef Result type;
-};
+template <class Result, class Default> struct result_or_default { typedef Result type; };
 
-template <class Default>
-struct result_or_default<unspecified, Default> {
-  typedef Default type;
-};
+template <class Default> struct result_or_default<unspecified, Default> { typedef Default type; };
 
-template <class Parameters, class Predicate, class DefaultValue>
-struct extract_parameter {
+template <class Parameters, class Predicate, class DefaultValue> struct extract_parameter {
   typedef typename get_predicate<Predicate>::type pred;
   typedef typename boost::mpl::find_if<Parameters, pred>::type iterator;
-  typedef typename result_or_default<
-    typename iterator::type, DefaultValue>::type type;
+  typedef typename result_or_default<typename iterator::type, DefaultValue>::type type;
 };
 
 struct CLBIND_API create_class {
-    static int stage1();
-    static int stage2();
+  static int stage1();
+  static int stage2();
 };
 
-} // detail
+} // namespace detail
 
-};
+}; // namespace clbind
 
 namespace clbind {
 namespace detail {
 
-template <class T>
-struct static_scope {
-  static_scope(T &self_) : self(self_) {
-  }
+template <class T> struct static_scope {
+  static_scope(T &self_) : self(self_) {}
 
   T &operator[](scope_ s) const {
     self.add_inner_scope(s);
@@ -284,8 +252,7 @@ struct static_scope {
   }
 
 private:
-  template <class U>
-  void operator, (U const &) const;
+  template <class U> void operator,(U const &) const;
   void operator=(static_scope const &);
 
   T &self;
@@ -294,15 +261,14 @@ private:
 struct class_registration;
 namespace {
 struct cast_entry {
-  cast_entry(class_id src, class_id target, cast_function cast)
-      : src(src), target(target), cast(cast) {}
+  cast_entry(class_id src, class_id target, cast_function cast) : src(src), target(target), cast(cast) {}
 
   class_id src;
   class_id target;
   cast_function cast;
 };
 
-} // namespace unnamed
+} // namespace
 
 struct class_registration : registration {
   class_registration(const string &name);
@@ -311,9 +277,9 @@ struct class_registration : registration {
 
   std::string m_name;
 
-  virtual std::string name() const { return this->m_name;}
+  virtual std::string name() const { return this->m_name; }
   virtual std::string kind() const { return "class_registration"; };
-  
+
   mutable std::map<const char *, int, detail::ltstr> m_static_constants;
 
   typedef std::pair<type_id, cast_function> base_desc;
@@ -332,12 +298,10 @@ struct class_registration : registration {
   bool m_derivable;
 };
 
-
-
 struct CLBIND_API class_base : scope_ {
 public:
   class_base(const string &name);
-  
+
   struct base_desc {
     type_id type;
     int ptr_offset;
@@ -360,7 +324,8 @@ public:
 
 private:
   class_registration *m_registration;
- public:
+
+public:
   int m_init_counter;
 };
 
@@ -371,29 +336,24 @@ private:
 #pragma pack(16)
 #endif
 
-template <int N>
-struct print_value_as_warning {
-  char operator()() { return N + 256; } //deliberately causing overflow
+template <int N> struct print_value_as_warning {
+  char operator()() { return N + 256; } // deliberately causing overflow
 };
-template <typename MethodPointerType>
-struct CountMethodArguments {
+template <typename MethodPointerType> struct CountMethodArguments {
   //            enum {value = 0 };
 };
 
-template <typename RT, typename OT, typename... ARGS>
-struct CountMethodArguments<RT (OT::*)(ARGS...)> {
+template <typename RT, typename OT, typename... ARGS> struct CountMethodArguments<RT (OT::*)(ARGS...)> {
   enum { value = sizeof...(ARGS) };
 };
 
-template <typename RT, typename OT, typename... ARGS>
-struct CountMethodArguments<RT (OT::*)(ARGS...) const> {
+template <typename RT, typename OT, typename... ARGS> struct CountMethodArguments<RT (OT::*)(ARGS...) const> {
   enum { value = sizeof...(ARGS) };
 };
 
-template <class Class, typename MethodPointerType, class Policies>
-struct memfun_registration : registration {
+template <class Class, typename MethodPointerType, class Policies> struct memfun_registration : registration {
   memfun_registration(const std::string &name, MethodPointerType f, Policies const &policies)
-    : m_name(name), methodPtr(f), policies(policies) {
+      : m_name(name), methodPtr(f), policies(policies) {
     this->m_arguments = policies.lambdaList();
     this->m_doc_string = policies.docstring();
     this->m_declares = policies.declares();
@@ -404,20 +364,18 @@ struct memfun_registration : registration {
     LOG_SCOPE(("%s:%d register_ %s/%s\n", __FILE__, __LINE__, this->kind().c_str(), this->name().c_str()));
     core::Symbol_sp classSymbol = reg::lisp_classSymbol<Class>();
     core::Symbol_sp symbol = core::lisp_intern(m_name, symbol_packageName(classSymbol));
-    using VariadicType = WRAPPER_AlienVariadicMethod< MethodPointerType, Policies, clbind::DefaultWrapper >;
-    core::FunctionDescription_sp fdesc = makeFunctionDescription(symbol,nil<core::T_O>());
-    auto entry = gc::GC<VariadicType>::allocate(methodPtr,fdesc, nil<core::T_O>() );
-    lisp_defineSingleDispatchMethod(clbind::DefaultWrapper(), 
-                                    symbol, classSymbol, entry, 0, true,
-                                    m_arguments, m_declares, m_doc_string,
-                                    m_auto_export,
+    using VariadicType = WRAPPER_AlienVariadicMethod<MethodPointerType, Policies, clbind::DefaultWrapper>;
+    core::FunctionDescription_sp fdesc = makeFunctionDescription(symbol, nil<core::T_O>());
+    auto entry = gc::GC<VariadicType>::allocate(methodPtr, fdesc, nil<core::T_O>());
+    lisp_defineSingleDispatchMethod(clbind::DefaultWrapper(), symbol, classSymbol, entry, 0, true, m_arguments, m_declares,
+                                    m_doc_string, m_auto_export,
                                     CountMethodArguments<MethodPointerType>::value + 1, // +1 for the self argument
                                     GatherPureOutValues<Policies, 0>::gather());
   }
-  
+
   virtual std::string name() const { return this->m_name; };
   virtual std::string kind() const { return "memfun_registration"; };
-  
+
   std::string m_name;
   MethodPointerType methodPtr;
   Policies policies;
@@ -427,23 +385,25 @@ struct memfun_registration : registration {
   bool m_auto_export;
 };
 
-template <class Class, class Begin, class End, class Policies>
-struct iterator_registration : registration {
-  iterator_registration(const string& name, Begin begin, End end, Policies const &policies, string const &arguments, string const &declares, string const &docstring)
-    : m_name(name), beginPtr(begin), endPtr(end), policies(policies), m_arguments(arguments), m_declares(declares), m_doc_string(docstring) {}
+template <class Class, class Begin, class End, class Policies> struct iterator_registration : registration {
+  iterator_registration(const string &name, Begin begin, End end, Policies const &policies, string const &arguments,
+                        string const &declares, string const &docstring)
+      : m_name(name), beginPtr(begin), endPtr(end), policies(policies), m_arguments(arguments), m_declares(declares),
+        m_doc_string(docstring) {}
 
   void register_() const {
     LOG_SCOPE(("%s:%d register_ %s/%s\n", __FILE__, __LINE__, this->kind().c_str(), this->name().c_str()));
     core::Symbol_sp classSymbol = reg::lisp_classSymbol<Class>();
     core::Symbol_sp symbol = core::lisp_intern(m_name, symbol_packageName(classSymbol));
-    using VariadicType = WRAPPER_Iterator<Policies, Class, Begin, End >;
-    core::FunctionDescription_sp fdesc = makeFunctionDescription(symbol,nil<core::T_O>());
+    using VariadicType = WRAPPER_Iterator<Policies, Class, Begin, End>;
+    core::FunctionDescription_sp fdesc = makeFunctionDescription(symbol, nil<core::T_O>());
     auto entry = gc::GC<VariadicType>::allocate(fdesc, nil<core::T_O>(), beginPtr, endPtr);
     //                int*** i = MethodPointerType(); printf("%p\n", i); // generate error to check type
     //                print_value_as_warning<CountMethodArguments<MethodPointerType>::value>()();
-    lisp_defineSingleDispatchMethod( clbind::DefaultWrapper(), symbol, classSymbol, entry, 0, true, m_arguments, m_declares, m_doc_string, true, 1); // one argument required for iterator - the object that has the sequence
+    lisp_defineSingleDispatchMethod(clbind::DefaultWrapper(), symbol, classSymbol, entry, 0, true, m_arguments, m_declares,
+                                    m_doc_string, true, 1); // one argument required for iterator - the object that has the sequence
   }
-  
+
   virtual std::string name() const { return this->m_name; };
   virtual std::string kind() const { return "iterator_registration"; };
 
@@ -460,30 +420,21 @@ struct iterator_registration : registration {
 #pragma pack(pop)
 #endif
 
-template <class P, class T>
-struct default_pointer {
-  typedef P type;
-};
+template <class P, class T> struct default_pointer { typedef P type; };
 
-template <class T>
-struct default_pointer<reg::null_type, T> {
-  typedef std::unique_ptr<T> type;
-};
+template <class T> struct default_pointer<reg::null_type, T> { typedef std::unique_ptr<T> type; };
 
-template <typename ConstructorType>
-struct CountConstructorArguments {
+template <typename ConstructorType> struct CountConstructorArguments {
   enum { value = 0 };
 };
 
-template <typename... ARGS>
-struct CountConstructorArguments<constructor<ARGS...>> {
+template <typename... ARGS> struct CountConstructorArguments<constructor<ARGS...>> {
   enum { value = sizeof...(ARGS) };
 };
 
- 
-template <class Class, class Pointer, class Signature, class Policies>
-struct constructor_registration_base : public registration {
-  constructor_registration_base(Policies const &policies, string const &name, string const &arguments, string const &declares, string const &docstring)
+template <class Class, class Pointer, class Signature, class Policies> struct constructor_registration_base : public registration {
+  constructor_registration_base(Policies const &policies, string const &name, string const &arguments, string const &declares,
+                                string const &docstring)
       : policies(policies), m_name(name), m_arguments(arguments), m_declares(declares), m_doc_string(docstring) {}
 
   void register_() const {
@@ -492,16 +443,17 @@ struct constructor_registration_base : public registration {
     if (m_name == "") {
       tname = "DEFAULT-CTOR";
     };
-    //                printf("%s:%d    constructor_registration_base::register_ called for %s\n", __FILE__, __LINE__, m_name.c_str());
+    //                printf("%s:%d    constructor_registration_base::register_ called for %s\n", __FILE__, __LINE__,
+    //                m_name.c_str());
     core::Symbol_sp sym = core::lisp_intern(tname, core::lisp_currentPackageName());
-    using VariadicType = WRAPPER_Constructor_O<Signature,Policies, Pointer, Class, DefaultWrapper>;
-    core::FunctionDescription_sp fdesc = makeFunctionDescription(sym,nil<core::T_O>());
+    using VariadicType = WRAPPER_Constructor_O<Signature, Policies, Pointer, Class, DefaultWrapper>;
+    core::FunctionDescription_sp fdesc = makeFunctionDescription(sym, nil<core::T_O>());
     auto entry = gctools::GC<VariadicType>::allocate(fdesc);
-    lisp_bytecode_defun( core::symbol_function, clbind::DefaultWrapper::BytecodeP, sym, core::lisp_currentPackageName(), entry, m_arguments, m_declares, m_doc_string, "=external=", 0, CountConstructorArguments<Signature>::value);
+    lisp_bytecode_defun(core::symbol_function, clbind::DefaultWrapper::BytecodeP, sym, core::lisp_currentPackageName(), entry,
+                        m_arguments, m_declares, m_doc_string, "=external=", 0, CountConstructorArguments<Signature>::value);
   }
-  virtual std::string name() const { return this->m_name;}
+  virtual std::string name() const { return this->m_name; }
   virtual std::string kind() const { return "constructor_registration_base"; };
-  
 
   Policies policies;
   string m_name;
@@ -510,41 +462,47 @@ struct constructor_registration_base : public registration {
   string m_doc_string;
 };
 
- /*! constructor_registration can construct either a derivable class or a non-derivable class */
- 
- class construct_non_derivable_class {};
- class construct_derivable_class {};
- 
- template <class Class, class HoldType, class Signature, class Policies, class DerivableType>
+/*! constructor_registration can construct either a derivable class or a non-derivable class */
+
+class construct_non_derivable_class {};
+class construct_derivable_class {};
+
+template <class Class, class HoldType, class Signature, class Policies, class DerivableType>
 struct constructor_registration : public constructor_registration_base<Class, HoldType, Signature, Policies> {
-   typedef constructor_registration_base<Class, HoldType, Signature, Policies> Base;
-  constructor_registration(Policies const &policies, string const &name, string const &arguments, string const &declares, string const &docstring) : constructor_registration_base<Class, HoldType, Signature, Policies>(policies, name, arguments, declares, docstring){};
+  typedef constructor_registration_base<Class, HoldType, Signature, Policies> Base;
+  constructor_registration(Policies const &policies, string const &name, string const &arguments, string const &declares,
+                           string const &docstring)
+      : constructor_registration_base<Class, HoldType, Signature, Policies>(policies, name, arguments, declares, docstring){};
 };
 
 /*! This is the constructor registration for default constructors */
 template <class Class, class HoldType, class Policies>
-  struct constructor_registration<Class, HoldType, default_constructor, Policies, construct_non_derivable_class> : public constructor_registration_base<Class, HoldType, default_constructor, Policies> {
-  constructor_registration(Policies const &policies, string const &name, string const &arguments, string const &declares, string const &docstring) : constructor_registration_base<Class, HoldType, default_constructor, Policies>(policies, name, arguments, declares, docstring){};
+struct constructor_registration<Class, HoldType, default_constructor, Policies, construct_non_derivable_class>
+    : public constructor_registration_base<Class, HoldType, default_constructor, Policies> {
+  constructor_registration(Policies const &policies, string const &name, string const &arguments, string const &declares,
+                           string const &docstring)
+      : constructor_registration_base<Class, HoldType, default_constructor, Policies>(policies, name, arguments, declares,
+                                                                                      docstring){};
   core::Creator_sp registerDefaultConstructor_() const {
-    core::GlobalSimpleFun_sp ep = core::makeGlobalSimpleFunAndFunctionDescription<DefaultConstructorCreator_O<Class,HoldType>>(nil<core::T_O>(),nil<core::T_O>());
+    core::GlobalSimpleFun_sp ep = core::makeGlobalSimpleFunAndFunctionDescription<DefaultConstructorCreator_O<Class, HoldType>>(
+        nil<core::T_O>(), nil<core::T_O>());
     core::Creator_sp allocator = gc::As<core::Creator_sp>(gc::GC<DefaultConstructorCreator_O<Class, HoldType>>::allocate(ep));
     return allocator;
   }
 };
 
-/*! 
-         * Derivable classes require constructors that use the garbage collector
-         * Specialize constructor_registration_base so that it's register_ function 
-         * instantiates a constructor functoid that uses the garbage collector
-         */
+/*!
+ * Derivable classes require constructors that use the garbage collector
+ * Specialize constructor_registration_base so that it's register_ function
+ * instantiates a constructor functoid that uses the garbage collector
+ */
 template <class Class, class Policies>
-  struct constructor_registration_base<Class, reg::null_type, default_constructor, Policies> : public registration {
-  constructor_registration_base(Policies const &policies, string const &name, string const &arguments, string const &declares, string const &docstring)
+struct constructor_registration_base<Class, reg::null_type, default_constructor, Policies> : public registration {
+  constructor_registration_base(Policies const &policies, string const &name, string const &arguments, string const &declares,
+                                string const &docstring)
       : policies(policies), m_name(name), m_arguments(arguments), m_declares(declares), m_doc_string(docstring) {}
 
-  void register_() const {
-    HARD_IMPLEMENT_MEF("Do I use this code?");
-  }
+  void register_() const { HARD_IMPLEMENT_MEF("Do I use this code?"); }
 
   Policies policies;
   string m_name;
@@ -557,77 +515,71 @@ template <class Class, class Policies>
          Specialized by making second template parameter reg::null_type
         */
 template <class Class, class Policies>
-  struct constructor_registration<Class, reg::null_type, default_constructor, Policies, construct_non_derivable_class> : public constructor_registration_base<Class, reg::null_type, default_constructor, Policies> {
-  constructor_registration(Policies const &policies, string const &name, string const &arguments, string const &declares, string const &docstring) : constructor_registration_base<Class, reg::null_type, default_constructor, Policies>(policies, name, arguments, declares, docstring){};
+struct constructor_registration<Class, reg::null_type, default_constructor, Policies, construct_non_derivable_class>
+    : public constructor_registration_base<Class, reg::null_type, default_constructor, Policies> {
+  constructor_registration(Policies const &policies, string const &name, string const &arguments, string const &declares,
+                           string const &docstring)
+      : constructor_registration_base<Class, reg::null_type, default_constructor, Policies>(policies, name, arguments, declares,
+                                                                                            docstring){};
   core::Creator_sp registerDefaultConstructor_() const {
-    //                printf("%s:%d In constructor_registration::registerDefaultConstructor derivable_default_constructor<> ----- Make sure that I'm being called for derivable classes\n", __FILE__, __LINE__ );
-//    return gctools::GC<DerivableDefaultConstructorCreator_O<Class>>::allocate();
-    return gctools::GC<DefaultConstructorCreator_O<Class,Class*>>::allocate();
+    //                printf("%s:%d In constructor_registration::registerDefaultConstructor derivable_default_constructor<> -----
+    //                Make sure that I'm being called for derivable classes\n", __FILE__, __LINE__ );
+    //    return gctools::GC<DerivableDefaultConstructorCreator_O<Class>>::allocate();
+    return gctools::GC<DefaultConstructorCreator_O<Class, Class *>>::allocate();
   }
 };
 
-template <
-    class Class, class Get, class GetPolicies, class Set = reg::null_type, class SetPolicies = reg::null_type>
+template <class Class, class Get, class GetPolicies, class Set = reg::null_type, class SetPolicies = reg::null_type>
 struct property_registration : registration {
- property_registration(
-                       const string &name,
-                       Get const &get,
-                       GetPolicies const &get_policies,
-                       Set const &set = Set(),
-                       SetPolicies const &set_policies = SetPolicies(),
-                       string const &arguments = "",
-                       string const &declares = "",
-                       string const &docstring = "")
- : m_name(name), get(get), get_policies(get_policies), set(set), set_policies(set_policies), m_arguments(arguments), m_declares(declares), m_doc_string(docstring) {}
+  property_registration(const string &name, Get const &get, GetPolicies const &get_policies, Set const &set = Set(),
+                        SetPolicies const &set_policies = SetPolicies(), string const &arguments = "", string const &declares = "",
+                        string const &docstring = "")
+      : m_name(name), get(get), get_policies(get_policies), set(set), set_policies(set_policies), m_arguments(arguments),
+        m_declares(declares), m_doc_string(docstring) {}
 
- void register_() const {
-     LOG_SCOPE(("%s:%d class_ register_ %s\n", __FILE__, __LINE__, this->m_name.c_str() ));
-     const string n(m_name);
+  void register_() const {
+    LOG_SCOPE(("%s:%d class_ register_ %s\n", __FILE__, __LINE__, this->m_name.c_str()));
+    const string n(m_name);
     //                int*** i = GetterMethoid<reg::null_type,Class,Get>(n,get);
     //                printf("%p\n", i);
-     core::Symbol_sp classSymbol = reg::lisp_classSymbol<Class>();
-     core::Symbol_sp sym = core::lisp_intern(n, symbol_packageName(classSymbol));
-     using VariadicGetterType = WRAPPER_Getter< reg::null_type, Class, Get >;
-     core::GlobalSimpleFun_sp entryPoint = makeGlobalSimpleFunAndFunctionDescription<VariadicGetterType>( sym ,nil<core::T_O>());
-     maybe_register_symbol_using_dladdr( (void*)VariadicGetterType::entry_point );
-     auto raw_getter = gc::GC<VariadicGetterType>::allocate( entryPoint, get );
-     core::BuiltinClosure_sp getter = gc::As<core::BuiltinClosure_sp>( raw_getter );
-     lisp_defineSingleDispatchMethod( clbind::DefaultWrapper(), sym, classSymbol, getter, 0, true, m_arguments, m_declares, m_doc_string, true, 1 );
-     core::T_sp setf_name = core::Cons_O::createList( cl::_sym_setf, sym );
-     using VariadicSetterType = WRAPPER_Setter<reg::null_type, Class, Set>;
-     core::GlobalSimpleFun_sp setterEntryPoint = makeGlobalSimpleFunAndFunctionDescription<VariadicSetterType>( setf_name ,nil<core::T_O>());
-     maybe_register_symbol_using_dladdr( (void*)VariadicSetterType::entry_point );
-     auto raw_setter = gc::GC<VariadicSetterType>::allocate( setterEntryPoint, set );
-     core::BuiltinClosure_sp setter = gc::As<core::BuiltinClosure_sp>( raw_setter );
-     lisp_defineSingleDispatchMethod( clbind::DefaultWrapper(), setf_name, classSymbol, setter, 1, true, m_arguments, m_declares, m_doc_string, true, 2);
+    core::Symbol_sp classSymbol = reg::lisp_classSymbol<Class>();
+    core::Symbol_sp sym = core::lisp_intern(n, symbol_packageName(classSymbol));
+    using VariadicGetterType = WRAPPER_Getter<reg::null_type, Class, Get>;
+    core::GlobalSimpleFun_sp entryPoint = makeGlobalSimpleFunAndFunctionDescription<VariadicGetterType>(sym, nil<core::T_O>());
+    maybe_register_symbol_using_dladdr((void *)VariadicGetterType::entry_point);
+    auto raw_getter = gc::GC<VariadicGetterType>::allocate(entryPoint, get);
+    core::BuiltinClosure_sp getter = gc::As<core::BuiltinClosure_sp>(raw_getter);
+    lisp_defineSingleDispatchMethod(clbind::DefaultWrapper(), sym, classSymbol, getter, 0, true, m_arguments, m_declares,
+                                    m_doc_string, true, 1);
+    core::T_sp setf_name = core::Cons_O::createList(cl::_sym_setf, sym);
+    using VariadicSetterType = WRAPPER_Setter<reg::null_type, Class, Set>;
+    core::GlobalSimpleFun_sp setterEntryPoint =
+        makeGlobalSimpleFunAndFunctionDescription<VariadicSetterType>(setf_name, nil<core::T_O>());
+    maybe_register_symbol_using_dladdr((void *)VariadicSetterType::entry_point);
+    auto raw_setter = gc::GC<VariadicSetterType>::allocate(setterEntryPoint, set);
+    core::BuiltinClosure_sp setter = gc::As<core::BuiltinClosure_sp>(raw_setter);
+    lisp_defineSingleDispatchMethod(clbind::DefaultWrapper(), setf_name, classSymbol, setter, 1, true, m_arguments, m_declares,
+                                    m_doc_string, true, 2);
     //                printf("%s:%d - allocated a getter@%p for %s\n", __FILE__, __LINE__, getter, name);
     // register the getter here
- }
- virtual std::string name() const { return this->m_name;}
- virtual std::string kind() const { return "property_registration"; };
- std::string m_name;
- Get get;
- GetPolicies get_policies;
- Set set;
- SetPolicies set_policies;
- string m_arguments;
- string m_declares;
- string m_doc_string;
+  }
+  virtual std::string name() const { return this->m_name; }
+  virtual std::string kind() const { return "property_registration"; };
+  std::string m_name;
+  Get get;
+  GetPolicies get_policies;
+  Set set;
+  SetPolicies set_policies;
+  string m_arguments;
+  string m_declares;
+  string m_doc_string;
 };
 
-
- template <
-    class Class, class Get, class GetPolicies>
-   struct property_registration<Class,Get,GetPolicies,reg::null_type,reg::null_type> : registration {
-  property_registration(
-      const string &name,
-      Get const &get,
-      GetPolicies const &get_policies,
-      reg::null_type const &set = reg::null_type(),
-      reg::null_type const &set_policies = reg::null_type(),
-      string const &arguments = "",
-      string const &declares = "",
-      string const &docstring = "")
+template <class Class, class Get, class GetPolicies>
+struct property_registration<Class, Get, GetPolicies, reg::null_type, reg::null_type> : registration {
+  property_registration(const string &name, Get const &get, GetPolicies const &get_policies,
+                        reg::null_type const &set = reg::null_type(), reg::null_type const &set_policies = reg::null_type(),
+                        string const &arguments = "", string const &declares = "", string const &docstring = "")
       : m_name(name), get(get), get_policies(get_policies), m_arguments(arguments), m_declares(declares), m_doc_string(docstring) {}
 
   void register_() const {
@@ -637,12 +589,13 @@ struct property_registration : registration {
     //                printf("%p\n", i);
     core::Symbol_sp classSymbol = reg::lisp_classSymbol<Class>();
     core::Symbol_sp symbol = core::lisp_intern(n, symbol_packageName(classSymbol));
-    using VariadicType = WRAPPER_Getter<reg::null_type, Class, Get >;
-    core::FunctionDescription_sp fdesc = makeFunctionDescription(symbol,nil<core::T_O>());
-    auto entry = gc::GC<VariadicType>::allocate( get, fdesc, nil<core::T_O>());
-    lisp_defineSingleDispatchMethod(clbind::DefaultWrapper(), symbol, classSymbol, entry, 0, true, m_arguments, m_declares, m_doc_string, true, 1);
+    using VariadicType = WRAPPER_Getter<reg::null_type, Class, Get>;
+    core::FunctionDescription_sp fdesc = makeFunctionDescription(symbol, nil<core::T_O>());
+    auto entry = gc::GC<VariadicType>::allocate(get, fdesc, nil<core::T_O>());
+    lisp_defineSingleDispatchMethod(clbind::DefaultWrapper(), symbol, classSymbol, entry, 0, true, m_arguments, m_declares,
+                                    m_doc_string, true, 1);
   }
-  virtual std::string name() const { return this->m_name;}
+  virtual std::string name() const { return this->m_name; }
   virtual std::string kind() const { return "property_registration"; };
   std::string m_name;
   Get get;
@@ -652,54 +605,42 @@ struct property_registration : registration {
   string m_doc_string;
 };
 
-
-
- 
-
-
 } // namespace detail
 
 // registers a class in the cl environment
-template <class T, class X1, class X2, class X3>
-struct class_ : detail::class_base {
+template <class T, class X1, class X2, class X3> struct class_ : detail::class_base {
   typedef class_<T, X1, X2, X3> self_t;
 
 private:
-  template <class A, class B, class C, class D>
-  class_(const class_<A, B, C, D> &);
+  template <class A, class B, class C, class D> class_(const class_<A, B, C, D> &);
 
 public:
   typedef boost::mpl::vector4<X1, X2, X3, clbind::detail::unspecified> parameters_type;
 
   // WrappedType MUST inherit from T
-  typedef typename detail::extract_parameter<
-    parameters_type, boost::is_base_and_derived<T, boost::mpl::_>, reg::null_type>::type WrappedType;
+  typedef typename detail::extract_parameter<parameters_type, boost::is_base_and_derived<T, boost::mpl::_>, reg::null_type>::type
+      WrappedType;
 
   typedef typename detail::extract_parameter<
-    parameters_type, boost::mpl::not_<
-                       boost::mpl::or_<
-                         detail::is_bases<boost::mpl::_>, boost::is_base_and_derived<boost::mpl::_, T>, boost::is_base_and_derived<T, boost::mpl::_>>>,
-    std::unique_ptr<T> // Was default to put the pointer into a T*
-    >::type HoldType;
+      parameters_type,
+      boost::mpl::not_<boost::mpl::or_<detail::is_bases<boost::mpl::_>, boost::is_base_and_derived<boost::mpl::_, T>,
+                                       boost::is_base_and_derived<T, boost::mpl::_>>>,
+      std::unique_ptr<T> // Was default to put the pointer into a T*
+      >::type HoldType;
 
-  template <class Src, class Target>
-  void add_downcast(Src *, Target *, boost::mpl::true_) {
-    add_cast(
-             reg::registered_class<Src>::id, reg::registered_class<Target>::id, detail::dynamic_cast_<Src, Target>::execute);
+  template <class Src, class Target> void add_downcast(Src *, Target *, boost::mpl::true_) {
+    add_cast(reg::registered_class<Src>::id, reg::registered_class<Target>::id, detail::dynamic_cast_<Src, Target>::execute);
   }
 
-  template <class Src, class Target>
-  void add_downcast(Src *, Target *, boost::mpl::false_) {}
+  template <class Src, class Target> void add_downcast(Src *, Target *, boost::mpl::false_) {}
 
   // this function generates conversion information
   // in the given class_rep structure. It will be able
   // to implicitly cast to the given template type
   // Dummy return value
-  template <class To>
-  int gen_base_info(detail::type_<To>) {
+  template <class To> int gen_base_info(detail::type_<To>) {
     add_base(typeid(To), detail::static_cast_<T, To>::execute);
-    add_cast(
-             reg::registered_class<T>::id, reg::registered_class<To>::id, detail::static_cast_<T, To>::execute);
+    add_cast(reg::registered_class<T>::id, reg::registered_class<To>::id, detail::static_cast_<T, To>::execute);
 
     add_downcast((To *)0, (T *)0, boost::is_polymorphic<To>());
     return 0;
@@ -722,7 +663,8 @@ public:
 #undef CLBIND_GEN_BASE_INFO
 
   template <typename NameType>
-  class_(scope_& outer_scope, const NameType& name, const std::string& docstring="") : class_base(PrepareName(name)), _outer_scope(&outer_scope), scope(*this) {
+  class_(scope_ &outer_scope, const NameType &name, const std::string &docstring = "")
+      : class_base(PrepareName(name)), _outer_scope(&outer_scope), scope(*this) {
 #ifndef NDEBUG
     detail::check_link_compatibility();
 #endif
@@ -731,84 +673,67 @@ public:
   }
 
   template <typename NameType, typename... Types>
-  class_ &def_constructor(const NameType& name,
-                          constructor<Types...> sig,
-                          string const &arguments = "",
-                          string const &declares = "",
-                          string const &docstring = "") {
+  class_ &def_constructor(const NameType &name, constructor<Types...> sig, string const &arguments = "",
+                          string const &declares = "", string const &docstring = "") {
     return this->def_constructor_(PrepareName(name), &sig, policies<adopt<result>>(), arguments, declares, docstring);
   }
 
-  template <typename NameType, class F, class... PTypes>
-  class_ &def(const NameType& name, F f, PTypes... pols)
-  {
+  template <typename NameType, class F, class... PTypes> class_ &def(const NameType &name, F f, PTypes... pols) {
     typedef policies<PTypes...> Policies;
     Policies curPolicies;
-    walk_policy(curPolicies,pols...);
-    return this->virtual_def(PrepareName(name), f,
-                             curPolicies,
-                             reg::null_type());
+    walk_policy(curPolicies, pols...);
+    return this->virtual_def(PrepareName(name), f, curPolicies, reg::null_type());
   }
 
   // static functions
   template <typename NameType, class F, class Policies>
-  class_ &def_static(const char*name,
-                     F fn,
-                     string const &docstring = "",
-                     string const &arguments = "",
-                     string const &declares = "",
-                     Policies policies=Policies() ) {
-      
-    this->scope_::def(name,fn,policies,docstring,arguments,declares);
+  class_ &def_static(const char *name, F fn, string const &docstring = "", string const &arguments = "",
+                     string const &declares = "", Policies policies = Policies()) {
+
+    this->scope_::def(name, fn, policies, docstring, arguments, declares);
     return *this;
   }
   // static functions
   template <typename NameType, class F>
-  class_ &def_static(const NameType& name,
-                     F fn,
-                     string const &docstring = "",
-                     string const &arguments = "",
+  class_ &def_static(const NameType &name, F fn, string const &docstring = "", string const &arguments = "",
                      string const &declares = "") {
-    this->scope_::def( name,fn,docstring.c_str(),arguments.c_str(),declares.c_str());
+    this->scope_::def(name, fn, docstring.c_str(), arguments.c_str(), declares.c_str());
     return *this;
-  }  
+  }
 
-
-    // static functions
-  template <typename... Types>
-  class_ &def(constructor<Types...> sig) {
-    printf("%s:%d def(expose::init...)\n", __FILE__, __LINE__ );
+  // static functions
+  template <typename... Types> class_ &def(constructor<Types...> sig) {
+    printf("%s:%d def(expose::init...)\n", __FILE__, __LINE__);
     stringstream ss;
     ss << "make-";
     ss << this->name();
     if (this->m_init_counter) {
       ss << this->m_init_counter;
     }
-    maybe_register_symbol_using_dladdr((void*)sig,sizeof(sig),ss.str());
-    this->def_constructor_(ss.str(),&sig,policies<>(),"","","");
+    maybe_register_symbol_using_dladdr((void *)sig, sizeof(sig), ss.str());
+    this->def_constructor_(ss.str(), &sig, policies<>(), "", "", "");
     this->m_init_counter++;
     return *this;
   }
 
   template <typename NameType, class Getter>
-  class_ &property( const NameType& name, Getter g, string const &arguments = "", string const &declares = "", string const &docstring = "") {
-    this->add_member(
-                     new detail::property_registration<T, Getter, reg::null_type>(
-                                                                                  PrepareName(name) // name
+  class_ &property(const NameType &name, Getter g, string const &arguments = "", string const &declares = "",
+                   string const &docstring = "") {
+    this->add_member(new detail::property_registration<T, Getter, reg::null_type>(PrepareName(name) // name
                                                                                   ,
                                                                                   g // Get
                                                                                   ,
                                                                                   reg::null_type() // GetPolicies
                                                                                   ,
-                                                                                  reg::null_type(), reg::null_type(), arguments, declares, docstring));
+                                                                                  reg::null_type(), reg::null_type(), arguments,
+                                                                                  declares, docstring));
     return *this;
   }
 
   template <typename NameType, class Begin, class End>
-  class_ &iterator(const NameType &iteratorName, Begin beginFn, End endFn, string const &arguments = "", string const &declares = "", string const &docstring = "") {
-    this->add_member(new detail::iterator_registration<T, Begin, End, reg::null_type>(
-										      PrepareName(iteratorName)
-                                                                                      ,
+  class_ &iterator(const NameType &iteratorName, Begin beginFn, End endFn, string const &arguments = "",
+                   string const &declares = "", string const &docstring = "") {
+    this->add_member(new detail::iterator_registration<T, Begin, End, reg::null_type>(PrepareName(iteratorName),
                                                                                       beginFn // begin
                                                                                       ,
                                                                                       endFn // end
@@ -819,68 +744,52 @@ public:
     return *this;
   }
 
-  template <typename NameType, class C, class D>
-  class_ &def_readonly(const NameType &name, D C::*mem_ptr) {
-    typedef detail::property_registration<T, D C::*, detail::null_type>
-      registration_type;
+  template <typename NameType, class C, class D> class_ &def_readonly(const NameType &name, D C::*mem_ptr) {
+    typedef detail::property_registration<T, D C::*, detail::null_type> registration_type;
 
-    this->add_member(new registration_type( PrepareName(name), mem_ptr, detail::null_type()));
+    this->add_member(new registration_type(PrepareName(name), mem_ptr, detail::null_type()));
     return *this;
   }
 
   template <typename NameType, class C, class D, class Policies>
   class_ &def_readonly(const NameType &name, D C::*mem_ptr, Policies const &policies) {
-    typedef detail::property_registration<T, D C::*, Policies>
-      registration_type;
+    typedef detail::property_registration<T, D C::*, Policies> registration_type;
 
-    this->add_member(new registration_type( PrepareName(name), mem_ptr, policies ));
+    this->add_member(new registration_type(PrepareName(name), mem_ptr, policies));
     return *this;
   }
 
-  template <typename NameType, class C, class D>
-  class_ &def_readwrite(const NameType& name, D C::*mem_ptr) {
-    typedef detail::property_registration<
-      T, D C::*, detail::null_type, D C::*> registration_type;
+  template <typename NameType, class C, class D> class_ &def_readwrite(const NameType &name, D C::*mem_ptr) {
+    typedef detail::property_registration<T, D C::*, detail::null_type, D C::*> registration_type;
 
-    this->add_member(new registration_type( PrepareName(name), mem_ptr, detail::null_type(), mem_ptr));
+    this->add_member(new registration_type(PrepareName(name), mem_ptr, detail::null_type(), mem_ptr));
     return *this;
   }
 
-    template <typename NameType, class C, class D, class GetPolicies>
-  class_ &def_readwrite(
-                        const NameType& name, D C::*mem_ptr, GetPolicies const &get_policies) {
-    typedef detail::property_registration<
-      T, D C::*, GetPolicies, D C::*> registration_type;
+  template <typename NameType, class C, class D, class GetPolicies>
+  class_ &def_readwrite(const NameType &name, D C::*mem_ptr, GetPolicies const &get_policies) {
+    typedef detail::property_registration<T, D C::*, GetPolicies, D C::*> registration_type;
 
-    this->add_member(
-                     new registration_type( PrepareName(name), mem_ptr, get_policies, mem_ptr));
+    this->add_member(new registration_type(PrepareName(name), mem_ptr, get_policies, mem_ptr));
     return *this;
   }
 
-    template < typename NameType, class C, class D, class GetPolicies, class SetPolicies>
-  class_ &def_readwrite(
-                        const NameType& name, D C::*mem_ptr, GetPolicies const &get_policies, SetPolicies const &set_policies) {
-    typedef detail::property_registration<
-      T, D C::*, GetPolicies, D C::*, SetPolicies> registration_type;
+  template <typename NameType, class C, class D, class GetPolicies, class SetPolicies>
+  class_ &def_readwrite(const NameType &name, D C::*mem_ptr, GetPolicies const &get_policies, SetPolicies const &set_policies) {
+    typedef detail::property_registration<T, D C::*, GetPolicies, D C::*, SetPolicies> registration_type;
 
-    this->add_member(
-                     new registration_type(
-                                           PrepareName(name), mem_ptr, get_policies, mem_ptr, set_policies));
+    this->add_member(new registration_type(PrepareName(name), mem_ptr, get_policies, mem_ptr, set_policies));
     return *this;
   }
 
-  template <class Derived, class Policies>
-  class_ &def(detail::operator_<Derived>, Policies const &policies) {
-    return this->def(
-                     Derived::name(), &Derived::template apply<T, Policies>::execute, policies);
+  template <class Derived, class Policies> class_ &def(detail::operator_<Derived>, Policies const &policies) {
+    return this->def(Derived::name(), &Derived::template apply<T, Policies>::execute, policies);
   }
 
-  template <class Derived>
-  class_ &def(detail::operator_<Derived>) {
-    return this->def(
-                     Derived::name(), &Derived::template apply<T, detail::null_type>::execute);
+  template <class Derived> class_ &def(detail::operator_<Derived>) {
+    return this->def(Derived::name(), &Derived::template apply<T, detail::null_type>::execute);
   }
-    
+
   //#endif // end_meister_disabled
 
 #if 0
@@ -888,8 +797,8 @@ public:
     return enum_maker(this, converter);
   }
 #endif
-  
-  scope_* _outer_scope;
+
+  scope_ *_outer_scope;
   detail::static_scope<self_t> scope;
 
 private:
@@ -897,23 +806,21 @@ private:
 
   void add_wrapper_cast(reg::null_type *) {}
 
-  template <class U>
-  void add_wrapper_cast(U *) {
-    add_cast(
-             reg::registered_class<U>::id, reg::registered_class<T>::id, detail::static_cast_<U, T>::execute);
+  template <class U> void add_wrapper_cast(U *) {
+    add_cast(reg::registered_class<U>::id, reg::registered_class<T>::id, detail::static_cast_<U, T>::execute);
 
     add_downcast((T *)0, (U *)0, boost::is_polymorphic<T>());
   }
 
   void init() {
     typedef typename detail::extract_parameter<
-      parameters_type, boost::mpl::or_<
-        detail::is_bases<boost::mpl::_>, boost::is_base_and_derived<boost::mpl::_, T>>,
-      no_bases>::type bases_t;
+        parameters_type, boost::mpl::or_<detail::is_bases<boost::mpl::_>, boost::is_base_and_derived<boost::mpl::_, T>>,
+        no_bases>::type bases_t;
 
     typedef typename boost::mpl::if_<detail::is_bases<bases_t>, bases_t, bases<bases_t>>::type Base;
 
-    class_base::init(typeid(T), reg::registered_class<T>::id, typeid(WrappedType), reg::registered_class<WrappedType>::id, isDerivableCxxClass<T>(0));
+    class_base::init(typeid(T), reg::registered_class<T>::id, typeid(WrappedType), reg::registered_class<WrappedType>::id,
+                     isDerivableCxxClass<T>(0));
 
     add_wrapper_cast((WrappedType *)0);
 #if 0
@@ -968,55 +875,46 @@ private:
 
   // these handle default implementation of virtual functions
   template <class F, class Policies>
-  class_ &virtual_def(const std::string &name, F const &fn,
-                      Policies const &policies,
-                      reg::null_type) {
-    maybe_register_symbol_using_dladdr(*(void**)&fn,sizeof(fn),name);
+  class_ &virtual_def(const std::string &name, F const &fn, Policies const &policies, reg::null_type) {
+    maybe_register_symbol_using_dladdr(*(void **)&fn, sizeof(fn), name);
     this->add_member(new detail::memfun_registration<T, F, Policies>(name, fn, policies));
     return *this;
   }
 
-  
   template <class Signature, class Policies>
-  class_ &def_default_constructor_(const char *name, Signature *, Policies const &, string const &docstring, string const &arguments, string const &declares) {
-    typedef typename boost::mpl::if_<
-      boost::is_same<WrappedType, reg::null_type>, T, WrappedType>::type construct_type;
+  class_ &def_default_constructor_(const char *name, Signature *, Policies const &, string const &docstring,
+                                   string const &arguments, string const &declares) {
+    typedef typename boost::mpl::if_<boost::is_same<WrappedType, reg::null_type>, T, WrappedType>::type construct_type;
 
     this->set_default_constructor(
-                                  new detail::constructor_registration<
-                                  construct_type, HoldType, Signature, Policies,detail::construct_non_derivable_class>(Policies(), name, arguments, declares, docstring));
+        new detail::constructor_registration<construct_type, HoldType, Signature, Policies, detail::construct_non_derivable_class>(
+            Policies(), name, arguments, declares, docstring));
     return *this;
   }
 
   template <class Signature, class Policies>
-  class_ &def_constructor_(const string &name, Signature *, Policies const &, string const &arguments, string const &declares, string const &docstring) {
+  class_ &def_constructor_(const string &name, Signature *, Policies const &, string const &arguments, string const &declares,
+                           string const &docstring) {
     typedef Signature signature;
 
-    typedef typename boost::mpl::if_<
-      boost::is_same<WrappedType, reg::null_type>, T, WrappedType>::type construct_type;
+    typedef typename boost::mpl::if_<boost::is_same<WrappedType, reg::null_type>, T, WrappedType>::type construct_type;
     this->add_member(
-                     new detail::constructor_registration<
-                     construct_type, HoldType, signature, Policies,detail::construct_non_derivable_class>(Policies(), name, arguments, declares, docstring));
+        new detail::constructor_registration<construct_type, HoldType, signature, Policies, detail::construct_non_derivable_class>(
+            Policies(), name, arguments, declares, docstring));
 
     return *this;
   }
 
 public:
-
   template <class Getter, class Setter>
-  class_& def_property(const std::string& prefix, Getter g, Setter s, const char* docstring="") {
-    this->property_impl(prefix,g,s);
+  class_ &def_property(const std::string &prefix, Getter g, Setter s, const char *docstring = "") {
+    this->property_impl(prefix, g, s);
   }
-
-  
 };
-}
+} // namespace clbind
 
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-
-
-
 
 #endif // CLBIND_CLASS_HPP_INCLUDED

--- a/include/clasp/clbind/class.h
+++ b/include/clasp/clbind/class.h
@@ -397,6 +397,7 @@ struct memfun_registration : registration {
     this->m_arguments = policies.lambdaList();
     this->m_doc_string = policies.docstring();
     this->m_declares = policies.declares();
+    this->m_auto_export = policies.autoExport();
   }
 
   void register_() const {
@@ -409,7 +410,7 @@ struct memfun_registration : registration {
     lisp_defineSingleDispatchMethod(clbind::DefaultWrapper(), 
                                     symbol, classSymbol, entry, 0, true,
                                     m_arguments, m_declares, m_doc_string,
-                                    true,
+                                    m_auto_export,
                                     CountMethodArguments<MethodPointerType>::value + 1, // +1 for the self argument
                                     GatherPureOutValues<Policies, 0>::gather());
   }
@@ -423,6 +424,7 @@ struct memfun_registration : registration {
   string m_arguments;
   string m_declares;
   string m_doc_string;
+  bool m_auto_export;
 };
 
 template <class Class, class Begin, class End, class Policies>

--- a/include/clasp/clbind/function.h
+++ b/include/clasp/clbind/function.h
@@ -199,6 +199,8 @@ struct function_registration<FunctionPointerType,policies<Policies...>,PureOutsP
     this->m_lambdalist = policies.lambdaList();
     this->m_docstring = policies.docstring();
     this->m_declares = policies.declares();
+    this->m_autoExport = policies.autoExport();
+    this->m_setf = policies.setf();
   }
 
   void register_() const {
@@ -208,7 +210,7 @@ struct function_registration<FunctionPointerType,policies<Policies...>,PureOutsP
     using VariadicType = WRAPPER_VariadicFunction<FunctionPointerType, policies<Policies...>, typename inValuePack::type, clbind::DefaultWrapper >;
     core::FunctionDescription_sp fdesc = makeFunctionDescription(symbol,nil<core::T_O>());
     auto entry = gctools::GC<VariadicType>::allocate(this->functionPtr,fdesc,nil<core::T_O>());
-    core::lisp_bytecode_defun( core::symbol_function, clbind::DefaultWrapper::BytecodeP, symbol, core::lisp_currentPackageName(), entry, m_lambdalist, m_declares, m_docstring, "=external=", 0, (CountFunctionArguments<FunctionPointerType>::value), GatherPureOutValues<policies<Policies...>, -1>::gather());
+    core::lisp_bytecode_defun(this->m_setf ? core::symbol_function_setf : core::symbol_function, clbind::DefaultWrapper::BytecodeP, symbol, core::lisp_currentPackageName(), entry, m_lambdalist, m_declares, m_docstring, "=external=", 0, (CountFunctionArguments<FunctionPointerType>::value), m_autoExport, GatherPureOutValues<policies<Policies...>, -1>::gather());
   }
 
   virtual std::string name() const { return this->m_name;}
@@ -220,6 +222,8 @@ struct function_registration<FunctionPointerType,policies<Policies...>,PureOutsP
   string m_lambdalist;
   string m_declares;
   string m_docstring;
+  bool m_autoExport;
+  bool m_setf;
 };
 
 } // namespace detail

--- a/include/clasp/clbind/function.h
+++ b/include/clasp/clbind/function.h
@@ -4,14 +4,14 @@
 
 /*
 Copyright (c) 2014, Christian E. Schafmeister
- 
+
 CLASP is free software; you can redistribute it and/or
 modify it under the terms of the GNU Library General Public
 License as published by the Free Software Foundation; either
 version 2 of the License, or (at your option) any later version.
- 
+
 See directory 'clasp/licenses' for full details.
- 
+
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
@@ -32,12 +32,11 @@ THE SOFTWARE.
 #define CLBIND_FUNCTION2_081014_HPP
 
 #if 0
-# define DEBUG_SCOPE 1
-# define LOG_SCOPE(xxx) printf xxx;
+#define DEBUG_SCOPE 1
+#define LOG_SCOPE(xxx) printf xxx;
 #else
-# define LOG_SCOPE(xxx)
+#define LOG_SCOPE(xxx)
 #endif
-
 
 #include <clasp/core/lambdaListHandler.fwd.h>
 //#include "clbind/prefix.h"
@@ -62,7 +61,8 @@ struct CLBIND_API registration {
 public:
   virtual gc::smart_ptr<core::Creator_O> registerDefaultConstructor_() const { HARD_SUBCLASS_MUST_IMPLEMENT(); };
   virtual std::string name() const = 0;
-  virtual std::string kind()const  = 0;
+  virtual std::string kind() const = 0;
+
 protected:
   virtual void register_() const = 0;
 
@@ -70,9 +70,8 @@ private:
   friend struct ::clbind::scope_;
   registration *m_next;
 };
-}
-} // namespace clbind::detail
-
+} // namespace detail
+} // namespace clbind
 
 #include <clasp/clbind/clbindPackage.h>
 #include <clasp/clbind/policies.h>
@@ -81,121 +80,121 @@ private:
 #include <clasp/clbind/apply.h>
 
 namespace clbind {
-template <typename... Types>
-class my_tuple : public std::tuple<Types...> {
-  my_tuple() {
-    printf("%s:%d:%s\n", __FILE__, __LINE__, __FUNCTION__ );
-  }
-};
-};
-
-namespace clbind {
-template <typename FunctionPtrType, typename Policies, typename PureOuts, typename ArgumentWrapper>
-class WRAPPER_VariadicFunction;
-};
-
-namespace clbind {
-template <typename RT, typename...ARGS, typename Policies, typename...PUREOUTS, typename ArgumentWrapper>
-class WRAPPER_VariadicFunction< RT(*)(ARGS...), Policies, clbind::pureOutsPack<PUREOUTS...>, ArgumentWrapper > : public core::GlobalSimpleFunBase_O {
-public:
-  typedef WRAPPER_VariadicFunction < RT(*)(ARGS...), Policies, clbind::pureOutsPack<PUREOUTS...>, ArgumentWrapper > MyType;
-  typedef core::GlobalSimpleFunBase_O TemplatedBase;
-  typedef RT(*FuncType)(ARGS...);
-public:
-  FuncType                   fptr;
-public:
-  static constexpr auto inValueMask = clbind::inValueMaskMuple<sizeof...(ARGS), Policies>();
-
-  enum { NumParams = sizeof...(ARGS)};
-
-  WRAPPER_VariadicFunction(FuncType ptr, core::FunctionDescription_sp fdesc, core::T_sp code)
-      : fptr(ptr), GlobalSimpleFunBase_O(fdesc,core::ClaspXepFunction::make<MyType>(),code)  {
-    this->validateCodePointer((void**)&this->fptr,sizeof(this->fptr));
-  };
-
-  virtual const char* describe() const { return "VariadicFunctor"; };
-
-  virtual size_t templatedSizeof() const { return sizeof(*this);};
-
-  void fixupInternalsForSnapshotSaveLoad( snapshotSaveLoad::Fixup* fixup ) {
-    this->TemplatedBase::fixupInternalsForSnapshotSaveLoad(fixup);
-    this->fixupOneCodePointer( fixup, (void**)&this->fptr );
-  };
-
-  static inline LCC_RETURN handler_entry_point_n(const BytecodeWrapper& dummy, core::T_O* lcc_closure, size_t lcc_nargs, core::T_O** lcc_args )
-  {
-    MyType* closure = gctools::untag_general<MyType*>((MyType*)lcc_closure);
-    INCREMENT_FUNCTION_CALL_COUNTER(closure);
-    DO_DRAG_CXX_CALLS();
-    if (lcc_nargs!=NumParams) cc_wrong_number_of_arguments(lcc_closure,lcc_nargs,NumParams,NumParams);
-    std::tuple<translate::from_object<ARGS,PUREOUTS>...> all_args(arg_tuple<0,Policies,ARGS...>::goFrame(lcc_args));
-    return apply_and_return<Policies,RT,decltype(closure->fptr),decltype(all_args)>::go(std::move(closure->fptr),std::move(all_args));
-  }
-
-  static inline LCC_RETURN entry_point_n(core::T_O* lcc_closure, size_t lcc_nargs, core::T_O** lcc_args ) {
-//    if (lcc_nargs != NumParams) cc_wrong_number_of_arguments(lcc_closure,lcc_nargs,NumParams,NumParams);
-    return handler_entry_point_n(ArgumentWrapper(),lcc_closure,lcc_nargs,lcc_args);
-  }
-  
-  static inline LISP_ENTRY_0() {
-    return entry_point_n(lcc_closure,0,NULL);
-  }
-  static inline LISP_ENTRY_1() {
-    core::T_O* args[1] = {lcc_farg0};
-    return entry_point_n(lcc_closure,1,args);
-  }
-  static inline LISP_ENTRY_2() {
-    core::T_O* args[2] = {lcc_farg0,lcc_farg1};
-    return entry_point_n(lcc_closure,2,args);
-  }
-  static inline LISP_ENTRY_3() {
-    core::T_O* args[3] = {lcc_farg0,lcc_farg1,lcc_farg2};
-    return entry_point_n(lcc_closure,3,args);
-  }
-  static inline LISP_ENTRY_4() {
-    core::T_O* args[4] = {lcc_farg0,lcc_farg1,lcc_farg2,lcc_farg3};
-    return entry_point_n(lcc_closure,4,args);
-  }
-  static inline LISP_ENTRY_5() {
-    core::T_O* args[5] = {lcc_farg0,lcc_farg1,lcc_farg2,lcc_farg3,lcc_farg4};
-    return entry_point_n(lcc_closure,5,args);
-  }
-
+template <typename... Types> class my_tuple : public std::tuple<Types...> {
+  my_tuple() { printf("%s:%d:%s\n", __FILE__, __LINE__, __FUNCTION__); }
 };
 }; // namespace clbind
 
+namespace clbind {
+template <typename FunctionPtrType, typename Policies, typename PureOuts, typename ArgumentWrapper> class WRAPPER_VariadicFunction;
+};
 
+namespace clbind {
+template <typename RT, typename... ARGS, typename Policies, typename... PUREOUTS, typename ArgumentWrapper>
+class WRAPPER_VariadicFunction<RT (*)(ARGS...), Policies, clbind::pureOutsPack<PUREOUTS...>, ArgumentWrapper>
+    : public core::GlobalSimpleFunBase_O {
+public:
+  typedef WRAPPER_VariadicFunction<RT (*)(ARGS...), Policies, clbind::pureOutsPack<PUREOUTS...>, ArgumentWrapper> MyType;
+  typedef core::GlobalSimpleFunBase_O TemplatedBase;
+  typedef RT (*FuncType)(ARGS...);
+
+public:
+  FuncType fptr;
+
+public:
+  static constexpr auto inValueMask = clbind::inValueMaskMuple<sizeof...(ARGS), Policies>();
+
+  enum { NumParams = sizeof...(ARGS) };
+
+  WRAPPER_VariadicFunction(FuncType ptr, core::FunctionDescription_sp fdesc, core::T_sp code)
+      : fptr(ptr), GlobalSimpleFunBase_O(fdesc, core::ClaspXepFunction::make<MyType>(), code) {
+    this->validateCodePointer((void **)&this->fptr, sizeof(this->fptr));
+  };
+
+  virtual const char *describe() const { return "VariadicFunctor"; };
+
+  virtual size_t templatedSizeof() const { return sizeof(*this); };
+
+  void fixupInternalsForSnapshotSaveLoad(snapshotSaveLoad::Fixup *fixup) {
+    this->TemplatedBase::fixupInternalsForSnapshotSaveLoad(fixup);
+    this->fixupOneCodePointer(fixup, (void **)&this->fptr);
+  };
+
+  static inline LCC_RETURN handler_entry_point_n(const BytecodeWrapper &dummy, core::T_O *lcc_closure, size_t lcc_nargs,
+                                                 core::T_O **lcc_args) {
+    MyType *closure = gctools::untag_general<MyType *>((MyType *)lcc_closure);
+    INCREMENT_FUNCTION_CALL_COUNTER(closure);
+    DO_DRAG_CXX_CALLS();
+    if (lcc_nargs != NumParams)
+      cc_wrong_number_of_arguments(lcc_closure, lcc_nargs, NumParams, NumParams);
+    std::tuple<translate::from_object<ARGS, PUREOUTS>...> all_args(arg_tuple<0, Policies, ARGS...>::goFrame(lcc_args));
+    return apply_and_return<Policies, RT, decltype(closure->fptr), decltype(all_args)>::go(std::move(closure->fptr),
+                                                                                           std::move(all_args));
+  }
+
+  static inline LCC_RETURN entry_point_n(core::T_O *lcc_closure, size_t lcc_nargs, core::T_O **lcc_args) {
+    //    if (lcc_nargs != NumParams) cc_wrong_number_of_arguments(lcc_closure,lcc_nargs,NumParams,NumParams);
+    return handler_entry_point_n(ArgumentWrapper(), lcc_closure, lcc_nargs, lcc_args);
+  }
+
+  static inline LISP_ENTRY_0() { return entry_point_n(lcc_closure, 0, NULL); }
+  static inline LISP_ENTRY_1() {
+    core::T_O *args[1] = {lcc_farg0};
+    return entry_point_n(lcc_closure, 1, args);
+  }
+  static inline LISP_ENTRY_2() {
+    core::T_O *args[2] = {lcc_farg0, lcc_farg1};
+    return entry_point_n(lcc_closure, 2, args);
+  }
+  static inline LISP_ENTRY_3() {
+    core::T_O *args[3] = {lcc_farg0, lcc_farg1, lcc_farg2};
+    return entry_point_n(lcc_closure, 3, args);
+  }
+  static inline LISP_ENTRY_4() {
+    core::T_O *args[4] = {lcc_farg0, lcc_farg1, lcc_farg2, lcc_farg3};
+    return entry_point_n(lcc_closure, 4, args);
+  }
+  static inline LISP_ENTRY_5() {
+    core::T_O *args[5] = {lcc_farg0, lcc_farg1, lcc_farg2, lcc_farg3, lcc_farg4};
+    return entry_point_n(lcc_closure, 5, args);
+  }
+};
+}; // namespace clbind
 
 template <typename FunctionPtrType, typename Policies, typename PureOutsPack, typename ArgumentWrapper>
-class gctools::GCStamp<clbind::WRAPPER_VariadicFunction<FunctionPtrType, Policies, PureOutsPack, ArgumentWrapper> > {
+class gctools::GCStamp<clbind::WRAPPER_VariadicFunction<FunctionPtrType, Policies, PureOutsPack, ArgumentWrapper>> {
 public:
-  static gctools::GCStampEnum const StampWtag = gctools::GCStamp<typename clbind::WRAPPER_VariadicFunction<FunctionPtrType, Policies, PureOutsPack, ArgumentWrapper >::TemplatedBase>::StampWtag;
+  static gctools::GCStampEnum const StampWtag =
+      gctools::GCStamp<typename clbind::WRAPPER_VariadicFunction<FunctionPtrType, Policies, PureOutsPack,
+                                                                 ArgumentWrapper>::TemplatedBase>::StampWtag;
 };
 
 template <typename FunctionPtrType, typename Policies, typename PureOutsPack, typename ArgumentWrapper>
-struct gctools::Inherits<typename clbind::WRAPPER_VariadicFunction<FunctionPtrType, Policies, PureOutsPack, ArgumentWrapper>::TemplatedBase, clbind::WRAPPER_VariadicFunction<FunctionPtrType, Policies, PureOutsPack, ArgumentWrapper> > : public std::true_type {};
+struct gctools::Inherits<
+    typename clbind::WRAPPER_VariadicFunction<FunctionPtrType, Policies, PureOutsPack, ArgumentWrapper>::TemplatedBase,
+    clbind::WRAPPER_VariadicFunction<FunctionPtrType, Policies, PureOutsPack, ArgumentWrapper>> : public std::true_type {};
 
 namespace clbind {
 
 namespace detail {
 
-template <typename FunctionPointerType>
-struct CountFunctionArguments {
+template <typename FunctionPointerType> struct CountFunctionArguments {
   enum { value = 0 };
 };
 
-template <typename RT, typename... ARGS>
-struct CountFunctionArguments<RT (*)(ARGS...)> {
+template <typename RT, typename... ARGS> struct CountFunctionArguments<RT (*)(ARGS...)> {
   enum { value = sizeof...(ARGS) };
 };
 
-template <class FunctionPointerType, class Policies=policies<>, class PureOutsPack=clbind::pureOutsPack<>>
+template <class FunctionPointerType, class Policies = policies<>, class PureOutsPack = clbind::pureOutsPack<>>
 struct function_registration;
 
-template <class FunctionPointerType, class...Policies, class PureOutsPack>
-struct function_registration<FunctionPointerType,policies<Policies...>,PureOutsPack> : registration {
-  function_registration(const std::string& name, FunctionPointerType f, policies<Policies...> const &policies) // , string const &lambdalist, string const &declares, string const &docstring)
-    : m_name(name), functionPtr(f), m_policies(policies) {
+template <class FunctionPointerType, class... Policies, class PureOutsPack>
+struct function_registration<FunctionPointerType, policies<Policies...>, PureOutsPack> : registration {
+  function_registration(
+      const std::string &name, FunctionPointerType f,
+      policies<Policies...> const &policies) // , string const &lambdalist, string const &declares, string const &docstring)
+      : m_name(name), functionPtr(f), m_policies(policies) {
     this->m_lambdalist = policies.lambdaList();
     this->m_docstring = policies.docstring();
     this->m_declares = policies.declares();
@@ -206,16 +205,20 @@ struct function_registration<FunctionPointerType,policies<Policies...>,PureOutsP
   void register_() const {
     LOG_SCOPE(("%s:%d register_ %s/%s\n", __FILE__, __LINE__, this->kind().c_str(), this->name().c_str()));
     core::Symbol_sp symbol = core::lisp_intern(m_name, core::lisp_currentPackageName());
-    using inValuePack = clbind::inValueTrueFalseMaskPack<FunctionArgCount<FunctionPointerType>::value,policies<Policies...>>;
-    using VariadicType = WRAPPER_VariadicFunction<FunctionPointerType, policies<Policies...>, typename inValuePack::type, clbind::DefaultWrapper >;
-    core::FunctionDescription_sp fdesc = makeFunctionDescription(symbol,nil<core::T_O>());
-    auto entry = gctools::GC<VariadicType>::allocate(this->functionPtr,fdesc,nil<core::T_O>());
-    core::lisp_bytecode_defun(this->m_setf ? core::symbol_function_setf : core::symbol_function, clbind::DefaultWrapper::BytecodeP, symbol, core::lisp_currentPackageName(), entry, m_lambdalist, m_declares, m_docstring, "=external=", 0, (CountFunctionArguments<FunctionPointerType>::value), m_autoExport, GatherPureOutValues<policies<Policies...>, -1>::gather());
+    using inValuePack = clbind::inValueTrueFalseMaskPack<FunctionArgCount<FunctionPointerType>::value, policies<Policies...>>;
+    using VariadicType =
+        WRAPPER_VariadicFunction<FunctionPointerType, policies<Policies...>, typename inValuePack::type, clbind::DefaultWrapper>;
+    core::FunctionDescription_sp fdesc = makeFunctionDescription(symbol, nil<core::T_O>());
+    auto entry = gctools::GC<VariadicType>::allocate(this->functionPtr, fdesc, nil<core::T_O>());
+    core::lisp_bytecode_defun(this->m_setf ? core::symbol_function_setf : core::symbol_function, clbind::DefaultWrapper::BytecodeP,
+                              symbol, core::lisp_currentPackageName(), entry, m_lambdalist, m_declares, m_docstring,
+                              "=external=", 0, (CountFunctionArguments<FunctionPointerType>::value), m_autoExport,
+                              GatherPureOutValues<policies<Policies...>, -1>::gather());
   }
 
-  virtual std::string name() const { return this->m_name;}
+  virtual std::string name() const { return this->m_name; }
   virtual std::string kind() const { return "function_registration"; };
-  
+
   std::string m_name;
   FunctionPointerType functionPtr;
   policies<Policies...> m_policies;

--- a/include/clasp/clbind/policies.h
+++ b/include/clasp/clbind/policies.h
@@ -4,14 +4,14 @@
 
 /*
 Copyright (c) 2014, Christian E. Schafmeister
- 
+
 CLASP is free software; you can redistribute it and/or
 modify it under the terms of the GNU Library General Public
 License as published by the Free Software Foundation; either
 version 2 of the License, or (at your option) any later version.
- 
+
 See directory 'clasp/licenses' for full details.
- 
+
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
@@ -127,12 +127,28 @@ struct DocString {
   DocString(const std::string& val) : m_doc_string(val) {};
 };
 
- 
+struct AutoExport {
+  bool m_auto_export;
+  AutoExport(bool val) : m_auto_export(val) {};
+};
+
+struct Setf {
+  bool m_setf;
+  Setf(bool val) : m_setf(val) {};
+};
+
+inline AutoExport noAutoExport() { return AutoExport(false); }
+
+inline Setf setf() { return Setf(true); }
+
+
 template <class...PTypes>
 struct policies {
     std::vector<Keyword> m_keywords;
     std::string m_lambda_list;
     std::string m_doc_string;
+    bool m_auto_export = true;
+    bool m_setf = false;
     void describe() {
         printf("%s:%d Descibing Policy\n", __FILE__, __LINE__ );
         if (this->m_lambda_list!="") {
@@ -164,6 +180,8 @@ struct policies {
   }
   std::string docstring() const { return this->m_doc_string; };
   std::string declares() const { return ""; };
+  bool autoExport() const { return m_auto_export; };
+  bool setf() const { return m_setf; };
 };
 
 template <class Policy, int N>
@@ -209,7 +227,19 @@ void update_policy(Policy& policy, const DocString& doc_string)
 }
 
 template <class Policy>
-void walk_policy(Policy& policy) 
+void update_policy(Policy& policy, const AutoExport& auto_export)
+{
+    policy.m_auto_export = auto_export.m_auto_export;
+}
+
+template <class Policy>
+void update_policy(Policy& policy, const Setf& setf)
+{
+    policy.m_setf = setf.m_setf;
+}
+
+template <class Policy>
+void walk_policy(Policy& policy)
 {
     // Do nothing
 }
@@ -218,7 +248,7 @@ template <class Policy, class PType, class... PTypes>
 void walk_policy(Policy& policy, PType arg, PTypes...args) {
     update_policy(policy,arg);
     walk_policy(policy,args...);
-} 
+}
 
 
 template <typename... Pols>

--- a/include/clasp/clbind/policies.h
+++ b/include/clasp/clbind/policies.h
@@ -27,7 +27,6 @@ THE SOFTWARE.
 #ifndef clbind_policies_H
 #define clbind_policies_H
 
-
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/and.hpp>
 #include <boost/mpl/not.hpp>
@@ -49,130 +48,115 @@ const int return_value_policy_copy_ = 32710;
 // This should only be used for pass-by-reference parameters that the
 // function modifies
 // The first argument is <1>
-template <int N>
-struct outValue {};
+template <int N> struct outValue {};
 
 // Declare that a (pass-by-reference) parameter is a pure out value and
 // should not be passed in from Lisp
 // For functions the first argument is <1>
 
+template <typename...> struct pureOutsPack {};
 
-template <typename...>
-struct pureOutsPack {};
+template <int N> struct pureOutValue {};
 
+template <int N> struct testType {};
 
-template <int N>
-struct pureOutValue {};
+template <int N> struct adopt {};
 
-template <int N>
-struct testType {};
+template <typename Policies> struct is_policy_list { typedef boost::mpl::false_ type; };
 
-template <int N>
-struct adopt {};
-
-template <typename Policies>
-struct is_policy_list {
-  typedef boost::mpl::false_ type;
-};
-
-enum return_value_policy { reference = return_value_policy_reference_,
-                           copy = return_value_policy_copy_
-};
+enum return_value_policy { reference = return_value_policy_reference_, copy = return_value_policy_copy_ };
 
 struct Keyword {
-    std::string m_name;
-    std::string m_default;
-    Keyword(const std::string& val) : m_name(val), m_default("") {};
-    template <class DefaultType>
-    Keyword& operator=(DefaultType x) {
-        std::stringstream ss;
-        ss << x;
-        this->m_default = ss.str();
-        return *this;
+  std::string m_name;
+  std::string m_default;
+  Keyword(const std::string &val) : m_name(val), m_default(""){};
+  template <class DefaultType> Keyword &operator=(DefaultType x) {
+    std::stringstream ss;
+    ss << x;
+    this->m_default = ss.str();
+    return *this;
+  }
+  Keyword &operator=(const char *x) {
+    std::stringstream ss;
+    ss << "\"" << x << "\"";
+    this->m_default = ss.str();
+    return *this;
+  }
+  Keyword &operator=(bool x) {
+    std::stringstream ss;
+    if (x) {
+      this->m_default = "T";
+    } else {
+      this->m_default = "NIL";
     }
-    Keyword& operator=(const char* x) {
-        std::stringstream ss;
-        ss << "\"" << x << "\"";
-        this->m_default = ss.str();
-        return *this;
+    return *this;
+  }
+  std::string asString() const {
+    if (this->m_default == "") {
+      return this->m_name;
+    } else {
+      std::stringstream ss;
+      ss << "(" << this->m_name;
+      ss << " " << this->m_default << ")";
+      return ss.str();
     }
-    Keyword& operator=(bool x) {
-        std::stringstream ss;
-        if (x) {
-          this->m_default = "T";
-        } else {
-          this->m_default = "NIL";
-        }
-        return *this;
-    }
-    std::string asString() const {
-        if (this->m_default=="") {
-            return this->m_name;
-        } else {
-            std::stringstream ss;
-            ss << "(" << this->m_name;
-            ss << " " << this->m_default << ")";
-            return ss.str();
-        }
-    }
+  }
 };
 
 struct LambdaList {
   std::string m_lambda_list;
-  LambdaList(const std::string& val) : m_lambda_list(val) {};
+  LambdaList(const std::string &val) : m_lambda_list(val){};
 };
 
 struct DocString {
   std::string m_doc_string;
-  DocString(const std::string& val) : m_doc_string(val) {};
+  DocString(const std::string &val) : m_doc_string(val){};
 };
 
 struct AutoExport {
   bool m_auto_export;
-  AutoExport(bool val) : m_auto_export(val) {};
+  AutoExport(bool val) : m_auto_export(val){};
 };
 
 struct Setf {
   bool m_setf;
-  Setf(bool val) : m_setf(val) {};
+  Setf(bool val) : m_setf(val){};
 };
 
 inline AutoExport noAutoExport() { return AutoExport(false); }
 
 inline Setf setf() { return Setf(true); }
 
-
-template <class...PTypes>
-struct policies {
-    std::vector<Keyword> m_keywords;
-    std::string m_lambda_list;
-    std::string m_doc_string;
-    bool m_auto_export = true;
-    bool m_setf = false;
-    void describe() {
-        printf("%s:%d Descibing Policy\n", __FILE__, __LINE__ );
-        if (this->m_lambda_list!="") {
-            printf("lambda_list = %s\n", this->m_lambda_list.c_str());
-        } else {
-            printf("keyword_list = %s\n", this->keyword_list().c_str());
-        }
-        printf("Docstring = %s\n", this->m_doc_string.c_str());
+template <class... PTypes> struct policies {
+  std::vector<Keyword> m_keywords;
+  std::string m_lambda_list;
+  std::string m_doc_string;
+  bool m_auto_export = true;
+  bool m_setf = false;
+  void describe() {
+    printf("%s:%d Descibing Policy\n", __FILE__, __LINE__);
+    if (this->m_lambda_list != "") {
+      printf("lambda_list = %s\n", this->m_lambda_list.c_str());
+    } else {
+      printf("keyword_list = %s\n", this->keyword_list().c_str());
     }
-    std::string keywordList() const {
-      if (this->m_keywords.size()==0) {
-        return "";
-      }
-      std::stringstream ss;
-      ss << "(&key ";
-      for ( size_t i=0; i<m_keywords.size(); ++i) {
-        ss << m_keywords[i].asString() << " ";
-      }
-      ss << ")";
-      return ss.str();
+    printf("Docstring = %s\n", this->m_doc_string.c_str());
+  }
+  std::string keywordList() const {
+    if (this->m_keywords.size() == 0) {
+      return "";
     }
+    std::stringstream ss;
+    ss << "(&key ";
+    for (size_t i = 0; i < m_keywords.size(); ++i) {
+      ss << m_keywords[i].asString() << " ";
+    }
+    ss << ")";
+    return ss.str();
+  }
 
   std::string lambdaList() const {
-    if (this->m_lambda_list!="") {
+    if (this->m_lambda_list != "") {
       return this->m_lambda_list;
     } else {
       return this->keywordList();
@@ -184,91 +168,54 @@ struct policies {
   bool setf() const { return m_setf; };
 };
 
-template <class Policy, int N>
-void update_policy(Policy& policy, const adopt<N>& dummy)
-{
+template <class Policy, int N> void update_policy(Policy &policy, const adopt<N> &dummy) {
   // Do nothing - this is handled with types
 }
 
-template <class Policy, int N>
-void update_policy(Policy& policy, const outValue<N>& dummy)
-{
+template <class Policy, int N> void update_policy(Policy &policy, const outValue<N> &dummy) {
   // Do nothing - this is handled with types
 }
 
-template <class Policy, int N>
-void update_policy(Policy& policy, const pureOutValue<N>& dummy)
-{
+template <class Policy, int N> void update_policy(Policy &policy, const pureOutValue<N> &dummy) {
   // Do nothing - this is handled with types
 }
 
-template <class Policy>
-void update_policy(Policy& policy, const return_value_policy& dummy)
-{
+template <class Policy> void update_policy(Policy &policy, const return_value_policy &dummy) {
   // Do nothing - this is handled with types
 }
 
-template <class Policy>
-void update_policy(Policy& policy, const Keyword& keyword)
-{
-    policy.m_keywords.push_back(keyword);
+template <class Policy> void update_policy(Policy &policy, const Keyword &keyword) { policy.m_keywords.push_back(keyword); }
+
+template <class Policy> void update_policy(Policy &policy, const LambdaList &lambda_list) {
+  policy.m_lambda_list = lambda_list.m_lambda_list;
 }
 
-template <class Policy>
-void update_policy(Policy& policy, const LambdaList& lambda_list)
-{
-    policy.m_lambda_list = lambda_list.m_lambda_list;
+template <class Policy> void update_policy(Policy &policy, const DocString &doc_string) {
+  policy.m_doc_string = doc_string.m_doc_string;
 }
 
-template <class Policy>
-void update_policy(Policy& policy, const DocString& doc_string)
-{
-    policy.m_doc_string = doc_string.m_doc_string;
+template <class Policy> void update_policy(Policy &policy, const AutoExport &auto_export) {
+  policy.m_auto_export = auto_export.m_auto_export;
 }
 
-template <class Policy>
-void update_policy(Policy& policy, const AutoExport& auto_export)
-{
-    policy.m_auto_export = auto_export.m_auto_export;
+template <class Policy> void update_policy(Policy &policy, const Setf &setf) { policy.m_setf = setf.m_setf; }
+
+template <class Policy> void walk_policy(Policy &policy) {
+  // Do nothing
 }
 
-template <class Policy>
-void update_policy(Policy& policy, const Setf& setf)
-{
-    policy.m_setf = setf.m_setf;
+template <class Policy, class PType, class... PTypes> void walk_policy(Policy &policy, PType arg, PTypes... args) {
+  update_policy(policy, arg);
+  walk_policy(policy, args...);
 }
 
-template <class Policy>
-void walk_policy(Policy& policy)
-{
-    // Do nothing
-}
+template <typename... Pols> struct is_policy_list<policies<Pols...>> { typedef boost::mpl::true_ type; };
+}; // namespace clbind
 
-template <class Policy, class PType, class... PTypes>
-void walk_policy(Policy& policy, PType arg, PTypes...args) {
-    update_policy(policy,arg);
-    walk_policy(policy,args...);
-}
+inline clbind::LambdaList operator"" _ll(const char *arg, size_t len) { return clbind::LambdaList(std::string(arg, len)); }
 
+inline clbind::DocString operator"" _docstring(const char *arg, size_t len) { return clbind::DocString(std::string(arg, len)); }
 
-template <typename... Pols>
-struct is_policy_list<policies<Pols...>> {
-  typedef boost::mpl::true_ type;
-};
-};
-
-
-inline clbind::LambdaList operator "" _ll(const char* arg, size_t len) {
-  return clbind::LambdaList(std::string(arg,len));
-}
-
-inline clbind::DocString operator "" _docstring(const char* arg, size_t len) {
-  return clbind::DocString(std::string(arg,len));
-}
-
-inline clbind::Keyword operator "" _a(const char* arg, size_t len) {
-  return clbind::Keyword(std::string(arg,len));
-}
-
+inline clbind::Keyword operator"" _a(const char *arg, size_t len) { return clbind::Keyword(std::string(arg, len)); }
 
 #endif

--- a/include/clasp/core/core.h
+++ b/include/clasp/core/core.h
@@ -1003,11 +1003,6 @@ void lisp_defineSingleDispatchMethod(const clbind::BytecodeWrapper& dummy_specia
                                      std::set<int> pureOutIndices = std::set<int>());
 
 
-#if 0
-void lisp_defmacro(Symbol_sp name, const string &packageName,
-                     BuiltinClosure_sp, const string &arguments = "", const string &declarestring = "",
-                     const string &docstring = "");
-#endif
   typedef enum { symbol_function, symbol_function_setf, symbol_function_macro } SymbolFunctionEnum;
   void lisp_bytecode_defun(SymbolFunctionEnum kind,
                            int bytecodep,
@@ -1020,18 +1015,8 @@ void lisp_defmacro(Symbol_sp name, const string &packageName,
                            const string &sourceFile = "",
                            int lineNumber = 0,
                            int numberOfRequiredArguments = 0,
+                           bool autoExport = true,
                            const std::set<int> &skipIndices = std::set<int>() );
-
-  void lisp_defmethod(Symbol_sp gfSymbol, Function_sp, const string &arguments, const string &docstring);
-
-  void lisp_defsetfSingleDispatchMethod(LispPtr lisp, const string &name, Symbol_sp classSymbol,
-                                        Function_sp, const string &arguments = "", const string &declares = "", const string &docstring = "", bool autoExport = true);
-
-  void lisp_defsetf(const string &name, Symbol_sp classSymbol,
-                    Function_sp, const string &arguments = "", const string &docstring = "", bool autoExport = true);
-
-  
-  core::T_sp lisp_hiddenBinderLookup(Symbol_sp sym);
 
 //
 // You define what is being sent to the debug log using these constants

--- a/include/clasp/core/core.h
+++ b/include/clasp/core/core.h
@@ -26,7 +26,7 @@ THE SOFTWARE.
 /* -^- */
 
 /** @defgroup exports
-    @defgroup clasp 
+    @defgroup clasp
         @ingroup exports
  */
 
@@ -61,7 +61,7 @@ THE SOFTWARE.
 #ifdef DEBUG_RELEASE
 #define DONT_OPTIMIZE_WHEN_DEBUG_RELEASE __attribute__((optnone))
 #else
-#define DONT_OPTIMIZE_WHEN_DEBUG_RELEASE 
+#define DONT_OPTIMIZE_WHEN_DEBUG_RELEASE
 #endif
 #define DONT_OPTIMIZE_ALWAYS __attribute__((optnone))
 #define NEVER_OPTIMIZE __attribute__((optnone))
@@ -79,7 +79,6 @@ THE SOFTWARE.
 namespace std {
 class type_info;
 };
-
 
 //
 // USE_TAGGED_PTR_P0  determines whether a p0 pointer,  the most-derived-pointer is stored
@@ -117,7 +116,6 @@ class type_info;
 #define DO_DEBUG_MPS_RECURSIVE_ALLOCATIONS()
 #endif
 
-
 #define clasp_unlikely(x) __builtin_expect(!!(x), 0)
 #define clasp_likely(x) __builtin_expect(!!(x), 1)
 #define UNLIKELY(x) clasp_unlikely(x)
@@ -128,7 +126,6 @@ class type_info;
 #define LIKELY_if(x) if (LIKELY(x))
 
 typedef std::size_t class_id;
-
 
 /*! Configure architecture dependent types */
 #include <clasp/core/configure_clasp.h>
@@ -142,7 +139,7 @@ struct BytecodeWrapper {
 // Use bytecode wrappers for all exposed functions
 using DefaultWrapper = BytecodeWrapper;
 
-};
+}; // namespace clbind
 
 /*! Use old Conditions system baked into C++
   OLD_CONDITIONS = 1
@@ -204,15 +201,15 @@ using DefaultWrapper = BytecodeWrapper;
 #define CLOS 1
 
 #ifdef SOURCE_DEBUG
- #ifdef DEBUG_LEVEL_FULL //[
-  #define DEBUG_ON 1
-  #define CALLSTACK_ON 1
-  #define DEBUG_ASSERT 1
- #else                     //][
-  #ifdef DEBUG_LEVEL_SILENT //[
-   #define CALLSTACK_SILENT 1
-  #endif //]
- #endif //]
+#ifdef DEBUG_LEVEL_FULL //[
+#define DEBUG_ON 1
+#define CALLSTACK_ON 1
+#define DEBUG_ASSERT 1
+#else                     //][
+#ifdef DEBUG_LEVEL_SILENT //[
+#define CALLSTACK_SILENT 1
+#endif //]
+#endif //]
 #endif
 
 /*! Use this in initializeCandoPrimitives to define a function
@@ -283,23 +280,21 @@ struct size_t_pair {
 #include <serializerNode.fwd.h>
 #endif
 
-
 namespace core {
-  extern bool _ClassesAreInitialized;
-  typedef uint handleType;
-  const uint handleNumberFlag = (uint)(1 << 31);
-  const uint handleNumberMask = handleNumberFlag - 1;
-  const uint MaxHandle = handleNumberFlag - 1;
-  const uint IllegalHandle = MaxHandle;
-  const handleType EmptyStringHandle = 0;
-  const handleType UniqueIdHandle = 1;
+extern bool _ClassesAreInitialized;
+typedef uint handleType;
+const uint handleNumberFlag = (uint)(1 << 31);
+const uint handleNumberMask = handleNumberFlag - 1;
+const uint MaxHandle = handleNumberFlag - 1;
+const uint IllegalHandle = MaxHandle;
+const handleType EmptyStringHandle = 0;
+const handleType UniqueIdHandle = 1;
 
-};
+}; // namespace core
 
 /*! Associate a namespace name with a Package.
   This is scraped out of the code by "registerClasses.py"
 */
-
 
 #define UndefinedUnsignedInt UINT_MAX
 #define UNDEF_UINT UndefinedUnsignedInt
@@ -334,9 +329,6 @@ namespace core {
  */
 /*@}*/
 
-
-
-
 #include <string>
 #include <vector>
 #include <queue>
@@ -349,26 +341,19 @@ namespace core {
 
 using string = std::string;
 using type_info = std::type_info;
-template <typename X, typename Y>
-using map = std::map<X, Y>;
-template <typename X>
-using vector = std::vector<X>;
+template <typename X, typename Y> using map = std::map<X, Y>;
+template <typename X> using vector = std::vector<X>;
 using stringstream = std::stringstream;
-template <typename X, typename Y>
-using pair = std::pair<X, Y>;
-template <typename X>
-using list = std::list<X>;
-template <typename X, typename Y>
-using multimap = std::multimap<X, Y>;
-template <typename X>
-using set = std::set<X>;
-template <typename X>
-using deque = std::deque<X>;
+template <typename X, typename Y> using pair = std::pair<X, Y>;
+template <typename X> using list = std::list<X>;
+template <typename X, typename Y> using multimap = std::multimap<X, Y>;
+template <typename X> using set = std::set<X>;
+template <typename X> using deque = std::deque<X>;
 
-
-void maybe_register_symbol_using_dladdr(void* functionPointer, size_t size=sizeof(void*), const std::string& name="", size_t arityCode=0);
-void maybe_register_symbol_using_dladdr_ep(void* functionPointer, size_t size=sizeof(void*), const std::string& name="", size_t arityCode=0);
-
+void maybe_register_symbol_using_dladdr(void *functionPointer, size_t size = sizeof(void *), const std::string &name = "",
+                                        size_t arityCode = 0);
+void maybe_register_symbol_using_dladdr_ep(void *functionPointer, size_t size = sizeof(void *), const std::string &name = "",
+                                           size_t arityCode = 0);
 
 #ifdef WIN32
 #include <limits>
@@ -392,8 +377,6 @@ typedef long long int LongLongInt;
 #define LongLongMaxScale 4096 // was 256
 #define LongLongIntBoundary LongLongMax / LongLongMaxScale
 
-
-
 /* --------------------------------------------------
    --------------------------------------------------
 
@@ -409,10 +392,10 @@ typedef long long int LongLongInt;
   STATIC_ROOT_FRAME_BEGIN(StaticFrame,staticFrame);
 */
 #define STATIC_ROOT_FRAME_BEGIN(X) struct X : public gctools::HeapRoot
-#define STATIC_ROOT_FRAME_END(X, N) \
-  ;                                 \
-  static X *N = NULL;               \
-  if (!N)                           \
+#define STATIC_ROOT_FRAME_END(X, N)                                                                                                \
+  ;                                                                                                                                \
+  static X *N = NULL;                                                                                                              \
+  if (!N)                                                                                                                          \
     N = new X();
 
 void dbg_hook(const char *errorString);
@@ -436,48 +419,31 @@ class StackBoundClass {};
       contains absolutely no smart_ptrs or weak_ptrs either directly
       or indirectly - DON'T PUT ANY POINTERS IN THE DERIVED CLASS */
 class GCIgnoreClass {};
-};
+}; // namespace gctools
 
-namespace reg
-{
+namespace reg {
 
 struct null_type : public gctools::GCIgnoreClass {};
 class_id const unknown_class = (std::numeric_limits<class_id>::max)();
 class type_id {
 public:
-  type_id()
-    : id(&typeid(null_type)) {}
+  type_id() : id(&typeid(null_type)) {}
 
-  type_id(std::type_info const &id)
-    : id(&id) {}
+  type_id(std::type_info const &id) : id(&id) {}
 
-  bool operator!=(type_id const &other) const {
-    return *id != *other.id;
-  }
+  bool operator!=(type_id const &other) const { return *id != *other.id; }
 
-  bool operator==(type_id const &other) const {
-    return *id == *other.id;
-  }
+  bool operator==(type_id const &other) const { return *id == *other.id; }
 
-  bool operator<(type_id const &other) const {
-    return id->before(*other.id);
-  }
+  bool operator<(type_id const &other) const { return id->before(*other.id); }
 
-  bool operator<=(type_id const& other) const {
-    return id->before(*other.id)||(*id == *other.id);
-  }
-    
-  bool operator>=(type_id const& other) const {
-    return !id->before(*other.id);
-  }
+  bool operator<=(type_id const &other) const { return id->before(*other.id) || (*id == *other.id); }
 
-  bool operator>(type_id const& other) const {
-    return (*id!=*other.id)&&!id->before(*other.id);
-  }
+  bool operator>=(type_id const &other) const { return !id->before(*other.id); }
 
-  char const *name() const {
-    return id->name();
-  }
+  bool operator>(type_id const &other) const { return (*id != *other.id) && !id->before(*other.id); }
+
+  char const *name() const { return id->name(); }
 
   std::type_info const *get_type_info() const { return this->id; };
 
@@ -486,16 +452,10 @@ private:
 };
 
 class_id allocate_class_id(type_id const &cls);
-template <class T>
-struct registered_class {
-  static class_id const id;
-};
-template <class T>
-class_id const registered_class<T>::id = allocate_class_id(typeid(T));
-template <class T>
-struct registered_class<T const>
-  : registered_class<T> {};
-};
+template <class T> struct registered_class { static class_id const id; };
+template <class T> class_id const registered_class<T>::id = allocate_class_id(typeid(T));
+template <class T> struct registered_class<T const> : registered_class<T> {};
+}; // namespace reg
 
 /*! This function is provided by the main.cc file */
 std::string program_name();
@@ -509,37 +469,35 @@ class HashTableEqual_O;
 class SimpleVector_O;
 class SimpleVector_byte8_t_O;
 
+[[noreturn]] void lisp_error_sprintf(const char *file, int lineno, const char *function, const char *fmt, ...);
+[[noreturn]] void lisp_errorDereferencedNonPointer(core::T_O *objP);
+[[noreturn]] void lisp_errorBadCast(class_id toType, class_id fromType, core::T_O *objP);
+[[noreturn]] void lisp_errorBadCastStampWtag(size_t toStampWtag, core::T_O *objP);
+[[noreturn]] void lisp_errorBadCastFromT_O(class_id toType, core::T_O *objP);
+[[noreturn]] void lisp_errorBadCastToFixnum(class_id fromType, core::T_O *objP);
+[[noreturn]] void lisp_errorBadCastFromT_OToCons_O(core::T_O *objP);
+[[noreturn]] void lisp_errorBadCastFromSymbol_O(class_id toType, core::Symbol_O *objP);
+[[noreturn]] void lisp_errorUnexpectedType(class_id expectedTyp, class_id givenTyp, core::T_O *objP);
+[[noreturn]] void lisp_errorUnexpectedNil(class_id expectedTyp);
+[[noreturn]] void lisp_errorDereferencedNil();
+[[noreturn]] void lisp_error_no_stamp(void *obj);
+[[noreturn]] void lisp_errorDereferencedUnbound();
+[[noreturn]] void lisp_errorIllegalDereference(void *v);
+[[noreturn]] void lisp_errorExpectedList(core::T_O *objP);
 
-  [[noreturn]]void lisp_error_sprintf(const char* file, int lineno, const char* function, const char* fmt, ... );
-  [[noreturn]]void lisp_errorDereferencedNonPointer(core::T_O *objP);
-  [[noreturn]]void lisp_errorBadCast(class_id toType, class_id fromType, core::T_O *objP);
-  [[noreturn]]void lisp_errorBadCastStampWtag(size_t toStampWtag, core::T_O *objP);
-  [[noreturn]]void lisp_errorBadCastFromT_O(class_id toType, core::T_O *objP);
-  [[noreturn]]void lisp_errorBadCastToFixnum(class_id fromType, core::T_O *objP);
-  [[noreturn]]void lisp_errorBadCastFromT_OToCons_O(core::T_O *objP);
-  [[noreturn]]void lisp_errorBadCastFromSymbol_O(class_id toType, core::Symbol_O *objP);
-  [[noreturn]]void lisp_errorUnexpectedType(class_id expectedTyp, class_id givenTyp, core::T_O *objP);
-  [[noreturn]]void lisp_errorUnexpectedNil(class_id expectedTyp);
-  [[noreturn]]void lisp_errorDereferencedNil();
-  [[noreturn]]void lisp_error_no_stamp(void* obj);
-  [[noreturn]]void lisp_errorDereferencedUnbound();
-  [[noreturn]]void lisp_errorIllegalDereference(void *v);
-  [[noreturn]]void lisp_errorExpectedList(core::T_O* objP);
-
-  template <typename To, typename From, typename ObjPtrType>
-    [[noreturn]]void lisp_errorCast(ObjPtrType objP) {
-    class_id to_typ = reg::registered_class<To>::id;
-    class_id from_typ = reg::registered_class<From>::id;
-    lisp_errorBadCast(to_typ, from_typ, reinterpret_cast<core::T_O *>(objP));
-    __builtin_unreachable();
-  }
-};
+template <typename To, typename From, typename ObjPtrType> [[noreturn]] void lisp_errorCast(ObjPtrType objP) {
+  class_id to_typ = reg::registered_class<To>::id;
+  class_id from_typ = reg::registered_class<From>::id;
+  lisp_errorBadCast(to_typ, from_typ, reinterpret_cast<core::T_O *>(objP));
+  __builtin_unreachable();
+}
+}; // namespace core
 
 namespace core {
-  class MultipleValues;
-  MultipleValues &lisp_multipleValues();
+class MultipleValues;
+MultipleValues &lisp_multipleValues();
 //  MultipleValues &lisp_callArgs();
-};
+}; // namespace core
 
 extern "C" {
 
@@ -549,37 +507,36 @@ void drag_cxx_calls();
 void drag_interpret_dtree();
 void drag_cons_allocation();
 void drag_general_allocation();
-
 };
 
 #ifdef DEBUG_DRAG_NATIVE_CALLS
-# define DO_DRAG_NATIVE_CALLS() drag_native_calls()
+#define DO_DRAG_NATIVE_CALLS() drag_native_calls()
 #else
-# define DO_DRAG_NATIVE_CALLS()
+#define DO_DRAG_NATIVE_CALLS()
 #endif
 
 #ifdef DEBUG_DRAG_CXX_CALLS
-# define DO_DRAG_CXX_CALLS() drag_cxx_calls()
+#define DO_DRAG_CXX_CALLS() drag_cxx_calls()
 #else
-# define DO_DRAG_CXX_CALLS()
+#define DO_DRAG_CXX_CALLS()
 #endif
 
 #ifdef DEBUG_DRAG_INTERPRET_DTREE
-# define DO_DRAG_INTERPRET_DTREE() drag_interpret_dtree()
+#define DO_DRAG_INTERPRET_DTREE() drag_interpret_dtree()
 #else
-# define DO_DRAG_INTERPRET_DTREE()
+#define DO_DRAG_INTERPRET_DTREE()
 #endif
 
 #ifdef DEBUG_DRAG_CONS_ALLOCATION
-# define DO_DRAG_CONS_ALLOCATION() drag_cons_allocation()
+#define DO_DRAG_CONS_ALLOCATION() drag_cons_allocation()
 #else
-# define DO_DRAG_CONS_ALLOCATION()
+#define DO_DRAG_CONS_ALLOCATION()
 #endif
 
 #ifdef DEBUG_DRAG_GENERAL_ALLOCATION
-# define DO_DRAG_GENERAL_ALLOCATION() drag_general_allocation()
+#define DO_DRAG_GENERAL_ALLOCATION() drag_general_allocation()
 #else
-# define DO_DRAG_GENERAL_ALLOCATION()
+#define DO_DRAG_GENERAL_ALLOCATION()
 #endif
 
 extern void clasp_mps_debug_allocation(const char *poolName, void *base, void *objAddr, int size, int kind);
@@ -610,13 +567,10 @@ extern void clasp_mps_debug_container(const char *ctype, const char *name, int s
 
 #include <clasp/gctools/multiple_value_pointers.h>
 
-
 namespace gctools {
-  void register_thread(mp::Process_sp process, void* stackTop);
-  void unregister_thread(mp::Process_sp process);
-};
-   
-
+void register_thread(mp::Process_sp process, void *stackTop);
+void unregister_thread(mp::Process_sp process);
+}; // namespace gctools
 
 #if 0
 namespace dummy_namespace {
@@ -650,7 +604,6 @@ namespace dummy_namespace {
 };
 #endif
 
-
 namespace core {
 class Instance_O;
 typedef gc::smart_ptr<Instance_O> Instance_sp;
@@ -662,21 +615,18 @@ typedef gc::smart_ptr<FuncallableInstance_O> FuncallableInstance_sp;
 #define LCC_PROTOTYPES
 #include <clasp/core/lispCallingConvention.h>
 #undef LCC_PROTOTYPES
-};
+}; // namespace core
 
 namespace core {
 core::T_sp lisp_true();
 uint lisp_hash(uintptr_t v);
-};
+}; // namespace core
 
 #include <clasp/gctools/gc_interface.h>
 
-
 class RootClass;
 
-
-#define EXTERN_SYMBOL(sym) extern core::Symbol_sp& _sym_##sym;
-
+#define EXTERN_SYMBOL(sym) extern core::Symbol_sp &_sym_##sym;
 
 namespace core {
 
@@ -710,12 +660,8 @@ string trimWhiteSpace(const string &inp);
 string stripCharacters(const string &inp, const string &strip);
 
 vector<string> split(const string &str, const string &delim = " \t");
-void tokenize(const string &str,
-              vector<string> &tokens,
-              const string &delimiters = " ");
-void queueSplitString(const string &str,
-                      std::queue<string> &tokens,
-                      const string &delimiters = " ");
+void tokenize(const string &str, vector<string> &tokens, const string &delimiters = " ");
+void queueSplitString(const string &str, std::queue<string> &tokens, const string &delimiters = " ");
 
 string stringUpper(const string &s);
 string stringUpper(const char *s);
@@ -723,8 +669,7 @@ string stringUpper(const char *s);
 string concatenateVectorStrings(VectorStrings strs);
 void appendVectorStrings(VectorStrings &app, VectorStrings strs);
 
-bool wildcmp(string sWild,
-             string sRegular);
+bool wildcmp(string sWild, string sRegular);
 
 /*
  * Documentation macros
@@ -743,10 +688,10 @@ typedef unsigned int AtomFlags; // Minimum 32 bits
 
 #ifndef MAX
 #define MAX(x, y) ((x) < (y) ? (y) : (x))
-#endif //MAX
+#endif // MAX
 #ifndef MIN
 #define MIN(x, y) ((x) > (y) ? (y) : (x))
-#endif //MIN
+#endif // MIN
 
 typedef unsigned int AtomHandle; // Implement the AtomHandle as an index into
 // a vector of atoms that maintains a constant
@@ -768,7 +713,7 @@ typedef vector<AtomHandle> VectorAtomHandle;
 // # p r a g m a warning( disable : 4290 )
 #endif
 
-};
+}; // namespace core
 
 /*! A type for an array of arguments */
 typedef core::T_O **ArgArray;
@@ -781,39 +726,38 @@ typedef gctools::tagged_pointer<Lisp> LispPtr;
 typedef void (*MakePackageCallback)(string const &packageName, LispPtr);
 typedef void (*ExportSymbolCallback)(Symbol_sp symbol, LispPtr);
 
- typedef void (*module_startup_function_type)(gctools::Tagged);
- typedef void (*module_shutdown_function_type)();
+typedef void (*module_startup_function_type)(gctools::Tagged);
+typedef void (*module_shutdown_function_type)();
 
 /* A few symbols associated with error handling that everything needs */
-extern Symbol_sp& _sym_error;
-extern Symbol_sp& _sym_setThrowPosition;
-extern Symbol_sp& _sym_makeCondition;
-extern Symbol_sp& _sym_simpleError;
+extern Symbol_sp &_sym_error;
+extern Symbol_sp &_sym_setThrowPosition;
+extern Symbol_sp &_sym_makeCondition;
+extern Symbol_sp &_sym_simpleError;
 /*! Search for multiple occurances of a string and replace it
  * \param str The string that is modified
  * \param search The string to search for
  * \param replace The string to replace with
  */
-string searchAndReplaceString(const string &str, const string &search, const string &replace );
+string searchAndReplaceString(const string &str, const string &search, const string &replace);
 
 /* The CallingConvention for Common Lisp functions is a pointer to where the multiple value result
-   should be written, the closed over environment for the function, the number of args, three explicit args that will pass in registers (or be NULL)
-   and a varargs list */
+   should be written, the closed over environment for the function, the number of args, three explicit args that will pass in
+   registers (or be NULL) and a varargs list */
 typedef void (*LispCallingConventionPtr)(T_mv *result, int nargs, T_sp arg1, T_sp arg2, T_sp arg3, va_list rest);
-}
+} // namespace core
 
 #include <clasp/core/core_globals.h>
 
 namespace kw {
-extern core::Symbol_sp& _sym_format_control;
-extern core::Symbol_sp& _sym_format_arguments;
-};
+extern core::Symbol_sp &_sym_format_control;
+extern core::Symbol_sp &_sym_format_arguments;
+}; // namespace kw
 
 // Can I get rid of this?
 #define IS_SYMBOL_DEFINED(x) (x)
 #define IS_SYMBOL_UNDEFINED(x) (!x)
 #define UNDEFINED_SYMBOL (unbound<core::Symbol_O>())
-
 
 //
 //
@@ -823,7 +767,7 @@ namespace core {
 /*! Fix lambda lists for methods.
     It converts ! in the string to the class symbol.
  */
-extern std::string fix_method_lambda(core::Symbol_sp class_symbol, const string& lambda );
+extern std::string fix_method_lambda(core::Symbol_sp class_symbol, const string &lambda);
 
 /*! Create the class hierarchy
  */
@@ -845,7 +789,7 @@ extern void initializePythonScript();
 class Cons_O;
 typedef gctools::smart_ptr<Cons_O> Cons_sp;
 
- class General_O;
+class General_O;
 typedef gctools::smart_ptr<General_O> General_sp;
 
 class Symbol_O;
@@ -858,165 +802,154 @@ class SimpleVector_O;
 typedef gctools::smart_ptr<SimpleVector_O> SimpleVector_sp;
 
 class Function_O;
- typedef gctools::smart_ptr<Function_O> Function_sp;
- class SimpleFun_O;
- typedef gctools::smart_ptr<SimpleFun_O> SimpleFun_sp;
- class CodeSimpleFun_O;
- typedef gctools::smart_ptr<CodeSimpleFun_O> CodeSimpleFun_sp; 
+typedef gctools::smart_ptr<Function_O> Function_sp;
+class SimpleFun_O;
+typedef gctools::smart_ptr<SimpleFun_O> SimpleFun_sp;
+class CodeSimpleFun_O;
+typedef gctools::smart_ptr<CodeSimpleFun_O> CodeSimpleFun_sp;
 
- class GlobalSimpleFunBase_O;
- typedef gctools::smart_ptr<GlobalSimpleFunBase_O> GlobalSimpleFunBase_sp;
+class GlobalSimpleFunBase_O;
+typedef gctools::smart_ptr<GlobalSimpleFunBase_O> GlobalSimpleFunBase_sp;
 
 class SymbolToEnumConverter_O;
 typedef gctools::smart_ptr<SymbolToEnumConverter_O> SymbolToEnumConverter_sp;
-}
+} // namespace core
 
 namespace gctools {
-  class Layout_code;
-  // Defined in clasp/src/gctools/gc_interface.cc
-  extern Layout_code* get_stamp_layout_codes();
-};
+class Layout_code;
+// Defined in clasp/src/gctools/gc_interface.cc
+extern Layout_code *get_stamp_layout_codes();
+}; // namespace gctools
 
 #if defined(USE_BOEHM) || defined(USE_MMTK)
-# define FRIEND_GC_SCANNER(nscl) friend gctools::Layout_code* gctools::get_stamp_layout_codes();
+#define FRIEND_GC_SCANNER(nscl) friend gctools::Layout_code *gctools::get_stamp_layout_codes();
 #elif defined(USE_MPS)
-# ifdef RUNNING_PRECISEPREP
-#  define FRIEND_GC_SCANNER(nscl)
-# else
-//#define FRIEND_GC_SCANNER(theclass) friend GC_RESULT gctools::obj_scan_helper<theclass>(mps_ss_t _ss, mps_word_t _mps_zs, mps_word_t _mps_w, mps_word_t & _mps_ufs, mps_word_t _mps_wt, mps_addr_t & client);
-#  define FRIEND_GC_SCANNER(dummy) friend gctools::Layout_code* gctools::get_stamp_layout_codes();
-# endif
+#ifdef RUNNING_PRECISEPREP
+#define FRIEND_GC_SCANNER(nscl)
+#else
+//#define FRIEND_GC_SCANNER(theclass) friend GC_RESULT gctools::obj_scan_helper<theclass>(mps_ss_t _ss, mps_word_t _mps_zs,
+//mps_word_t _mps_w, mps_word_t & _mps_ufs, mps_word_t _mps_wt, mps_addr_t & client);
+#define FRIEND_GC_SCANNER(dummy) friend gctools::Layout_code *gctools::get_stamp_layout_codes();
 #endif
-
+#endif
 
 namespace core {
 
 #define _NEW_(x) (new x)
 
-  class DebugStream;
+class DebugStream;
 
 /* Callbacks that initialize the Lisp environment have this structure*/
 
-  typedef void (*InitializationCallback)(LispPtr);
+typedef void (*InitializationCallback)(LispPtr);
 
-  [[noreturn]]void errorFormatted(const char *errorString);
-  [[noreturn]]void errorFormatted(const string &msg);
+[[noreturn]] void errorFormatted(const char *errorString);
+[[noreturn]] void errorFormatted(const string &msg);
 
 //
 //  Lisp class access functions for when we only have a forward
 //  definition for the Lisp class and for any other object
 //
 
-//extern "C" string _safe_rep_(core::T_sp obj);
-  string _rep_(T_sp obj);
+// extern "C" string _safe_rep_(core::T_sp obj);
+string _rep_(T_sp obj);
 /*! Convert underscores to "-" and "STAR" to "*" and "AMP" to "&"
       to convert a C++ name to a lisp symbol */
-  string lispify_symbol_name(string const &name);
-  string magic_name(const string& name, const string& optional_package="");
-  void colon_split(const string& name, string& package_part, string& symbol_part);
- 
-  Symbol_sp lispify_intern_keyword(string const &name);
+string lispify_symbol_name(string const &name);
+string magic_name(const string &name, const string &optional_package = "");
+void colon_split(const string &name, string &package_part, string &symbol_part);
+
+Symbol_sp lispify_intern_keyword(string const &name);
 //    Symbol_sp lispify_intern2(string const& name, string const& packageName);
 // lisp_lispifyAndInternWithPackageNameIfNotGiven
-  Symbol_sp lispify_intern(const string &name, const string &packageName = "", bool exportSymbol = true);
+Symbol_sp lispify_intern(const string &name, const string &packageName = "", bool exportSymbol = true);
 //    Symbol_sp lispify_intern_export(string const& name, string const& packageName);
-  Symbol_sp lisp_upcase_intern(string const &name, string const &packageName);
-  Symbol_sp lisp_upcase_intern_export(string const &name, string const &packageName);
-  void* lisp_to_void_ptr(T_sp o);
-  T_sp lisp_from_void_ptr(void* p);
+Symbol_sp lisp_upcase_intern(string const &name, string const &packageName);
+Symbol_sp lisp_upcase_intern_export(string const &name, string const &packageName);
+void *lisp_to_void_ptr(T_sp o);
+T_sp lisp_from_void_ptr(void *p);
 uint64_t lisp_nameword(T_sp name);
- 
-  List_sp lisp_copy_default_special_bindings();
+
+List_sp lisp_copy_default_special_bindings();
 /*! Write characters to the stream */
 #if 0
   gc::GCStack &lisp_threadLocalStack();
 #endif
 
-  LispPtr lisp_fromObject(T_sp obj);
-  string lisp_currentPackageName();
-  string lisp_packageName(T_sp package);
-  string lisp_classNameAsString(Instance_sp c);
-  void lisp_throwUnexpectedType(T_sp offendingObject, Symbol_sp expectedTypeId);
-  core::T_sp lisp_false();
+LispPtr lisp_fromObject(T_sp obj);
+string lisp_currentPackageName();
+string lisp_packageName(T_sp package);
+string lisp_classNameAsString(Instance_sp c);
+void lisp_throwUnexpectedType(T_sp offendingObject, Symbol_sp expectedTypeId);
+core::T_sp lisp_false();
 //  T_sp lisp_vaslist_toCons(vaslist vargs);
-//bool lisp_fixnumP(core::T_sp obj);
-//gctools::Fixnum lisp_asFixnum(core::T_sp obj);
+// bool lisp_fixnumP(core::T_sp obj);
+// gctools::Fixnum lisp_asFixnum(core::T_sp obj);
 /*! Create a SourcePosInfo object for a C++ function */
-  SourcePosInfo_sp lisp_createSourcePosInfo(const string &sourceFile, size_t filePos, int lineno);
+SourcePosInfo_sp lisp_createSourcePosInfo(const string &sourceFile, size_t filePos, int lineno);
 
-  T_sp lisp_lookup_reader_patch(T_sp patches, T_sp key, bool &found);
-//bool lisp_characterP(core::T_sp obj);
-  bool lisp_BuiltInClassesInitialized();
-  Instance_sp lisp_built_in_class();
-  Instance_sp  lisp_standard_class();
-  Instance_sp  lisp_clbind_cxx_class();
-  Instance_sp  lisp_derivable_cxx_class();
-  void lisp_pushClassSymbolOntoSTARallCxxClassesSTAR(Symbol_sp classSymbol);
-  void lisp_defparameter(Symbol_sp sym, T_sp val);
-  T_sp lisp_symbolValue(Symbol_sp sym);
-  string symbol_symbolName(Symbol_sp);
-  string symbol_packageName(Symbol_sp);
-  Symbol_sp lisp_symbolNil();
-  bool lisp_boundp(Symbol_sp s);
-  T_sp lisp_adjust_array(T_sp array, T_sp new_size, T_sp fill_pointer);
-  [[noreturn]]void lisp_errorCannotAllocateInstanceWithMissingDefaultConstructor(T_sp theClassSymbol);
-  T_sp lisp_boot_findClassBySymbolOrNil(Symbol_sp sym);
-  void lisp_addClassSymbol(Symbol_sp classSymbol, gctools::smart_ptr<Creator_O> cb, Symbol_sp baseClassSymbol1); //, Symbol_sp baseClassSymbol2 = UNDEFINED_SYMBOL, Symbol_sp baseClassSymbol3 = UNDEFINED_SYMBOL);
-  void lisp_addClass(Symbol_sp classSymbol);
-//void lisp_addClassAndInitialize(Symbol_sp classSymbol, gctools::smart_ptr<Creator> cb, Symbol_sp baseClassSymbol1, Symbol_sp baseClassSymbol2 = UNDEFINED_SYMBOL, Symbol_sp baseClassSymbol3 = UNDEFINED_SYMBOL);
-  void lisp_throwIfBuiltInClassesNotInitialized();
-  Instance_sp lisp_classFromClassSymbol(Symbol_sp classSymbol);
-  Instance_sp lisp_instance_class(T_sp obj);
-  Instance_sp lisp_static_class(T_sp obj);
-  Function_sp lisp_symbolFunction(Symbol_sp sym);
-  string lisp_symbolNameAsString(Symbol_sp sym);
-  T_sp lisp_createStr(const string &str);
-  T_sp lisp_createFixnum(int num);
-  T_sp lisp_createList(T_sp a1);
-  T_sp lisp_createList(T_sp a1, T_sp a2);
-  T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3);
-  T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4);
-  T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5);
-  T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5, T_sp a6);
-  T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5, T_sp a6, T_sp a7);
-  T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5, T_sp a6, T_sp a7, T_sp a8);
+T_sp lisp_lookup_reader_patch(T_sp patches, T_sp key, bool &found);
+// bool lisp_characterP(core::T_sp obj);
+bool lisp_BuiltInClassesInitialized();
+Instance_sp lisp_built_in_class();
+Instance_sp lisp_standard_class();
+Instance_sp lisp_clbind_cxx_class();
+Instance_sp lisp_derivable_cxx_class();
+void lisp_pushClassSymbolOntoSTARallCxxClassesSTAR(Symbol_sp classSymbol);
+void lisp_defparameter(Symbol_sp sym, T_sp val);
+T_sp lisp_symbolValue(Symbol_sp sym);
+string symbol_symbolName(Symbol_sp);
+string symbol_packageName(Symbol_sp);
+Symbol_sp lisp_symbolNil();
+bool lisp_boundp(Symbol_sp s);
+T_sp lisp_adjust_array(T_sp array, T_sp new_size, T_sp fill_pointer);
+[[noreturn]] void lisp_errorCannotAllocateInstanceWithMissingDefaultConstructor(T_sp theClassSymbol);
+T_sp lisp_boot_findClassBySymbolOrNil(Symbol_sp sym);
+void lisp_addClassSymbol(
+    Symbol_sp classSymbol, gctools::smart_ptr<Creator_O> cb,
+    Symbol_sp baseClassSymbol1); //, Symbol_sp baseClassSymbol2 = UNDEFINED_SYMBOL, Symbol_sp baseClassSymbol3 = UNDEFINED_SYMBOL);
+void lisp_addClass(Symbol_sp classSymbol);
+// void lisp_addClassAndInitialize(Symbol_sp classSymbol, gctools::smart_ptr<Creator> cb, Symbol_sp baseClassSymbol1, Symbol_sp
+// baseClassSymbol2 = UNDEFINED_SYMBOL, Symbol_sp baseClassSymbol3 = UNDEFINED_SYMBOL);
+void lisp_throwIfBuiltInClassesNotInitialized();
+Instance_sp lisp_classFromClassSymbol(Symbol_sp classSymbol);
+Instance_sp lisp_instance_class(T_sp obj);
+Instance_sp lisp_static_class(T_sp obj);
+Function_sp lisp_symbolFunction(Symbol_sp sym);
+string lisp_symbolNameAsString(Symbol_sp sym);
+T_sp lisp_createStr(const string &str);
+T_sp lisp_createFixnum(int num);
+T_sp lisp_createList(T_sp a1);
+T_sp lisp_createList(T_sp a1, T_sp a2);
+T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3);
+T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4);
+T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5);
+T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5, T_sp a6);
+T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5, T_sp a6, T_sp a7);
+T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5, T_sp a6, T_sp a7, T_sp a8);
 
 //    void lisp_setGlobalInt(const string& package, const string& n, uint val );
 //    Symbol_sp lisp_allocate_packageless_sid(string const& n);
-  Symbol_sp lisp_getClassSymbolForClassName(const string &n);
-  string lisp_convertCNameToLispName(string const &cname, bool convertUnderscoreToDash = true);
-List_sp lisp_parse_arguments(const string &packageName, const string &args, int numberOfRequiredArguments=0, const std::set<int> skip_indices = std::set<int>() );
-List_sp lisp_lexical_variable_names(List_sp lambda_list, bool& trivial_wrapper);
-  List_sp lisp_parse_declares(const string &packageName, const string &declarestring);
+Symbol_sp lisp_getClassSymbolForClassName(const string &n);
+string lisp_convertCNameToLispName(string const &cname, bool convertUnderscoreToDash = true);
+List_sp lisp_parse_arguments(const string &packageName, const string &args, int numberOfRequiredArguments = 0,
+                             const std::set<int> skip_indices = std::set<int>());
+List_sp lisp_lexical_variable_names(List_sp lambda_list, bool &trivial_wrapper);
+List_sp lisp_parse_declares(const string &packageName, const string &declarestring);
 
-void lisp_defineSingleDispatchMethod(const clbind::BytecodeWrapper& dummy_specializer,
-                                     T_sp name,
-                                     Symbol_sp classSymbol,
-                                     GlobalSimpleFunBase_sp entry,
-                                     size_t TemplateDispatchOn = 0,
-                                     bool useTemplateDispatchOn = false,
-                                     const string &lambda_list = "",
-                                     const string &declares = "",
-                                     const string &docstring = "",
-                                     bool autoExport = true,
-                                     int number_of_required_arguments = -1,
-                                     std::set<int> pureOutIndices = std::set<int>());
+void lisp_defineSingleDispatchMethod(const clbind::BytecodeWrapper &dummy_specializer, T_sp name, Symbol_sp classSymbol,
+                                     GlobalSimpleFunBase_sp entry, size_t TemplateDispatchOn = 0,
+                                     bool useTemplateDispatchOn = false, const string &lambda_list = "",
+                                     const string &declares = "", const string &docstring = "", bool autoExport = true,
+                                     int number_of_required_arguments = -1, std::set<int> pureOutIndices = std::set<int>());
 
+typedef enum { symbol_function, symbol_function_setf, symbol_function_macro } SymbolFunctionEnum;
 
-  typedef enum { symbol_function, symbol_function_setf, symbol_function_macro } SymbolFunctionEnum;
-  void lisp_bytecode_defun(SymbolFunctionEnum kind,
-                           int bytecodep,
-                           Symbol_sp sym,
-                           const string &packageName,
-                           GlobalSimpleFunBase_sp fc,
-                           const string& arguments = "",
-                           const string& declares = "",
-                           const string &docstring = "",
-                           const string &sourceFile = "",
-                           int lineNumber = 0,
-                           int numberOfRequiredArguments = 0,
-                           bool autoExport = true,
-                           const std::set<int> &skipIndices = std::set<int>() );
+void lisp_bytecode_defun(SymbolFunctionEnum kind, int bytecodep, Symbol_sp sym, const string &packageName,
+                         GlobalSimpleFunBase_sp fc, const string &arguments = "", const string &declares = "",
+                         const string &docstring = "", const string &sourceFile = "", int lineNumber = 0,
+                         int numberOfRequiredArguments = 0, bool autoExport = true,
+                         const std::set<int> &skipIndices = std::set<int>());
 
 //
 // You define what is being sent to the debug log using these constants
@@ -1055,36 +988,35 @@ void lisp_defineSingleDispatchMethod(const clbind::BytecodeWrapper& dummy_specia
 #define DEBUG_COMPILED_LISP_CATCH 0x000B0000
 #define DEBUG_COMPILED_LISP_UNWIND_PROTECT 0x000C0000
 
-  bool lisp_debugIsOn(const char *fileName, uint debugFlag = DEBUG_CPP_FUNCTION);
+bool lisp_debugIsOn(const char *fileName, uint debugFlag = DEBUG_CPP_FUNCTION);
 
-  DebugStream *lisp_debugLog();
+DebugStream *lisp_debugLog();
 /*! Return a string representation of the object */
-  string lisp_rep(T_sp obj);
-  uint32_t lisp_badge(T_sp obj);
-  uint32_t lisp_general_badge(General_sp obj);
-  Symbol_sp lisp_internKeyword(const string &name);
-  Symbol_sp lisp_intern(const string &name);
-  Symbol_sp lisp_intern(const string &symbolName, const string &packageName);
-  T_sp lisp_ComplexVector_TFromMultipleValues(T_mv values);
-  string symbol_fullName(Symbol_sp s);
-  void lisp_logException(const char *file, const char *fn, int line, const char *structure, T_sp condition);
-  void lisp_extendSymbolToEnumConverter(SymbolToEnumConverter_sp conv, Symbol_sp const &name, Symbol_sp const &archiveName, int value);
+string lisp_rep(T_sp obj);
+uint32_t lisp_badge(T_sp obj);
+uint32_t lisp_general_badge(General_sp obj);
+Symbol_sp lisp_internKeyword(const string &name);
+Symbol_sp lisp_intern(const string &name);
+Symbol_sp lisp_intern(const string &symbolName, const string &packageName);
+T_sp lisp_ComplexVector_TFromMultipleValues(T_mv values);
+string symbol_fullName(Symbol_sp s);
+void lisp_logException(const char *file, const char *fn, int line, const char *structure, T_sp condition);
+void lisp_extendSymbolToEnumConverter(SymbolToEnumConverter_sp conv, Symbol_sp const &name, Symbol_sp const &archiveName,
+                                      int value);
 /*! Return the index of the top of the stack */
-  size_t lisp_pushCatchThrowException(T_sp throwTag, T_sp value);
-  int lisp_lookupEnumForSymbol(Symbol_sp predefSymId, T_sp symbol);
-  core::Symbol_sp lisp_lookupSymbolForEnum(Symbol_sp predefSymId, int enumVal);
-};
+size_t lisp_pushCatchThrowException(T_sp throwTag, T_sp value);
+int lisp_lookupEnumForSymbol(Symbol_sp predefSymId, T_sp symbol);
+core::Symbol_sp lisp_lookupSymbolForEnum(Symbol_sp predefSymId, int enumVal);
+}; // namespace core
 
 #include <clasp/gctools/interrupt.h>
 #include <clasp/gctools/threadlocal.h>
 #include <clasp/core/exceptions.h>
 
-
 namespace kw {
-extern core::Symbol_sp& _sym_function;
-extern core::Symbol_sp& _sym_macro;
-};
-
+extern core::Symbol_sp &_sym_function;
+extern core::Symbol_sp &_sym_macro;
+}; // namespace kw
 
 namespace core {
 
@@ -1110,13 +1042,13 @@ typedef void (*PrintvFlushCallback)();
 
 const char *trimSourceFilePathName(const char *fullPathName);
 
-};
+}; // namespace core
 
 namespace llvm_interface {
 
 typedef void (*llvmAddSymbolCallbackType)(const core::Symbol_sp &sym);
 extern llvmAddSymbolCallbackType addSymbol;
-}
+} // namespace llvm_interface
 
 #include <clasp/core/clasp_gmpxx.h>
 
@@ -1124,16 +1056,14 @@ namespace reg {
 
 void lisp_associateClassIdWithClassSymbol(class_id cid, core::Symbol_sp sym);
 
-template <class T>
-void lisp_registerClassSymbol(core::Symbol_sp sym) {
+template <class T> void lisp_registerClassSymbol(core::Symbol_sp sym) {
   class_id cid = registered_class<T>::id;
   lisp_associateClassIdWithClassSymbol(cid, sym);
 }
 
 core::Symbol_sp lisp_classSymbolFromClassId(class_id cid);
 
-template <class T>
-core::Symbol_sp lisp_classSymbol() {
+template <class T> core::Symbol_sp lisp_classSymbol() {
   class_id cid = registered_class<T>::id;
   core::Symbol_sp sym = lisp_classSymbolFromClassId(cid); //_lisp->classSymbolsHolder()[cid];
   if (sym.nilp()) {
@@ -1143,7 +1073,7 @@ core::Symbol_sp lisp_classSymbol() {
   }
   return sym;
 }
-};
+}; // namespace reg
 #define KERNEL_NAME "kernel"
 
 #define clasp_disable_interrupts()
@@ -1153,7 +1083,6 @@ core::Symbol_sp lisp_classSymbol() {
 #include <dmalloc.h>
 #endif
 
-
 namespace core {
 struct cl_env {};
 typedef cl_env *cl_env_ptr;
@@ -1161,15 +1090,15 @@ typedef cl_env *cl_env_ptr;
 inline cl_env_ptr clasp_process_env() {
   return NULL;
 #if 0
-# ifdef ECL_WINDOWS_THREADS
+#ifdef ECL_WINDOWS_THREADS
   return TlsGetValue(cl_env_key);
-# else
+#else
   struct cl_env_struct *rv = pthread_getspecific(cl_env_key);
   if (rv)
     return rv;
   ecl_thread_internal_error("pthread_getspecific() failed.");
   return NULL;
-# endif
+#endif
 #endif
 };
 
@@ -1177,15 +1106,13 @@ inline void clasp_disable_interrupts_env(const cl_env_ptr){};
 inline void clasp_enable_interrupts_env(const cl_env_ptr){};
 //    inline void clasp_disable_interrupts() {};
 //    inline void clasp_enable_interrupts() {};
-};
-
+}; // namespace core
 
 namespace core {
-  void core__mangledSymbols(T_sp stream_designator);
+void core__mangledSymbols(T_sp stream_designator);
 };
 
-
-extern void* _ZTVN4core6LispE;
+extern void *_ZTVN4core6LispE;
 
 #define CLASP_DEFAULT_CTOR
 

--- a/include/clasp/gctools/containers.h
+++ b/include/clasp/gctools/containers.h
@@ -4,14 +4,14 @@
 
 /*
 Copyright (c) 2014, Christian E. Schafmeister
- 
+
 CLASP is free software; you can redistribute it and/or
 modify it under the terms of the GNU Library General Public
 License as published by the Free Software Foundation; either
 version 2 of the License, or (at your option) any later version.
- 
+
 See directory 'clasp/licenses' for full details.
- 
+
 The above copyright notice and this permission notice shall be included in
 all copies or substantial portions of the Software.
 
@@ -33,7 +33,7 @@ namespace gctools {
 class GCContainer {
 private:
 };
-};
+}; // namespace gctools
 
 #include <clasp/gctools/gcvector.h>
 #include <clasp/gctools/gcSmallMap.h>
@@ -44,8 +44,7 @@ private:
 
 namespace gctools {
 
-template <class Vec>
-class Vec0_impl {
+template <class Vec> class Vec0_impl {
 #if defined(USE_MPS) && !defined(RUNNING_PRECISEPREP)
   friend GC_RESULT(::obj_scan)(GC_SCAN_STATE_TYPE ss, GC_POINTER base, GC_POINTER limit);
 #endif
@@ -61,12 +60,15 @@ public:
   typedef typename vector_type::size_type size_type;
   typedef typename vector_type::pointer pointer;
   typedef typename vector_type::const_pointer const_pointer;
+
 public:
   vector_type _Vector;
-  Vec0_impl(bool dummy) :_Vector(dummy) {}; // don't allocate GC memory ctor
-  Vec0_impl() {};
+  Vec0_impl(bool dummy) : _Vector(dummy){}; // don't allocate GC memory ctor
+  Vec0_impl(){};
+
 public:
   typename Vec::pointer_to_moveable contents() const { return this->_Vector.contents(); };
+
 public:
   void swap(Vec0_impl &other) { this->_Vector.swap(other._Vector); };
   iterator begin() { return this->_Vector.begin(); };
@@ -74,24 +76,21 @@ public:
   const_iterator begin() const { return this->_Vector.begin(); };
   const_iterator end() const { return this->_Vector.end(); };
   size_t size() const { return this->_Vector.size(); };
-  bool empty() const { return this->_Vector.size()==0; };
+  bool empty() const { return this->_Vector.size() == 0; };
   inline void unsafe_set_end(size_t e) { this->_Vector.unsafe_set_end(e); };
   void ensure_initialized() { return this->_Vector.ensure_initialized(); };
   size_t capacity() const { return this->_Vector.capacity(); };
   size_t max_size() const { return ~(size_t)0; };
   pointer_type data() const { return this->_Vector._Contents->data(); };
-  inline void operator = (const Vec0_impl& other) {
-    this->_Vector = other._Vector;
-  }
+  inline void operator=(const Vec0_impl &other) { this->_Vector = other._Vector; }
   inline reference operator[](size_t i) { return this->_Vector[i]; };
   inline const_reference operator[](size_t i) const { return this->_Vector[i]; };
-  void resize(size_t n, const value_type &initialElement = value_type()) {
-    this->_Vector.resize(n, initialElement);
-  };
+  void resize(size_t n, const value_type &initialElement = value_type()) { this->_Vector.resize(n, initialElement); };
   void reserve(size_t n) { this->_Vector.reserve(n); };
-  void assign( size_t count, const value_type& value ) {
+  void assign(size_t count, const value_type &value) {
     this->resize(count);
-    for (size_t zz=0; zz<count; zz++ ) this->_Vector[zz] = value;
+    for (size_t zz = 0; zz < count; zz++)
+      this->_Vector[zz] = value;
   }
   void clear() { this->_Vector.clear(); };
   void push_back(const_reference val) { this->_Vector.push_back(val); };
@@ -100,16 +99,17 @@ public:
   const_reference front() const { return this->_Vector[0]; }
   reference back() { return this->_Vector[this->_Vector.size() - 1]; }
   const_reference back() const { return this->_Vector[this->_Vector.size() - 1]; }
-  iterator insert(const_iterator position, const value_type &val) { return const_cast<iterator>(this->_Vector.emplace(position, val)); };
-  template <typename... ARGS>
-  iterator emplace(const_iterator position, ARGS &&... args) { return this->_Vector.emplace(position, std::forward<ARGS>(args)...); };
-  template <typename... ARGS>
-  void emplace_back(ARGS &&... args) { this->_Vector.emplace_back(std::forward<ARGS>(args)...); };
+  iterator insert(const_iterator position, const value_type &val) {
+    return const_cast<iterator>(this->_Vector.emplace(position, val));
+  };
+  template <typename... ARGS> iterator emplace(const_iterator position, ARGS &&...args) {
+    return this->_Vector.emplace(position, std::forward<ARGS>(args)...);
+  };
+  template <typename... ARGS> void emplace_back(ARGS &&...args) { this->_Vector.emplace_back(std::forward<ARGS>(args)...); };
   iterator erase(iterator position) { return this->_Vector.erase(position); };
 };
 
-template <class Arr>
-class Array0_impl {
+template <class Arr> class Array0_impl {
 #if defined(USE_MPS) && !defined(RUNNING_PRECISEPREP)
   friend GC_RESULT(::obj_scan)(GC_SCAN_STATE_TYPE ss, GC_POINTER base, GC_POINTER limit);
 #endif
@@ -126,7 +126,8 @@ public:
   array_type _Array;
 
 public:
-  //        template <typename...ARGS> Array0_impl(size_t numExtraArgs,const value_type& val, ARGS&&...args) : _Array(numExtraArgs,val,std::forward<ARGS>(args)...) {};
+  //        template <typename...ARGS> Array0_impl(size_t numExtraArgs,const value_type& val, ARGS&&...args) :
+  //        _Array(numExtraArgs,val,std::forward<ARGS>(args)...) {};
   Array0_impl() : _Array(){};
 
 public:
@@ -134,8 +135,7 @@ public:
   typename Arr::pointer_to_moveable contents() const { return this->_Array.contents(); };
 
 public:
-  template <typename... ARGS>
-  void allocate(size_t numExtraArgs, const value_type &initialValue, ARGS &&... args) {
+  template <typename... ARGS> void allocate(size_t numExtraArgs, const value_type &initialValue, ARGS &&...args) {
     this->_Array.allocate(numExtraArgs, initialValue, std::forward<ARGS>(args)...);
   }
 
@@ -151,30 +151,24 @@ public:
   void clear() { this->_Array.clear(); };
 };
 
-template <class T>
-class Vec0 : public Vec0_impl<GCVector<T, GCContainerAllocator<GCVector_moveable<T>>>> {
+template <class T> class Vec0 : public Vec0_impl<GCVector<T, GCContainerAllocator<GCVector_moveable<T>>>> {
 public:
   typedef Vec0_impl<GCVector<T, GCContainerAllocator<GCVector_moveable<T>>>> Base;
-  Vec0(bool dummy) : Base(dummy) {}; // don't allocate GC memory ctor
-  Vec0() : Base() {};
+  Vec0(bool dummy) : Base(dummy){}; // don't allocate GC memory ctor
+  Vec0() : Base(){};
 };
 
-
-};
-
-
+}; // namespace gctools
 
 namespace gctools {
-template <class T>
-class Vec0_uncopyable : public Vec0<T> {
+template <class T> class Vec0_uncopyable : public Vec0<T> {
 public:
   typedef Vec0<T> Base;
   Vec0_uncopyable() : Base(){};
-  Vec0_uncopyable(const Vec0_uncopyable<T>& orig) :Base() {};
+  Vec0_uncopyable(const Vec0_uncopyable<T> &orig) : Base(){};
 };
 
-template <class K, class V>
-class SmallMap : public GCSmallMap<K, V, GCContainerAllocator<GCVector_moveable<pair<K, V>>>> {
+template <class K, class V> class SmallMap : public GCSmallMap<K, V, GCContainerAllocator<GCVector_moveable<pair<K, V>>>> {
 public:
   typedef GCSmallMap<K, V, GCContainerAllocator<GCVector_moveable<pair<K, V>>>> Base;
   SmallMap() : Base(){};
@@ -194,10 +188,10 @@ public:
   SmallMultimap() : Base(){};
 };
 
-template <class K, class V, class Compare>
-class SmallMultimap_uncopyable : public SmallMultimap<K,V,Compare> {
+template <class K, class V, class Compare> class SmallMultimap_uncopyable : public SmallMultimap<K, V, Compare> {
 public:
-  typedef SmallMultimap<K,V,Compare> Base;
+  typedef SmallMultimap<K, V, Compare> Base;
+
 public:
   void insert2(K key, V value) {
     pair<K, V> key_value(key, value);
@@ -205,16 +199,14 @@ public:
   }
 
   SmallMultimap_uncopyable() : Base(){};
-  SmallMultimap_uncopyable(const SmallMultimap_uncopyable<K,V,Compare>& other) : Base() {};
+  SmallMultimap_uncopyable(const SmallMultimap_uncopyable<K, V, Compare> &other) : Base(){};
 };
 
-template <class K>
-class SmallOrderedSet : public GCSmallSet<K, GCContainerAllocator<GCVector_moveable<K>>> {
+template <class K> class SmallOrderedSet : public GCSmallSet<K, GCContainerAllocator<GCVector_moveable<K>>> {
 public:
   typedef GCSmallSet<K, GCContainerAllocator<GCVector_moveable<K>>> Base;
   SmallOrderedSet() : Base(){};
 };
-
 
 }; // namespace gctools
 #endif

--- a/include/clasp/gctools/containers.h
+++ b/include/clasp/gctools/containers.h
@@ -79,7 +79,7 @@ public:
   void ensure_initialized() { return this->_Vector.ensure_initialized(); };
   size_t capacity() const { return this->_Vector.capacity(); };
   size_t max_size() const { return ~(size_t)0; };
-  //  pointer_type data() const { return this->_Vector.data(); };
+  pointer_type data() const { return this->_Vector._Contents->data(); };
   inline void operator = (const Vec0_impl& other) {
     this->_Vector = other._Vector;
   }

--- a/src/core/foundation.cc
+++ b/src/core/foundation.cc
@@ -1088,6 +1088,7 @@ void lisp_bytecode_defun(SymbolFunctionEnum kind,
                          const string &sourceFile,
                          int lineNumber,
                          int numberOfRequiredArguments,
+                         bool autoExport,
                          const std::set<int> &skipIndices)
 {
   List_sp lambda_list = lisp_parse_arguments(packageName, arguments,numberOfRequiredArguments,skipIndices);
@@ -1128,7 +1129,7 @@ void lisp_bytecode_defun(SymbolFunctionEnum kind,
     names = Cons_O::create(sym,names);
     core::_sym_STARbuiltin_setf_function_namesSTAR->setf_symbolValue(names);
   }
-  sym->exportYourself();
+  if (autoExport) sym->exportYourself();
   T_sp tdocstring = nil<T_O>();
   if (docstring!="") tdocstring = core::SimpleBaseString_O::make(docstring);
   func->setf_lambdaList(lambda_list);

--- a/src/core/foundation.cc
+++ b/src/core/foundation.cc
@@ -33,7 +33,6 @@ THE SOFTWARE.
 #include <csignal>
 #include <dlfcn.h>
 
-
 #include <clasp/core/foundation.h>
 #include <clasp/core/object.h>
 #include <clasp/core/lisp.h>
@@ -85,39 +84,37 @@ THE SOFTWARE.
 #include <clasp/core/null.h>
 #include <clasp/core/wrappers.h>
 
-
-
 namespace reg {
 
 typedef std::map<type_id, class_id> map_type;
-map_type* global_registered_ids_ptr = NULL;
+map_type *global_registered_ids_ptr = NULL;
 class_id global_next_id = 0;
 
 void dump_class_ids() {
-  if ( global_registered_ids_ptr == NULL ) {
+  if (global_registered_ids_ptr == NULL) {
     printf("The global_registered_ids_ptr is NULL\n");
     return;
   }
   char buffer[1024];
-  for ( auto it : (*global_registered_ids_ptr) ) {
-    const char* fnName = it.first.name();
+  for (auto it : (*global_registered_ids_ptr)) {
+    const char *fnName = it.first.name();
     size_t length;
     int status;
     char *ret = abi::__cxa_demangle(fnName, NULL, &length, &status);
     if (status == 0) {
-      printf("  %s --> %lu : %s\n", ret, it.second, _rep_(lisp_classSymbolFromClassId(it.second)).c_str() );
+      printf("  %s --> %lu : %s\n", ret, it.second, _rep_(lisp_classSymbolFromClassId(it.second)).c_str());
       delete ret;
     } else {
-        // demangling failed. Output function name as a C function with
-        // no arguments.
-      printf("  %s --> %lu : %s\n", it.first.name(), it.second, _rep_(lisp_classSymbolFromClassId(it.second)).c_str() );
+      // demangling failed. Output function name as a C function with
+      // no arguments.
+      printf("  %s --> %lu : %s\n", it.first.name(), it.second, _rep_(lisp_classSymbolFromClassId(it.second)).c_str());
     }
   }
 }
 
 class_id allocate_class_id(type_id const &cls) {
-//  printf("%s:%d:%s\n", __FILE__, __LINE__, __FUNCTION__ );
-  if ( global_registered_ids_ptr == NULL ) {
+  //  printf("%s:%d:%s\n", __FILE__, __LINE__, __FUNCTION__ );
+  if (global_registered_ids_ptr == NULL) {
     global_registered_ids_ptr = new map_type();
   }
   std::pair<map_type::iterator, bool> inserted = global_registered_ids_ptr->insert(std::make_pair(cls, global_next_id));
@@ -130,11 +127,10 @@ class_id allocate_class_id(type_id const &cls) {
   return inserted.first->second;
 }
 
-
 void lisp_associateClassIdWithClassSymbol(class_id cid, core::Symbol_sp sym) {
   ASSERT(_lisp);
   // I'm clobbering the memory - add this assert
-  ASSERT(_lisp->classSymbolsHolder().size() < 4096 && _lisp->classSymbolsHolder().size()>=0 );
+  ASSERT(_lisp->classSymbolsHolder().size() < 4096 && _lisp->classSymbolsHolder().size() >= 0);
   if (cid >= _lisp->classSymbolsHolder().size()) {
     _lisp->classSymbolsHolder().resize(cid + 1, core::lisp_symbolNil());
   }
@@ -148,27 +144,26 @@ core::Symbol_sp lisp_classSymbolFromClassId(class_id cid) {
   }
   return sym;
 }
-};
-
+}; // namespace reg
 
 namespace core {
 
 union NW {
-  uint64_t  word;
+  uint64_t word;
   char name[8];
 };
 
-uint64_t lisp_nameword(core::T_sp name)
-{
+uint64_t lisp_nameword(core::T_sp name) {
   NW nw;
   if (gc::IsA<String_sp>(name)) {
     String_sp sname = gc::As_unsafe<String_sp>(name);
     size_t i = 0;
-    size_t iEnd(std::min((size_t)sname->length(),(size_t)8));
-    for ( ; i<iEnd; ++i ) {
+    size_t iEnd(std::min((size_t)sname->length(), (size_t)8));
+    for (; i < iEnd; ++i) {
       nw.name[i] = sname->rowMajorAref(i).unsafe_character();
     }
-    for ( size_t is = i; is<7; ++is ) nw.name[is] = ' ';
+    for (size_t is = i; is < 7; ++is)
+      nw.name[is] = ' ';
     nw.name[7] = '\0';
     return nw.word;
   } else if (gc::IsA<Symbol_sp>(name)) {
@@ -177,118 +172,106 @@ uint64_t lisp_nameword(core::T_sp name)
     }
     String_sp sname = gc::As_unsafe<Symbol_sp>(name)->symbolName();
     size_t i = 0;
-    size_t iEnd(std::min((size_t)sname->length(),(size_t)8));
-    for ( ; i<iEnd; ++i ) {
+    size_t iEnd(std::min((size_t)sname->length(), (size_t)8));
+    for (; i < iEnd; ++i) {
       nw.name[i] = sname->rowMajorAref(i).unsafe_character();
     }
-    for ( size_t is = i; is<7; ++is ) nw.name[is] = ' ';
+    for (size_t is = i; is < 7; ++is)
+      nw.name[is] = ' ';
     nw.name[7] = '\0';
     return nw.word;
   }
-  SIMPLE_ERROR(("The name %s must be a string or a symbol") , _rep_(name));
+  SIMPLE_ERROR(("The name %s must be a string or a symbol"), _rep_(name));
 }
-    
 
 Instance_sp lisp_built_in_class() {
   return _lisp->_Roots._TheBuiltInClass;
-//  return cl__find_class(clbind::_sym_built_in_class,false,nil<T_O>());
+  //  return cl__find_class(clbind::_sym_built_in_class,false,nil<T_O>());
 }
 Instance_sp lisp_standard_class() {
   return _lisp->_Roots._TheStandardClass;
   // return cl__find_class(cl::_sym_standard_class,false,nil<T_O>());
 }
 
-Instance_sp lisp_derivable_cxx_class() {
-  return _lisp->_Roots._TheDerivableCxxClass;
-}
-Instance_sp lisp_clbind_cxx_class() {
-  return _lisp->_Roots._TheClbindCxxClass;
-}
-
+Instance_sp lisp_derivable_cxx_class() { return _lisp->_Roots._TheDerivableCxxClass; }
+Instance_sp lisp_clbind_cxx_class() { return _lisp->_Roots._TheClbindCxxClass; }
 
 /*! Convert valid objects to void*/
-void* lisp_to_void_ptr(T_sp o) {
+void *lisp_to_void_ptr(T_sp o) {
   if (gc::IsA<clasp_ffi::ForeignData_sp>(o)) {
     return gc::As_unsafe<clasp_ffi::ForeignData_sp>(o)->ptr();
   } else if (gc::IsA<Pointer_sp>(o)) {
     return gc::As_unsafe<Pointer_sp>(o)->ptr();
   }
-  SIMPLE_ERROR(("The object %s cannot be converted to a void*") , _rep_(o));
+  SIMPLE_ERROR(("The object %s cannot be converted to a void*"), _rep_(o));
 }
 
 /*! Convert void* to a ForeignData_O object */
-T_sp lisp_from_void_ptr(void* p) {
-  return clasp_ffi::ForeignData_O::create(p);
-}
-};
+T_sp lisp_from_void_ptr(void *p) { return clasp_ffi::ForeignData_O::create(p); }
+}; // namespace core
 
 namespace core {
 
 DOCGROUP(clasp);
-CL_DEFUN void core__dump_class_ids()
-{
-  reg::dump_class_ids();
-}
+CL_DEFUN void core__dump_class_ids() { reg::dump_class_ids(); }
 
-
-void lisp_errorExpectedList(core::T_O* v) {
+void lisp_errorExpectedList(core::T_O *v) {
   T_sp tv((gctools::Tagged)v);
-  TYPE_ERROR(tv,cl::_sym_list);
+  TYPE_ERROR(tv, cl::_sym_list);
 }
 
-void lisp_errorIllegalDereference(void *v) {
-  SIMPLE_ERROR(("Tried to dereference px=%p") , v);
-}
+void lisp_errorIllegalDereference(void *v) { SIMPLE_ERROR(("Tried to dereference px=%p"), v); }
 
-void lisp_errorDereferencedNonPointer(core::T_O *v) {
-  SIMPLE_ERROR(("Tried to dereference immediate value: %p") , (void*)v);
-}
+void lisp_errorDereferencedNonPointer(core::T_O *v) { SIMPLE_ERROR(("Tried to dereference immediate value: %p"), (void *)v); }
 
-void lisp_errorDereferencedNil() {
-  SIMPLE_ERROR(("Tried to dereference nil"));
-}
+void lisp_errorDereferencedNil() { SIMPLE_ERROR(("Tried to dereference nil")); }
 
-void lisp_errorDereferencedUnbound() {
-  SIMPLE_ERROR(("Tried to dereference unbound"));
-}
-
+void lisp_errorDereferencedUnbound() { SIMPLE_ERROR(("Tried to dereference unbound")); }
 
 DONT_OPTIMIZE_ALWAYS void lisp_errorUnexpectedTypeStampWtag(size_t to, core::T_O *objP) {
   size_t expectedStamp = STAMP_UNSHIFT_WTAG(to);
 #ifdef DEBUG_RUNTIME
   // This is a really low level debug code appropriate when debugging the runtime
-  const char* expectedName = obj_name(expectedStamp);
-  printf("%s:%d:%s ----- Unexpected type error! ------\n", __FILE__, __LINE__, __FUNCTION__ );
-  printf(" EXPECTED stamp_wtag = %4lu name: %s\n", (size_t)to, expectedName );
-  printf(" the actual object with tagged pointer %p has the header:\n", objP );
+  const char *expectedName = obj_name(expectedStamp);
+  printf("%s:%d:%s ----- Unexpected type error! ------\n", __FILE__, __LINE__, __FUNCTION__);
+  printf(" EXPECTED stamp_wtag = %4lu name: %s\n", (size_t)to, expectedName);
+  printf(" the actual object with tagged pointer %p has the header:\n", objP);
   client_describe(objP);
-# if 0
+#if 0
   for ( size_t ii=0; ii<_lisp->_Roots.staticClassSymbolsUnshiftedNowhere.size(); ii++ ) {
     Symbol_sp ssym = _lisp->_Roots.staticClassSymbolsUnshiftedNowhere[ii];
     printf("%s:%d:%s _lisp->_Roots.staticClassSymbolsUnshiftedNowhere[%lu] -> %s\n", __FILE__, __LINE__, __FUNCTION__, ii, _rep_(ssym).c_str() );
   }
-# endif
+#endif
 #endif
   Symbol_sp expectedClassSymbol = _lisp->_Roots.staticClassSymbolsUnshiftedNowhere[expectedStamp];
   T_sp obj((gctools::Tagged)objP);
-  TYPE_ERROR(obj,expectedClassSymbol);
+  TYPE_ERROR(obj, expectedClassSymbol);
 }
 
 DONT_OPTIMIZE_ALWAYS void lisp_errorUnexpectedType(class_id expected_class_id, class_id given_class_id, core::T_O *objP) {
   if (expected_class_id >= _lisp->classSymbolsHolder().size()) {
-    core::lisp_error_simple(__FUNCTION__, __FILE__, __LINE__, fmt::sprintf("expected class_id %d out of range max[%d]" , expected_class_id , _lisp->classSymbolsHolder().size()));
+    core::lisp_error_simple(
+        __FUNCTION__, __FILE__, __LINE__,
+        fmt::sprintf("expected class_id %d out of range max[%d]", expected_class_id, _lisp->classSymbolsHolder().size()));
   }
   core::Symbol_sp expectedSym = _lisp->classSymbolsHolder()[expected_class_id];
   if (expectedSym.nilp()) {
-    core::lisp_error_simple(__FUNCTION__, __FILE__, __LINE__, fmt::sprintf("unexpected class_id for object %p (given_class_id %d / expected_class_id %d) could not lookup expected_class_id symbol" , (void*)objP , given_class_id , expected_class_id));
+    core::lisp_error_simple(__FUNCTION__, __FILE__, __LINE__,
+                            fmt::sprintf("unexpected class_id for object %p (given_class_id %d / expected_class_id %d) could not "
+                                         "lookup expected_class_id symbol",
+                                         (void *)objP, given_class_id, expected_class_id));
   }
 
   if (given_class_id >= _lisp->classSymbolsHolder().size()) {
-    core::lisp_error_simple(__FUNCTION__, __FILE__, __LINE__, fmt::sprintf("given class_id %d out of range max[%d]" , given_class_id , _lisp->classSymbolsHolder().size()));
+    core::lisp_error_simple(
+        __FUNCTION__, __FILE__, __LINE__,
+        fmt::sprintf("given class_id %d out of range max[%d]", given_class_id, _lisp->classSymbolsHolder().size()));
   }
   core::Symbol_sp givenSym = _lisp->classSymbolsHolder()[given_class_id];
   if (givenSym.nilp()) {
-    core::lisp_error_simple(__FUNCTION__, __FILE__, __LINE__, fmt::sprintf("given class_id %d symbol was not defined" , given_class_id));
+    core::lisp_error_simple(__FUNCTION__, __FILE__, __LINE__,
+                            fmt::sprintf("given class_id %d symbol was not defined", given_class_id));
   }
 
   gctools::smart_ptr<core::T_O> obj((gc::Tagged)objP);
@@ -303,7 +286,6 @@ DONT_OPTIMIZE_ALWAYS void lisp_errorBadCastToFixnum(class_id from_typ, core::T_O
 DONT_OPTIMIZE_ALWAYS void lisp_errorBadCast(class_id toType, class_id fromType, core::T_O *objP) {
   lisp_errorUnexpectedType(toType, fromType, objP);
 }
-
 
 DONT_OPTIMIZE_ALWAYS void lisp_errorBadCastStampWtag(size_t to, core::T_O *objP) {
   lisp_errorUnexpectedTypeStampWtag((size_t)to, objP);
@@ -328,22 +310,25 @@ DONT_OPTIMIZE_ALWAYS void lisp_errorBadCastFromSymbol_O(class_id toType, core::S
 
 DONT_OPTIMIZE_ALWAYS void lisp_errorUnexpectedNil(class_id expectedTyp) {
   if (expectedTyp >= _lisp->classSymbolsHolder().size()) {
-    core::lisp_error_simple(__FUNCTION__, __FILE__, __LINE__, fmt::sprintf("expected class_id %" PRu " out of range max[%zu]" , expectedTyp , _lisp->classSymbolsHolder().size()));
+    core::lisp_error_simple(
+        __FUNCTION__, __FILE__, __LINE__,
+        fmt::sprintf("expected class_id %" PRu " out of range max[%zu]", expectedTyp, _lisp->classSymbolsHolder().size()));
   }
   core::Symbol_sp expectedSym = _lisp->classSymbolsHolder()[expectedTyp];
   if (expectedSym.nilp()) {
-    core::lisp_error_simple(__FUNCTION__, __FILE__, __LINE__, fmt::sprintf("expected class_id %" PRu " symbol was not defined" , expectedTyp));
+    core::lisp_error_simple(__FUNCTION__, __FILE__, __LINE__,
+                            fmt::sprintf("expected class_id %" PRu " symbol was not defined", expectedTyp));
   }
   TYPE_ERROR(nil<core::T_O>(), expectedSym);
 }
 
-};
+}; // namespace core
 namespace boost {
 using namespace core;
 void assertion_failed(char const *expr, char const *function, char const *file, long line) {
   THROW_HARD_ERROR("A BOOST assertion failed");
 }
-};
+}; // namespace boost
 
 namespace llvm_interface {
 
@@ -367,7 +352,7 @@ void lisp_vectorPushExtend(T_sp vec, T_sp obj) {
   ComplexVector_T_sp vvec = gc::As<ComplexVector_T_sp>(vec);
   vvec->vectorPushExtend(obj);
 }
-};
+}; // namespace core
 
 namespace core {
 
@@ -377,30 +362,19 @@ void lisp_pushClassSymbolOntoSTARallCxxClassesSTAR(Symbol_sp classSymbol) {
   }
 };
 
-void lisp_defparameter(Symbol_sp sym, T_sp val) {
-  sym->defparameter(val);
-}
+void lisp_defparameter(Symbol_sp sym, T_sp val) { sym->defparameter(val); }
 
-void lisp_write(const string &fmt, T_sp strm) {
-  clasp_write_string(fmt, strm);
-}
+void lisp_write(const string &fmt, T_sp strm) { clasp_write_string(fmt, strm); }
 
-Symbol_sp lisp_symbolNil() {
-  return nil<Symbol_O>();
-}
+Symbol_sp lisp_symbolNil() { return nil<Symbol_O>(); }
 
-bool lisp_boundp(Symbol_sp s) {
-  return s->boundP();
-}
+bool lisp_boundp(Symbol_sp s) { return s->boundP(); }
 
 T_sp lisp_adjust_array(T_sp array, T_sp new_size, T_sp fill_pointer) {
-  return eval::funcall(cl::_sym_adjust_array,array,new_size,kw::_sym_fill_pointer,fill_pointer);
+  return eval::funcall(cl::_sym_adjust_array, array, new_size, kw::_sym_fill_pointer, fill_pointer);
 }
 
-
-List_sp lisp_copy_default_special_bindings() {
-  return _lisp->copy_default_special_bindings();
-}
+List_sp lisp_copy_default_special_bindings() { return _lisp->copy_default_special_bindings(); }
 
 CL_LAMBDA(name);
 CL_DECLARE();
@@ -418,42 +392,42 @@ CL_DEFUN String_sp core__lispify_name(String_sp name) {
 - package_str :: Return the package part.
 - symbol_str :: Return the symbol part.
 * Description
-Convert strings that have the form pkg:name or pkg__name into a package name string and a symbol name string, run them through lispify_symbol_name and then recombine them as pkg:name.
+Convert strings that have the form pkg:name or pkg__name into a package name string and a symbol name string, run them through
+lispify_symbol_name and then recombine them as pkg:name.
 */
-void colon_split(const string& name, string& package_str, string& symbol_str)
-{
+void colon_split(const string &name, string &package_str, string &symbol_str) {
   std::size_t found = name.find(":");
-  if ( found != std::string::npos ) {
-    package_str = name.substr(0,found);
-    transform( package_str.begin(), package_str.end(), package_str.begin(), ::toupper );
-    symbol_str = name.substr(found+1,std::string::npos);
+  if (found != std::string::npos) {
+    package_str = name.substr(0, found);
+    transform(package_str.begin(), package_str.end(), package_str.begin(), ::toupper);
+    symbol_str = name.substr(found + 1, std::string::npos);
     size_t first = 0;
-    for ( first=0; first<symbol_str.size(); first++ ) {
-      if (!isspace(symbol_str[first])) break;
+    for (first = 0; first < symbol_str.size(); first++) {
+      if (!isspace(symbol_str[first]))
+        break;
     }
     size_t last;
-    for ( last=symbol_str.size()-1; last>=0; last-- ) {
-      if (!isspace(symbol_str[last])) break;
+    for (last = symbol_str.size() - 1; last >= 0; last--) {
+      if (!isspace(symbol_str[last]))
+        break;
     }
-    symbol_str = symbol_str.substr(first,last-first+1);
-    if (symbol_str[0] == '|' &&
-        symbol_str[symbol_str.size()-1] == '|') {
-      symbol_str = symbol_str.substr(1,symbol_str.size()-2);
+    symbol_str = symbol_str.substr(first, last - first + 1);
+    if (symbol_str[0] == '|' && symbol_str[symbol_str.size() - 1] == '|') {
+      symbol_str = symbol_str.substr(1, symbol_str.size() - 2);
     }
     return;
   }
-  SIMPLE_ERROR(("Could not convert %s into package:symbol_name") , name);
+  SIMPLE_ERROR(("Could not convert %s into package:symbol_name"), name);
 }
 
 CL_LAMBDA("name &optional (package \"\")");
 CL_DOCSTRING(R"(Intern the package:name or name/package combination)");
 DOCGROUP(clasp);
-CL_DEFUN Symbol_sp core__magic_intern(const string& name, const string& package)
-{
-  std::string pkg_sym = magic_name(name,package);
+CL_DEFUN Symbol_sp core__magic_intern(const string &name, const string &package) {
+  std::string pkg_sym = magic_name(name, package);
   std::string sym;
   std::string pkg;
-  colon_split(pkg_sym,pkg,sym);
+  colon_split(pkg_sym, pkg, sym);
   Package_sp p = gc::As<Package_sp>(_lisp->findPackage(pkg));
   return p->intern(SimpleBaseString_O::make(sym));
 }
@@ -461,36 +435,34 @@ CL_DEFUN Symbol_sp core__magic_intern(const string& name, const string& package)
 CL_LAMBDA("name");
 CL_DOCSTRING(R"(Disassemble and intern the package:name)");
 DOCGROUP(clasp);
-CL_DEFUN T_mv core__magic_disassemble_and_intern(const string& name)
-{
+CL_DEFUN T_mv core__magic_disassemble_and_intern(const string &name) {
   std::string sym;
   std::string pkg;
-  colon_split(name,pkg,sym);
+  colon_split(name, pkg, sym);
   Package_sp p = gc::As<Package_sp>(_lisp->findPackage(pkg));
   p->intern(SimpleBaseString_O::make(sym));
-  return Values(SimpleBaseString_O::make(pkg),SimpleBaseString_O::make(sym));
+  return Values(SimpleBaseString_O::make(pkg), SimpleBaseString_O::make(sym));
 }
-
 
 /*!
 * Arguments
 - name :: A string.
 - package_name :: A string
 * Description
-Convert strings that have the form pkg:name or pkg__name into a package name string and a symbol name string, run them through lispify_symbol_name and then recombine them as pkg:name. If
-package_name is not the empty string in either of the above cases, signal an error.
-If the name has neither of the above forms then use the package_name to construct package_name:name after lispifying name and return that.
+Convert strings that have the form pkg:name or pkg__name into a package name string and a symbol name string, run them through
+lispify_symbol_name and then recombine them as pkg:name. If package_name is not the empty string in either of the above cases,
+signal an error. If the name has neither of the above forms then use the package_name to construct package_name:name after
+lispifying name and return that.
 */
-std::string magic_name(const std::string& name,const std::string& package_name)
-{
+std::string magic_name(const std::string &name, const std::string &package_name) {
   // printf("%s:%d magic_name -> %s\n", __FILE__, __LINE__, name.c_str());
   std::size_t found = name.find(":");
-  if ( found != std::string::npos ) {
-    if ( package_name != "" ) {
-      SIMPLE_ERROR(("Cannot convert %s into a symbol name because package_name %s was provided") , name , package_name);
+  if (found != std::string::npos) {
+    if (package_name != "") {
+      SIMPLE_ERROR(("Cannot convert %s into a symbol name because package_name %s was provided"), name, package_name);
     }
-    std::string pkg_str = name.substr(0,found);
-    std::string symbol_str = name.substr(found+1,std::string::npos);
+    std::string pkg_str = name.substr(0, found);
+    std::string symbol_str = name.substr(found + 1, std::string::npos);
     pkg_str = lispify_symbol_name(pkg_str);
     symbol_str = lispify_symbol_name(symbol_str);
     stringstream ss;
@@ -498,27 +470,26 @@ std::string magic_name(const std::string& name,const std::string& package_name)
     return ss.str();
   }
   std::size_t found2 = name.find("__");
-  if ( found2 != std::string::npos ) {
-    if ( package_name != "" ) {
-      SIMPLE_ERROR(("Cannot convert %s into a symbol name because package_name %s was provided") , name , package_name);
+  if (found2 != std::string::npos) {
+    if (package_name != "") {
+      SIMPLE_ERROR(("Cannot convert %s into a symbol name because package_name %s was provided"), name, package_name);
     }
-    std::string pkg_str = name.substr(0,found2);
-    std::string symbol_str = name.substr(found2+2,std::string::npos);
+    std::string pkg_str = name.substr(0, found2);
+    std::string symbol_str = name.substr(found2 + 2, std::string::npos);
     pkg_str = lispify_symbol_name(pkg_str);
     symbol_str = lispify_symbol_name(symbol_str);
     stringstream ss;
     ss << pkg_str << ":" << symbol_str;
     return ss.str();
   }
-  if ( package_name != "" ) {
+  if (package_name != "") {
     std::string symbol_str = lispify_symbol_name(name);
     stringstream ss;
     ss << package_name << ":" << symbol_str;
     return ss.str();
   }
-  SIMPLE_ERROR(("Cannot convert %s into a package:name form because no package_name was provided") , name);
+  SIMPLE_ERROR(("Cannot convert %s into a package:name form because no package_name was provided"), name);
 }
-
 
 CL_LAMBDA("name &optional (package \"\")");
 CL_DECLARE();
@@ -530,14 +501,13 @@ Convert strings that have the form pkg:name or pkg__name into a package name str
 run them through lispify_symbol_name and then recombine them as pkg:name.
 Then split them again (sorry) and return (values pkg:sym pkg sym).)dx")
 DOCGROUP(clasp);
-CL_DEFUN T_mv core__magic_name(const std::string& name, const std::string& package) {
-  std::string pkg_sym = magic_name(name,package);
+CL_DEFUN T_mv core__magic_name(const std::string &name, const std::string &package) {
+  std::string pkg_sym = magic_name(name, package);
   std::string sym;
   std::string pkg;
-  colon_split(pkg_sym,pkg,sym);
-  return Values(SimpleBaseString_O::make(pkg_sym),SimpleBaseString_O::make(pkg),SimpleBaseString_O::make(sym));
+  colon_split(pkg_sym, pkg, sym);
+  return Values(SimpleBaseString_O::make(pkg_sym), SimpleBaseString_O::make(pkg), SimpleBaseString_O::make(sym));
 };
-
 
 MultipleValues &lisp_multipleValues() {
   //	return &(_lisp->multipleValues());
@@ -552,12 +522,12 @@ MultipleValues &lisp_multipleValues() {
 }
 #endif
 
-[[noreturn]]void errorFormatted(const string &msg) {
+[[noreturn]] void errorFormatted(const string &msg) {
   dbg_hook(msg.c_str());
   core__invoke_internal_debugger(nil<core::T_O>());
 }
 
-[[noreturn]]void errorFormatted(const char *msg) {
+[[noreturn]] void errorFormatted(const char *msg) {
   dbg_hook(msg);
   core__invoke_internal_debugger(nil<core::T_O>());
 }
@@ -599,33 +569,34 @@ bool lispify_match(const char *&cur, const char *match, NextCharTest nextCharTes
     ++ccur;
     ++match;
   }
-  if ( nextCharTest == ignore ) {
+  if (nextCharTest == ignore) {
     cur = ccur;
     return true;
   }
-  if ( nextCharTest == upperCaseAlpha ) {
+  if (nextCharTest == upperCaseAlpha) {
     if (*match && upper_case_p(*match)) {
       cur = ccur;
       return true;
     }
     return false;
   }
-  SIMPLE_ERROR(("Unknown nextCharTest(%d)") , nextCharTest );
+  SIMPLE_ERROR(("Unknown nextCharTest(%d)"), nextCharTest);
 }
 
 string lispify_symbol_name(const string &s) {
   bool new_rule_change = false;
-  LOG("lispify_symbol_name pass1 source[%s]" , s);
+  LOG("lispify_symbol_name pass1 source[%s]", s);
   /*! Temporarily store the string in a buffer */
 #define LISPIFY_BUFFER_SIZE 1024
   char buffer[LISPIFY_BUFFER_SIZE];
   int name_length = s.size();
-  if ((name_length+2)>=LISPIFY_BUFFER_SIZE) {
-    printf("%s:%d The C++ string is too large to lispify - increase LISPIFY_BUFFER_SIZE to at least %d\n", __FILE__, __LINE__, (name_length+2));
+  if ((name_length + 2) >= LISPIFY_BUFFER_SIZE) {
+    printf("%s:%d The C++ string is too large to lispify - increase LISPIFY_BUFFER_SIZE to at least %d\n", __FILE__, __LINE__,
+           (name_length + 2));
     abort();
   }
-  memset(buffer,0,name_length+2);
-  strncpy(buffer,s.c_str(),name_length);
+  memset(buffer, 0, name_length + 2);
+  strncpy(buffer, s.c_str(), name_length);
   stringstream stream_pass1;
   const char *cur = buffer;
   while (*cur) {
@@ -718,7 +689,7 @@ string lispify_symbol_name(const string &s) {
   }
   stringstream stream_pass2;
   string str_pass2 = stream_pass1.str();
-  LOG("lispify_symbol_name pass2 source[%s]" , str_pass2);
+  LOG("lispify_symbol_name pass2 source[%s]", str_pass2);
   const char *start_pass2 = str_pass2.c_str();
   cur = start_pass2;
   while (*cur) {
@@ -732,16 +703,15 @@ string lispify_symbol_name(const string &s) {
     stream_pass2 << (char)(char_upcase(*cur));
     ++cur;
   }
-  LOG("lispify_symbol_name output[%s]" , stream_pass2.str());
-  if ( new_rule_change ) {
-    printf("%s:%d The symbol |%s| changed according to the new rule ([A-Z]+)([A-Z][a-z]) -> \\1-\\2-\n", __FILE__, __LINE__, stream_pass2.str().c_str() );
+  LOG("lispify_symbol_name output[%s]", stream_pass2.str());
+  if (new_rule_change) {
+    printf("%s:%d The symbol |%s| changed according to the new rule ([A-Z]+)([A-Z][a-z]) -> \\1-\\2-\n", __FILE__, __LINE__,
+           stream_pass2.str().c_str());
   }
   return stream_pass2.str();
 }
 
-string symbol_symbolName(Symbol_sp sym) {
-  return sym->symbolNameAsString();
-}
+string symbol_symbolName(Symbol_sp sym) { return sym->symbolNameAsString(); }
 
 string symbol_packageName(Symbol_sp sym) {
   T_sp p = sym->homePackage();
@@ -772,13 +742,13 @@ Instance_sp lisp_instance_class(T_sp o) {
   } else if (o.unboundp()) {
     SIMPLE_ERROR("lisp_instance_class called on #<UNBOUND>");
   } else {
-    SIMPLE_ERROR(("Add support for unknown (immediate?) object to lisp_instance_class obj = %p") , (void*)(o.raw_()));
+    SIMPLE_ERROR(("Add support for unknown (immediate?) object to lisp_instance_class obj = %p"), (void *)(o.raw_()));
   }
   return gc::As_unsafe<Instance_sp>(tc);
 }
 
 Instance_sp lisp_static_class(T_sp o) {
-  if ( o.generalp() ) {
+  if (o.generalp()) {
     General_sp go(o.unsafe_general());
     if (go.nilp()) {
       return core::Null_O::staticClass();
@@ -821,23 +791,20 @@ string _rep_(T_sp obj) {
     return "#<UNBOUND>";
   }
   stringstream ss;
-  ss << "WTF-object@" << (void*)obj.raw_();
+  ss << "WTF-object@" << (void *)obj.raw_();
   return ss.str();
 #endif
 }
 
 void lisp_throwUnexpectedType(T_sp offendingObject, Symbol_sp expectedTypeId) {
   Symbol_sp offendingTypeId = cl__class_of(offendingObject)->_className();
-  SIMPLE_ERROR(("Expected %s of class[%s] to be subclass of class[%s]") , _rep_(offendingObject) , _rep_(offendingTypeId) , _rep_(expectedTypeId));
+  SIMPLE_ERROR(("Expected %s of class[%s] to be subclass of class[%s]"), _rep_(offendingObject), _rep_(offendingTypeId),
+               _rep_(expectedTypeId));
 }
 
-string lisp_classNameAsString(Instance_sp c) {
-  return c->_classNameAsString();
-}
+string lisp_classNameAsString(Instance_sp c) { return c->_classNameAsString(); }
 
-void lisp_throwLispError(const string &str) {
-  SIMPLE_ERROR(("%s") , str);
-}
+void lisp_throwLispError(const string &str) { SIMPLE_ERROR(("%s"), str); }
 
 #if 0
 void lisp_throwLispError(const boost::format &fmt) {
@@ -850,9 +817,7 @@ bool lisp_debugIsOn(const char *fileName, uint debugFlags) {
   return ret;
 }
 
-DebugStream *lisp_debugLog() {
-  return &(_lisp->debugLog());
-}
+DebugStream *lisp_debugLog() { return &(_lisp->debugLog()); }
 
 uint lisp_hash(uintptr_t x) {
   HashGenerator hg;
@@ -860,42 +825,33 @@ uint lisp_hash(uintptr_t x) {
   return static_cast<uint>(hg.rawhash());
 }
 
-T_sp lisp_true() {
-  return _lisp->_true();
-}
+T_sp lisp_true() { return _lisp->_true(); }
 
-T_sp lisp_false() {
-  return _lisp->_false();
-}
+T_sp lisp_false() { return _lisp->_false(); }
 
-string lisp_rep(T_sp obj) {
-  return _rep_(obj);
-}
+string lisp_rep(T_sp obj) { return _rep_(obj); }
 
-bool lisp_CoreBuiltInClassesInitialized() {
-  return _lisp->CoreBuiltInClassesInitialized();
-}
+bool lisp_CoreBuiltInClassesInitialized() { return _lisp->CoreBuiltInClassesInitialized(); }
 
-bool lisp_BuiltInClassesInitialized() {
-  return _lisp->BuiltInClassesInitialized();
-}
+bool lisp_BuiltInClassesInitialized() { return _lisp->BuiltInClassesInitialized(); }
 
 T_sp lisp_boot_findClassBySymbolOrNil(Symbol_sp classSymbol) {
   Instance_sp mc = gc::As<Instance_sp>(eval::funcall(cl::_sym_findClass, classSymbol, _lisp->_true()));
   return mc;
 }
 
-List_sp lisp_parse_arguments(const string &packageName, const string &args, int number_of_required_arguments, const std::set<int> skip_indices ) {
+List_sp lisp_parse_arguments(const string &packageName, const string &args, int number_of_required_arguments,
+                             const std::set<int> skip_indices) {
   if (args == "") {
     // If args is "" then cook up arguments using number_of_required_arguments and skip_indices
     ql::list args;
     int num = 0;
-    for ( int idx=0; idx< number_of_required_arguments; idx++) {
-      if (skip_indices.count(idx)==0) {
+    for (int idx = 0; idx < number_of_required_arguments; idx++) {
+      if (skip_indices.count(idx) == 0) {
         stringstream ss;
         ss << "ARG" << num;
         num++;
-        Symbol_sp arg_sym = _lisp->intern(ss.str(),packageName);
+        Symbol_sp arg_sym = _lisp->intern(ss.str(), packageName);
         args << arg_sym;
       }
     }
@@ -909,13 +865,13 @@ List_sp lisp_parse_arguments(const string &packageName, const string &args, int 
   Reader_sp reader = Reader_O::create(str);
   T_sp osscons = reader->primitive_read(true, nil<T_O>(), false);
 #else
-  T_sp osscons = read_lisp_object(str,true,nil<T_O>(), false);
+  T_sp osscons = read_lisp_object(str, true, nil<T_O>(), false);
 #endif
   List_sp sscons = osscons;
   return sscons;
 }
 
-List_sp lisp_lexical_variable_names( List_sp lambda_list, bool& trivial_wrapper ) {
+List_sp lisp_lexical_variable_names(List_sp lambda_list, bool &trivial_wrapper) {
   gctools::Vec0<RequiredArgument> reqs;
   gctools::Vec0<OptionalArgument> optionals;
   gctools::Vec0<KeywordArgument> keys;
@@ -924,29 +880,26 @@ List_sp lisp_lexical_variable_names( List_sp lambda_list, bool& trivial_wrapper 
   T_sp key_flag;
   T_sp allow_other_keys;
   T_sp decl_dict = nil<T_O>();
-  parse_lambda_list(lambda_list,
-                    cl::_sym_function,
-                    reqs,
-                    optionals,
-                    restarg,
-                    key_flag,
-                    keys,
-                    allow_other_keys,
-                    auxs);
+  parse_lambda_list(lambda_list, cl::_sym_function, reqs, optionals, restarg, key_flag, keys, allow_other_keys, auxs);
   //
   // trivial_wrapper is true if only required arguments are in lambda_list
   //
   trivial_wrapper = true;
-  if (optionals.size()>0) trivial_wrapper = false;
-  if (keys.size()>0) trivial_wrapper = false;
-  if (auxs.size()>0) trivial_wrapper = false;
-  if (restarg.isDefined()) trivial_wrapper = false;
-  if (allow_other_keys.notnilp()) trivial_wrapper = false;
-  if (key_flag.notnilp()) trivial_wrapper = false;
-  T_sp vars = lexical_variable_names(reqs,optionals,restarg,keys,auxs);
+  if (optionals.size() > 0)
+    trivial_wrapper = false;
+  if (keys.size() > 0)
+    trivial_wrapper = false;
+  if (auxs.size() > 0)
+    trivial_wrapper = false;
+  if (restarg.isDefined())
+    trivial_wrapper = false;
+  if (allow_other_keys.notnilp())
+    trivial_wrapper = false;
+  if (key_flag.notnilp())
+    trivial_wrapper = false;
+  T_sp vars = lexical_variable_names(reqs, optionals, restarg, keys, auxs);
   return vars;
 }
-
 
 List_sp lisp_parse_declares(const string &packageName, const string &declarestring) {
   if (declarestring == "")
@@ -959,18 +912,16 @@ List_sp lisp_parse_declares(const string &packageName, const string &declarestri
   Reader_sp reader = Reader_O::create(str);
   List_sp sscons = reader->primitive_read(true, nil<T_O>(), false);
 #else
-  List_sp sscons = read_lisp_object(str,true,nil<T_O>(), false);
+  List_sp sscons = read_lisp_object(str, true, nil<T_O>(), false);
 #endif
   return sscons;
 }
 
-
 /*! Insert the package qualified class_symbol into the lambda list wherever a ! is seen */
-string fix_method_lambda(core::Symbol_sp class_symbol, const string& lambda)
-{
+string fix_method_lambda(core::Symbol_sp class_symbol, const string &lambda) {
   stringstream new_lambda;
-  for ( auto c : lambda ) {
-    if ( c == '!' ) {
+  for (auto c : lambda) {
+    if (c == '!') {
       new_lambda << class_symbol->formattedName(true);
     } else {
       new_lambda << c;
@@ -979,23 +930,14 @@ string fix_method_lambda(core::Symbol_sp class_symbol, const string& lambda)
   return new_lambda.str();
 }
 
-
 SYMBOL_EXPORT_SC_(KeywordPkg, body);
 SYMBOL_EXPORT_SC_(KeywordPkg, docstring);
 
-void lisp_defineSingleDispatchMethod(const clbind::BytecodeWrapper& specializer,
-                                     T_sp name,
-                                     Symbol_sp classSymbol,
-                                     GlobalSimpleFunBase_sp method_body,
-                                     size_t TemplateDispatchOn,
-                                     bool useTemplateDispatchOn,
-                                     const string &raw_arguments,
-                                     const string &declares,
-                                     const string &docstring,
-                                     bool autoExport,
-                                     int number_of_required_arguments,
-                                     const std::set<int> pureOutIndices) {
-  string arguments = fix_method_lambda(classSymbol,raw_arguments);
+void lisp_defineSingleDispatchMethod(const clbind::BytecodeWrapper &specializer, T_sp name, Symbol_sp classSymbol,
+                                     GlobalSimpleFunBase_sp method_body, size_t TemplateDispatchOn, bool useTemplateDispatchOn,
+                                     const string &raw_arguments, const string &declares, const string &docstring, bool autoExport,
+                                     int number_of_required_arguments, const std::set<int> pureOutIndices) {
+  string arguments = fix_method_lambda(classSymbol, raw_arguments);
   Instance_sp receiver_class = gc::As<Instance_sp>(eval::funcall(cl::_sym_findClass, classSymbol, _lisp->_true()));
   Symbol_sp className = receiver_class->_className();
   List_sp ldeclares = lisp_parse_declares(gc::As<Package_sp>(className->getPackage())->getName(), declares);
@@ -1003,60 +945,67 @@ void lisp_defineSingleDispatchMethod(const clbind::BytecodeWrapper& specializer,
   // method name  -- sometimes the method name will belong to another class (ie: core:--init--)
   List_sp lambda_list;
   size_t single_dispatch_argument_index;
-  if (useTemplateDispatchOn) single_dispatch_argument_index = TemplateDispatchOn;
+  if (useTemplateDispatchOn)
+    single_dispatch_argument_index = TemplateDispatchOn;
   if (arguments == "" && number_of_required_arguments >= 0) {
-    lambda_list = lisp_parse_arguments(gc::As<Package_sp>(className->getPackage())->getName(), arguments, number_of_required_arguments, pureOutIndices );
+    lambda_list = lisp_parse_arguments(gc::As<Package_sp>(className->getPackage())->getName(), arguments,
+                                       number_of_required_arguments, pureOutIndices);
   } else if (arguments != "") {
     List_sp llraw = lisp_parse_arguments(gc::As<Package_sp>(className->getPackage())->getName(), arguments);
     T_mv mv_llprocessed = process_single_dispatch_lambda_list(llraw, true);
     T_sp tllproc = coerce_to_list(mv_llprocessed); // slice
     lambda_list = coerce_to_list(tllproc);
-    MultipleValues& mvn = core::lisp_multipleValues();
-    Symbol_sp sd_symbol = gc::As<Symbol_sp>(mvn.valueGet(1,mv_llprocessed.number_of_values()));
-    Symbol_sp specializer_symbol = gc::As<Symbol_sp>(mvn.valueGet(2,mv_llprocessed.number_of_values()));
-    T_sp dispatchOn = mvn.valueGet(3,mv_llprocessed.number_of_values());
-    if (dispatchOn.unsafe_fixnum() !=0) {
-      printf("%s:%d:%s bad dispatchOn lambda_list = %s sd_symbol = %s  specializer_symbol = %s dispatchOn = %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(lambda_list).c_str(), _rep_(sd_symbol).c_str(), _rep_(specializer_symbol).c_str(), _rep_(dispatchOn).c_str()  );
+    MultipleValues &mvn = core::lisp_multipleValues();
+    Symbol_sp sd_symbol = gc::As<Symbol_sp>(mvn.valueGet(1, mv_llprocessed.number_of_values()));
+    Symbol_sp specializer_symbol = gc::As<Symbol_sp>(mvn.valueGet(2, mv_llprocessed.number_of_values()));
+    T_sp dispatchOn = mvn.valueGet(3, mv_llprocessed.number_of_values());
+    if (dispatchOn.unsafe_fixnum() != 0) {
+      printf("%s:%d:%s bad dispatchOn lambda_list = %s sd_symbol = %s  specializer_symbol = %s dispatchOn = %s\n", __FILE__,
+             __LINE__, __FUNCTION__, _rep_(lambda_list).c_str(), _rep_(sd_symbol).c_str(), _rep_(specializer_symbol).c_str(),
+             _rep_(dispatchOn).c_str());
       abort();
     }
     single_dispatch_argument_index = dispatchOn.unsafe_fixnum();
   }
   if (TemplateDispatchOn != single_dispatch_argument_index) {
-    SIMPLE_ERROR(("Mismatch between single_dispatch_argument_index[%d] from lambda_list and TemplateDispatchOn[%d] for class %s  method: %s  lambda_list: %s") , single_dispatch_argument_index , TemplateDispatchOn , _rep_(classSymbol) , _rep_(name) , arguments);
+    SIMPLE_ERROR(("Mismatch between single_dispatch_argument_index[%d] from lambda_list and TemplateDispatchOn[%d] for class %s  "
+                  "method: %s  lambda_list: %s"),
+                 single_dispatch_argument_index, TemplateDispatchOn, _rep_(classSymbol), _rep_(name), arguments);
   }
-  LOG("Interned method in class[%s]@%p with symbol[%s] arguments[%s] - autoexport[%d]" , receiver_class->instanceClassName() , (receiver_class.get()) , sym->fullName() , arguments , autoExport);
-  
+  LOG("Interned method in class[%s]@%p with symbol[%s] arguments[%s] - autoexport[%d]", receiver_class->instanceClassName(),
+      (receiver_class.get()), sym->fullName(), arguments, autoExport);
+
   T_sp docStr = nil<T_O>();
-  if (docstring!="") docStr = SimpleBaseString_O::make(docstring);
-  SingleDispatchGenericFunction_sp gfn = core__ensure_single_dispatch_generic_function(name, autoExport,single_dispatch_argument_index, lambda_list ); // Ensure the single dispatch generic function exists
+  if (docstring != "")
+    docStr = SimpleBaseString_O::make(docstring);
+  SingleDispatchGenericFunction_sp gfn = core__ensure_single_dispatch_generic_function(
+      name, autoExport, single_dispatch_argument_index, lambda_list); // Ensure the single dispatch generic function exists
   //
   //
   bool trivial_wrapper;
-  List_sp vars = lisp_lexical_variable_names( lambda_list, trivial_wrapper );
+  List_sp vars = lisp_lexical_variable_names(lambda_list, trivial_wrapper);
   Function_sp func;
   if (trivial_wrapper) {
     func = method_body;
   } else {
-    List_sp funcall_form = Cons_O::create( cleavirPrimop::_sym_funcall, Cons_O::create( method_body, vars ));
-    List_sp declare_form = Cons_O::createList( cl::_sym_declare, Cons_O::createList (core::_sym_lambdaName, name ));
-    //printf("%s:%d:%s funcall_form = %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(funcall_form).c_str() );
-    List_sp form = Cons_O::createList(cl::_sym_lambda,lambda_list,declare_form, funcall_form);
-    //printf("%s:%d:%s assembled form = %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(form).c_str() );
-    func = comp::bytecompile( form,comp::Lexenv_O::make_top_level());
+    List_sp funcall_form = Cons_O::create(cleavirPrimop::_sym_funcall, Cons_O::create(method_body, vars));
+    List_sp declare_form = Cons_O::createList(cl::_sym_declare, Cons_O::createList(core::_sym_lambdaName, name));
+    // printf("%s:%d:%s funcall_form = %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(funcall_form).c_str() );
+    List_sp form = Cons_O::createList(cl::_sym_lambda, lambda_list, declare_form, funcall_form);
+    // printf("%s:%d:%s assembled form = %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(form).c_str() );
+    func = comp::bytecompile(form, comp::Lexenv_O::make_top_level());
   }
 
   func->setf_sourcePathname(nil<T_O>());
   func->setf_lambdaList(lambda_list); // use this for lambda wrapper
   func->setf_docstring(docStr);
   List_sp names = core::_sym_STARbuiltin_single_dispatch_method_namesSTAR->symbolValue();
-  names = Cons_O::create(name,names);
+  names = Cons_O::create(name, names);
   core::_sym_STARbuiltin_single_dispatch_method_namesSTAR->setf_symbolValue(names);
-  core__ensure_single_dispatch_method(gfn, name, receiver_class, ldeclares, docStr, func );
+  core__ensure_single_dispatch_method(gfn, name, receiver_class, ldeclares, docStr, func);
 }
 
-void lisp_throwIfBuiltInClassesNotInitialized() {
-  _lisp->throwIfBuiltInClassesNotInitialized();
-}
+void lisp_throwIfBuiltInClassesNotInitialized() { _lisp->throwIfBuiltInClassesNotInitialized(); }
 
 Instance_sp lisp_classFromClassSymbol(Symbol_sp classSymbol) {
   return gc::As<Instance_sp>(eval::funcall(cl::_sym_findClass, classSymbol, _lisp->_true()));
@@ -1074,64 +1023,56 @@ Symbol_sp lispify_intern(const string &name, const string &defaultPackageName, b
   return sym;
 }
 
+SYMBOL_EXPORT_SC_(CorePkg, bytecode_wrapper);
 
-SYMBOL_EXPORT_SC_(CorePkg,bytecode_wrapper);
-
-void lisp_bytecode_defun(SymbolFunctionEnum kind,
-                         int bytecodep,
-                         Symbol_sp sym,
-                         const string &packageName,
-                         GlobalSimpleFunBase_sp entry,
-                         const string& arguments,
-                         const string& declares,
-                         const string &docstring,
-                         const string &sourceFile,
-                         int lineNumber,
-                         int numberOfRequiredArguments,
-                         bool autoExport,
-                         const std::set<int> &skipIndices)
-{
-  List_sp lambda_list = lisp_parse_arguments(packageName, arguments,numberOfRequiredArguments,skipIndices);
+void lisp_bytecode_defun(SymbolFunctionEnum kind, int bytecodep, Symbol_sp sym, const string &packageName,
+                         GlobalSimpleFunBase_sp entry, const string &arguments, const string &declares, const string &docstring,
+                         const string &sourceFile, int lineNumber, int numberOfRequiredArguments, bool autoExport,
+                         const std::set<int> &skipIndices) {
+  List_sp lambda_list = lisp_parse_arguments(packageName, arguments, numberOfRequiredArguments, skipIndices);
   bool trivial_wrapper;
-  List_sp vars = lisp_lexical_variable_names( lambda_list, trivial_wrapper );
+  List_sp vars = lisp_lexical_variable_names(lambda_list, trivial_wrapper);
   Function_sp func;
   if (!bytecodep) {
-    printf("%s:%d:%s We don't support LambdaListHandler anymore\n", __FILE__, __LINE__, __FUNCTION__ );
+    printf("%s:%d:%s We don't support LambdaListHandler anymore\n", __FILE__, __LINE__, __FUNCTION__);
     abort();
   } else {
     if (trivial_wrapper) {
       func = entry;
     } else {
-      List_sp funcall_form = Cons_O::create( cleavirPrimop::_sym_funcall, Cons_O::create( entry, vars ));
-      List_sp declare_form = Cons_O::createList( cl::_sym_declare, Cons_O::createList (core::_sym_lambdaName, sym ));
-    //printf("%s:%d:%s funcall_form = %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(funcall_form).c_str() );
-      List_sp form = Cons_O::createList(cl::_sym_lambda,lambda_list,declare_form, funcall_form);
-    //printf("%s:%d:%s assembled form = %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(form).c_str() );
-      func = comp::bytecompile( form,comp::Lexenv_O::make_top_level());
-//    printf("%s:%d:%s compiled a non-trivial wrapper for %s %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(sym).c_str(), _rep_(lambda_list).c_str() );
+      List_sp funcall_form = Cons_O::create(cleavirPrimop::_sym_funcall, Cons_O::create(entry, vars));
+      List_sp declare_form = Cons_O::createList(cl::_sym_declare, Cons_O::createList(core::_sym_lambdaName, sym));
+      // printf("%s:%d:%s funcall_form = %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(funcall_form).c_str() );
+      List_sp form = Cons_O::createList(cl::_sym_lambda, lambda_list, declare_form, funcall_form);
+      // printf("%s:%d:%s assembled form = %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(form).c_str() );
+      func = comp::bytecompile(form, comp::Lexenv_O::make_top_level());
+      //    printf("%s:%d:%s compiled a non-trivial wrapper for %s %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(sym).c_str(),
+      //    _rep_(lambda_list).c_str() );
     }
   }
   func->setSourcePosInfo(SimpleBaseString_O::make(sourceFile), 0, lineNumber, 0);
-  if (kind==symbol_function) {
+  if (kind == symbol_function) {
     sym->setf_symbolFunction(func);
     List_sp names = core::_sym_STARbuiltin_function_namesSTAR->symbolValue();
-    names = Cons_O::create(sym,names);
+    names = Cons_O::create(sym, names);
     core::_sym_STARbuiltin_function_namesSTAR->setf_symbolValue(names);
-  } else if (kind==symbol_function_macro) {
+  } else if (kind == symbol_function_macro) {
     sym->setf_symbolFunction(func);
     sym->setf_macroP(true);
     List_sp names = core::_sym_STARbuiltin_macro_function_namesSTAR->symbolValue();
-    names = Cons_O::create(sym,names);
+    names = Cons_O::create(sym, names);
     core::_sym_STARbuiltin_macro_function_namesSTAR->setf_symbolValue(names);
-  } else if (kind==symbol_function_setf) {
+  } else if (kind == symbol_function_setf) {
     sym->setSetfFdefinition(func);
     List_sp names = core::_sym_STARbuiltin_setf_function_namesSTAR->symbolValue();
-    names = Cons_O::create(sym,names);
+    names = Cons_O::create(sym, names);
     core::_sym_STARbuiltin_setf_function_namesSTAR->setf_symbolValue(names);
   }
-  if (autoExport) sym->exportYourself();
+  if (autoExport)
+    sym->exportYourself();
   T_sp tdocstring = nil<T_O>();
-  if (docstring!="") tdocstring = core::SimpleBaseString_O::make(docstring);
+  if (docstring != "")
+    tdocstring = core::SimpleBaseString_O::make(docstring);
   func->setf_lambdaList(lambda_list);
   func->setf_docstring(tdocstring);
 }
@@ -1154,9 +1095,7 @@ Symbol_sp lisp_intern(const string &name, const string &pkg) {
   return _lisp->internWithPackageName(pkg, name);
 }
 
-string symbol_fullName(Symbol_sp s) {
-  return s->fullName();
-}
+string symbol_fullName(Symbol_sp s) { return s->fullName(); }
 
 void lisp_installGlobalInitializationCallback(InitializationCallback initGlobals) {
   _lisp->installGlobalInitializationCallback(initGlobals);
@@ -1172,11 +1111,13 @@ Symbol_sp lisp_lookupSymbolForEnum(Symbol_sp predefSymId, int enumVal) {
   return converter->symbolForEnumIndex(enumVal);
 }
 
-void lisp_extendSymbolToEnumConverter(SymbolToEnumConverter_sp conv, Symbol_sp const &name, Symbol_sp const &archiveName, int value) {
+void lisp_extendSymbolToEnumConverter(SymbolToEnumConverter_sp conv, Symbol_sp const &name, Symbol_sp const &archiveName,
+                                      int value) {
   conv->addSymbolEnumPair(name, archiveName, value);
 }
 
-void lisp_debugLogWrite(char const *fileName, const char *functionName, uint lineNumber, uint col, const string &fmt_str, uint debugFlags) {
+void lisp_debugLogWrite(char const *fileName, const char *functionName, uint lineNumber, uint col, const string &fmt_str,
+                        uint debugFlags) {
   if (debugFlags == DEBUG_SCRIPT) {
     _lisp->debugLog().beginNode(DEBUG_TOPLEVEL, fileName, functionName, lineNumber, 0, fmt_str);
     _lisp->debugLog().endNode(DEBUG_TOPLEVEL);
@@ -1277,7 +1218,7 @@ string unEscapeWhiteSpace(string const &inp) {
         sout << "\\";
         break;
       default:
-          THROW_HARD_ERROR("Illegal escaped char[%s]", c);
+        THROW_HARD_ERROR("Illegal escaped char[%s]", c);
         break;
       }
     } else {
@@ -1300,13 +1241,9 @@ string trimWhiteSpace(const string &str) {
   return str.substr(startpos, endpos - startpos + 1);
 }
 
-Function_sp lisp_symbolFunction(Symbol_sp sym) {
-  return sym->symbolFunction();
-}
+Function_sp lisp_symbolFunction(Symbol_sp sym) { return sym->symbolFunction(); }
 
-T_sp lisp_symbolValue(Symbol_sp sym) {
-  return sym->symbolValue();
-}
+T_sp lisp_symbolValue(Symbol_sp sym) { return sym->symbolValue(); }
 
 string lisp_symbolNameAsString(Symbol_sp sym) {
   if (sym.nilp())
@@ -1314,68 +1251,65 @@ string lisp_symbolNameAsString(Symbol_sp sym) {
   return sym->symbolNameAsString();
 }
 
-T_sp lisp_createStr(const string &s) {
-  return SimpleBaseString_O::make(s);
-}
+T_sp lisp_createStr(const string &s) { return SimpleBaseString_O::make(s); }
 
-T_sp lisp_createFixnum(int fn) {
-  return make_fixnum(fn);
-}
+T_sp lisp_createFixnum(int fn) { return make_fixnum(fn); }
 
 SourcePosInfo_sp lisp_createSourcePosInfo(const string &fileName, size_t filePos, int lineno) {
   SimpleBaseString_sp fn = SimpleBaseString_O::make(fileName);
   T_mv sfi_mv = core__file_scope(fn);
   FileScope_sp sfi = gc::As<FileScope_sp>(sfi_mv);
-  MultipleValues& mvn = core::lisp_multipleValues();
-  Fixnum_sp handle = gc::As<Fixnum_sp>(mvn.valueGet(1,sfi_mv.number_of_values()));
+  MultipleValues &mvn = core::lisp_multipleValues();
+  Fixnum_sp handle = gc::As<Fixnum_sp>(mvn.valueGet(1, sfi_mv.number_of_values()));
   int sfindex = unbox_fixnum(handle);
   return SourcePosInfo_O::create(sfindex, filePos, lineno, 0);
 }
 
 /*! Create a core:source-pos-info object on the fly */
-SourcePosInfo_sp core__createSourcePosInfo(const string& filename, size_t filePos, int lineno) {
-  return lisp_createSourcePosInfo(filename,filePos,lineno);
+SourcePosInfo_sp core__createSourcePosInfo(const string &filename, size_t filePos, int lineno) {
+  return lisp_createSourcePosInfo(filename, filePos, lineno);
 }
 
-  
 T_sp lisp_createList(T_sp a1) { return Cons_O::create(a1, nil<T_O>()); }
 T_sp lisp_createList(T_sp a1, T_sp a2) { return Cons_O::createList(a1, a2); };
 T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3) { return Cons_O::createList(a1, a2, a3); };
 T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4) { return Cons_O::createList(a1, a2, a3, a4); };
 T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5) { return Cons_O::createList(a1, a2, a3, a4, a5); };
 T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5, T_sp a6) { return Cons_O::createList(a1, a2, a3, a4, a5, a6); };
-T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5, T_sp a6, T_sp a7) { return Cons_O::createList(a1, a2, a3, a4, a5, a6, a7); }
-T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5, T_sp a6, T_sp a7, T_sp a8) { return Cons_O::createList(a1, a2, a3, a4, a5, a6, a7, a8); }
-
-[[noreturn]] void lisp_error_no_stamp(void* ptr)
-{
-  gctools::Header_s* header = reinterpret_cast<gctools::Header_s*>(gctools::GeneralPtrToHeaderPtr(ptr));
-  SIMPLE_ERROR(("This General_O object %p does not return a stamp because its subclass should overload get_stamp_() and return one  - the subclass header stamp value is %lu") , ((void*)ptr) , header->_badge_stamp_wtag_mtag.stamp_());
+T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5, T_sp a6, T_sp a7) {
+  return Cons_O::createList(a1, a2, a3, a4, a5, a6, a7);
+}
+T_sp lisp_createList(T_sp a1, T_sp a2, T_sp a3, T_sp a4, T_sp a5, T_sp a6, T_sp a7, T_sp a8) {
+  return Cons_O::createList(a1, a2, a3, a4, a5, a6, a7, a8);
 }
 
-void lisp_errorCannotAllocateInstanceWithMissingDefaultConstructor(T_sp aclass_symbol)
-{
+[[noreturn]] void lisp_error_no_stamp(void *ptr) {
+  gctools::Header_s *header = reinterpret_cast<gctools::Header_s *>(gctools::GeneralPtrToHeaderPtr(ptr));
+  SIMPLE_ERROR(("This General_O object %p does not return a stamp because its subclass should overload get_stamp_() and return one "
+                " - the subclass header stamp value is %lu"),
+               ((void *)ptr), header->_badge_stamp_wtag_mtag.stamp_());
+}
+
+void lisp_errorCannotAllocateInstanceWithMissingDefaultConstructor(T_sp aclass_symbol) {
   ASSERT(aclass_symbol);
   Symbol_sp cclassSymbol = aclass_symbol.as<Symbol_O>();
-  SIMPLE_ERROR(("You cannot allocate a %s with no arguments because it is missing a default constructor") , _rep_(cclassSymbol));
+  SIMPLE_ERROR(("You cannot allocate a %s with no arguments because it is missing a default constructor"), _rep_(cclassSymbol));
 }
-void lisp_errorExpectedTypeSymbol(Symbol_sp typeSym, T_sp datum) {
-  TYPE_ERROR(datum, typeSym);
-}
+void lisp_errorExpectedTypeSymbol(Symbol_sp typeSym, T_sp datum) { TYPE_ERROR(datum, typeSym); }
 
 #define MAX_SPRINTF_BUFFER 1024
-[[noreturn]]void lisp_error_sprintf(const char* fileName, int lineNumber, const char* functionName, const char* fmt, ... ) {
+[[noreturn]] void lisp_error_sprintf(const char *fileName, int lineNumber, const char *functionName, const char *fmt, ...) {
   va_list args;
-  va_start(args,fmt);
+  va_start(args, fmt);
   char buffer[MAX_SPRINTF_BUFFER];
-  vsnprintf(buffer,MAX_SPRINTF_BUFFER,fmt,args);
+  vsnprintf(buffer, MAX_SPRINTF_BUFFER, fmt, args);
   va_end(args);
   stringstream ss;
   ss << "In " << functionName << " " << fileName << " line " << lineNumber << std::endl;
   ss << buffer;
   if (!_sym_signalSimpleError) {
     printf("%s:%d %s\n", __FILE__, __LINE__, ss.str().c_str());
-    throw(HardError("System starting up - debugger not available yet: "+ss.str()));
+    throw(HardError("System starting up - debugger not available yet: " + ss.str()));
   }
   if (!_sym_signalSimpleError->fboundp()) {
     printf("%s:%d %s\n", __FILE__, __LINE__, ss.str().c_str());
@@ -1384,14 +1318,12 @@ void lisp_errorExpectedTypeSymbol(Symbol_sp typeSym, T_sp datum) {
   }
   SYMBOL_EXPORT_SC_(ClPkg, programError);
   eval::funcall(_sym_signalSimpleError,
-                core::_sym_simpleProgramError,    //arg0
-                nil<T_O>(),              // arg1
+                core::_sym_simpleProgramError,    // arg0
+                nil<T_O>(),                       // arg1
                 SimpleBaseString_O::make(buffer), // arg2
                 nil<T_O>());
   UNREACHABLE();
 }
-
-
 
 DONT_OPTIMIZE_ALWAYS
 NOINLINE void lisp_error_simple(const char *functionName, const char *fileName, int lineNumber, const string &fmt) {
@@ -1400,7 +1332,7 @@ NOINLINE void lisp_error_simple(const char *functionName, const char *fileName, 
   ss << fmt;
   if (!_sym_signalSimpleError) {
     printf("%s:%d %s\n", __FILE__, __LINE__, ss.str().c_str());
-    throw(HardError("System starting up - debugger not available yet: "+ss.str()));
+    throw(HardError("System starting up - debugger not available yet: " + ss.str()));
   }
   if (!_sym_signalSimpleError->fboundp()) {
     printf("%s:%d %s\n", __FILE__, __LINE__, ss.str().c_str());
@@ -1409,13 +1341,11 @@ NOINLINE void lisp_error_simple(const char *functionName, const char *fileName, 
   }
   SYMBOL_EXPORT_SC_(ClPkg, programError);
   eval::funcall(_sym_signalSimpleError,
-                core::_sym_simpleProgramError,    //arg0
-                nil<T_O>(),              // arg1
-                SimpleBaseString_O::make("~a"),
-                core::Cons_O::createList(SimpleBaseString_O::make(fmt)));
+                core::_sym_simpleProgramError, // arg0
+                nil<T_O>(),                    // arg1
+                SimpleBaseString_O::make("~a"), core::Cons_O::createList(SimpleBaseString_O::make(fmt)));
   UNREACHABLE();
 }
-
 
 [[noreturn]] void lisp_error(T_sp datum, T_sp arguments) {
   if (!cl::_sym_error->fboundp()) {
@@ -1424,27 +1354,27 @@ NOINLINE void lisp_error_simple(const char *functionName, const char *fileName, 
     printf("%s:%d lisp_error ->\n %s\n", __FILE__, __LINE__, ss.str().c_str());
     early_debug(nil<T_O>(), false);
   }
-  core__apply1( coerce::functionDesignator(cl::_sym_error), arguments, datum);
+  core__apply1(coerce::functionDesignator(cl::_sym_error), arguments, datum);
   UNREACHABLE();
 }
 
 string stringUpper(const string &s) {
-  LOG("Converting string(%s) to uppercase" , s);
+  LOG("Converting string(%s) to uppercase", s);
   stringstream ss;
   for (uint si = 0; si < s.length(); si++) {
     ss << (char)(char_upcase(s[si]));
   }
-  LOG("Returning stringUpper(%s)" , ss.str());
+  LOG("Returning stringUpper(%s)", ss.str());
   return ss.str();
 }
 
 string stringUpper(const char *s) {
-  LOG("Converting const char*(%s) to uppercase" , s);
+  LOG("Converting const char*(%s) to uppercase", s);
   stringstream ss;
   for (; *s; s++) {
     ss << (char)(char_upcase(*s));
   }
-  LOG("Returning stringUpper(%s)" , ss.str());
+  LOG("Returning stringUpper(%s)", ss.str());
   return ss.str();
 }
 
@@ -1455,10 +1385,8 @@ vector<string> split(const string &str, const string &delimiters) {
 }
 
 /*! DONT PUT DEBUGGING CODE IN TOKENIZE!!!!  IT IS USED BY DebugStream
-     */
-void tokenize(const string &str,
-              vector<string> &tokens,
-              const string &delimiters) {
+ */
+void tokenize(const string &str, vector<string> &tokens, const string &delimiters) {
   tokens.erase(tokens.begin(), tokens.end());
   // Skip delimiters at beginning.
   string::size_type lastPos = str.find_first_not_of(delimiters, 0);
@@ -1485,9 +1413,7 @@ string searchAndReplaceString(const string &str, const string &search, const str
   return result;
 }
 
-void queueSplitString(const string &str,
-                      std::queue<string> &tokens,
-                      const string &delimiters) {
+void queueSplitString(const string &str, std::queue<string> &tokens, const string &delimiters) {
   //    LOG("foundation.cc::tokenize-- Entered" );
   // Skip delimiters at beginning.
   string::size_type lastPos = str.find_first_not_of(delimiters, 0);
@@ -1510,8 +1436,7 @@ void queueSplitString(const string &str,
 //
 //	Return true if it matches and false if it doesn't
 //
-bool wildcmp(string const &sWild,
-             string const &sRegular) {
+bool wildcmp(string const &sWild, string const &sRegular) {
   const char *wild, *mp, *cp;
   const char *regular;
 
@@ -1591,8 +1516,7 @@ void throwIfClassesNotInitialized(const LispPtr &lisp) {
   }
 }
 
-};
-
+}; // namespace core
 
 extern "C" {
 size_t global_drag_native_calls_delay = 0;
@@ -1602,36 +1526,34 @@ size_t global_drag_cons_allocation_delay = 0;
 size_t global_drag_general_allocation_delay = 0;
 
 void drag_native_calls() {
-  for (size_t ii=0; ii<global_drag_native_calls_delay; ii++ ) {
+  for (size_t ii = 0; ii < global_drag_native_calls_delay; ii++) {
     drag_delay();
   }
 };
 
 void drag_cxx_calls() {
-  for (size_t ii=0; ii<global_drag_cxx_calls_delay; ii++ ) {
+  for (size_t ii = 0; ii < global_drag_cxx_calls_delay; ii++) {
     drag_delay();
   }
 };
 
 void drag_interpret_dtree() {
-  for (size_t ii=0; ii<global_drag_interpret_dtree_delay; ii++ ) {
+  for (size_t ii = 0; ii < global_drag_interpret_dtree_delay; ii++) {
     drag_delay();
   }
 };
 
 void drag_cons_allocation() {
-  for (size_t ii=0; ii<global_drag_cons_allocation_delay; ii++ ) {
+  for (size_t ii = 0; ii < global_drag_cons_allocation_delay; ii++) {
     drag_delay();
   }
 };
-
 
 void drag_general_allocation() {
-  for (size_t ii=0; ii<global_drag_general_allocation_delay; ii++ ) {
+  for (size_t ii = 0; ii < global_drag_general_allocation_delay; ii++) {
     drag_delay();
   }
 };
-
 };
 
 namespace core {
@@ -1671,15 +1593,12 @@ CL_DEFUN void core__set_drag_general_allocation_delay(size_t num) {
 #endif
 };
 
-};
-
-
-
+}; // namespace core
 
 namespace core {
 
 uint32_t lisp_general_badge(General_sp object) {
-  const gctools::Header_s* header = gctools::header_pointer(object.unsafe_general());
+  const gctools::Header_s *header = gctools::header_pointer(object.unsafe_general());
   if (header->_badge_stamp_wtag_mtag._header_badge == gctools::BaseHeader_s::BadgeStampWtagMtag::NoBadge) {
     header->_badge_stamp_wtag_mtag._header_badge = lisp_calculate_heap_badge();
   }
@@ -1687,7 +1606,7 @@ uint32_t lisp_general_badge(General_sp object) {
 }
 
 uint32_t lisp_cons_badge(Cons_sp object) {
-  const gctools::Header_s* header = (gctools::Header_s*)gctools::ConsPtrToHeaderPtr(object.unsafe_cons());
+  const gctools::Header_s *header = (gctools::Header_s *)gctools::ConsPtrToHeaderPtr(object.unsafe_cons());
   if (header->_badge_stamp_wtag_mtag._header_badge == gctools::BaseHeader_s::BadgeStampWtagMtag::NoBadge) {
     header->_badge_stamp_wtag_mtag._header_badge = lisp_calculate_heap_badge();
   }
@@ -1700,46 +1619,40 @@ uint32_t lisp_badge(T_sp object) {
     return lisp_cons_badge(cobject);
   } else if (object.generalp()) {
     return lisp_general_badge(gc::As_unsafe<General_sp>(object));
-  } else return 0;
-}
-
-
-DOCGROUP(clasp);
-CL_DEFUN size_t core__get_badge(T_sp object)
-{
-  return lisp_badge(object);
+  } else
+    return 0;
 }
 
 DOCGROUP(clasp);
-CL_DEFUN void core__set_badge(T_sp object, size_t badge)
-{
+CL_DEFUN size_t core__get_badge(T_sp object) { return lisp_badge(object); }
+
+DOCGROUP(clasp);
+CL_DEFUN void core__set_badge(T_sp object, size_t badge) {
   if (object.consp()) {
-    gctools::Header_s* header = reinterpret_cast<gctools::Header_s*>(gctools::ConsPtrToHeaderPtr(object.unsafe_cons()));
+    gctools::Header_s *header = reinterpret_cast<gctools::Header_s *>(gctools::ConsPtrToHeaderPtr(object.unsafe_cons()));
     header->_badge_stamp_wtag_mtag._header_badge = badge;
     return;
   } else if (object.generalp()) {
-    gctools::Header_s* header = const_cast<gctools::Header_s*>(gctools::header_pointer(object.unsafe_general()));
+    gctools::Header_s *header = const_cast<gctools::Header_s *>(gctools::header_pointer(object.unsafe_general()));
     header->_badge_stamp_wtag_mtag._header_badge = badge;
   }
 }
 
-
-
-uint32_t lisp_calculate_heap_badge()
-{
-  if (!my_thread) return 123456;
+uint32_t lisp_calculate_heap_badge() {
+  if (!my_thread)
+    return 123456;
   return my_thread->random();
 }
 
-};
+}; // namespace core
 
 size_t global_pointerCount = 0;
 size_t global_goodPointerCount = 0;
 std::set<std::string> global_mangledSymbols;
 std::set<uintptr_t> global_addresses;
-snapshotSaveLoad::SymbolLookup* global_SymbolLookup = NULL;
+snapshotSaveLoad::SymbolLookup *global_SymbolLookup = NULL;
 
-void maybe_register_symbol_using_dladdr_ep(void* functionPointer, size_t size, const std::string& name, size_t arityCode ) {
+void maybe_register_symbol_using_dladdr_ep(void *functionPointer, size_t size, const std::string &name, size_t arityCode) {
 #if 0
   if (name=="BUILD-ASTS") {
     printf("%s:%d:%s Registering BUILD-ASTS function with %s:%lu functionPointer = %p\n", __FILE__, __LINE__, __FUNCTION__, name.c_str(), arityCode, functionPointer );
@@ -1754,38 +1667,48 @@ void maybe_register_symbol_using_dladdr_ep(void* functionPointer, size_t size, c
       global_SymbolLookup = new snapshotSaveLoad::SymbolLookup();
       global_SymbolLookup->addAllLibraries();
     }
-    if (global_addresses.count((uintptr_t)functionPointer) == 0 ) {
-      if ((uintptr_t)functionPointer < 1024) return; // This means it's a virtual method.
+    if (global_addresses.count((uintptr_t)functionPointer) == 0) {
+      if ((uintptr_t)functionPointer < 1024)
+        return; // This means it's a virtual method.
       global_pointerCount++;
       Dl_info info;
 #if defined(_TARGET_OS_LINUX)
-      const Elf64_Sym* extra_info;
-      int ret = dladdr1( functionPointer, &info, (void**)&extra_info, RTLD_DL_SYMENT );
+      const Elf64_Sym *extra_info;
+      int ret = dladdr1(functionPointer, &info, (void **)&extra_info, RTLD_DL_SYMENT);
 #else
-      int ret = dladdr( functionPointer, &info );
+      int ret = dladdr(functionPointer, &info);
 #endif
       bool system_dladdr_had_problem = false;
-      if ( ret == 0 ) {
-        printf("%s:%d %lu/%lu FAIL system dladdr returned 0x0 for %s\n", __FILE__, __LINE__, (global_pointerCount-global_goodPointerCount), global_pointerCount, name.c_str());
+      if (ret == 0) {
+        printf("%s:%d %lu/%lu FAIL system dladdr returned 0x0 for %s\n", __FILE__, __LINE__,
+               (global_pointerCount - global_goodPointerCount), global_pointerCount, name.c_str());
         system_dladdr_had_problem = true;
       } else if (!info.dli_sname) {
-        printf("%s:%d %lu/%lu FAIL system dladdr could not find a symbol to match %p of %s\n", __FILE__, __LINE__, (global_pointerCount-global_goodPointerCount), global_pointerCount, functionPointer, name.c_str());
+        printf("%s:%d %lu/%lu FAIL system dladdr could not find a symbol to match %p of %s\n", __FILE__, __LINE__,
+               (global_pointerCount - global_goodPointerCount), global_pointerCount, functionPointer, name.c_str());
         system_dladdr_had_problem = true;
       } else if (info.dli_saddr != functionPointer) {
-        printf("%s:%d %lu/%lu FAIL system dladdr could not find exact match to %p - found %p of %s\n", __FILE__, __LINE__, (global_pointerCount-global_goodPointerCount), global_pointerCount, functionPointer, info.dli_saddr, name.c_str());
+        printf("%s:%d %lu/%lu FAIL system dladdr could not find exact match to %p - found %p of %s\n", __FILE__, __LINE__,
+               (global_pointerCount - global_goodPointerCount), global_pointerCount, functionPointer, info.dli_saddr, name.c_str());
         system_dladdr_had_problem = true;
-      } else if (dlsym( RTLD_DEFAULT, info.dli_sname ) == 0 ) {
-        printf("%s:%d %lu/%lu WARNING system dlsym could not find name %s - I'm going to add it anyway - if this works - remove this message\n", __FILE__, __LINE__, (global_pointerCount-global_goodPointerCount), global_pointerCount, info.dli_sname );
+      } else if (dlsym(RTLD_DEFAULT, info.dli_sname) == 0) {
+        printf("%s:%d %lu/%lu WARNING system dlsym could not find name %s - I'm going to add it anyway - if this works - remove "
+               "this message\n",
+               __FILE__, __LINE__, (global_pointerCount - global_goodPointerCount), global_pointerCount, info.dli_sname);
       }
       std::string claspDladdrName;
-      if ( !global_SymbolLookup->lookupAddr((uintptr_t)functionPointer, claspDladdrName ) ) {
-        printf("%s:%d:%s FAIL Clasp's dladdr could not find a symbol for the address %p for name %s - THIS WILL BREAK save-lisp-and-die\n", __FILE__, __LINE__, __FUNCTION__, (void*)functionPointer, name.c_str());
+      if (!global_SymbolLookup->lookupAddr((uintptr_t)functionPointer, claspDladdrName)) {
+        printf("%s:%d:%s FAIL Clasp's dladdr could not find a symbol for the address %p for name %s - THIS WILL BREAK "
+               "save-lisp-and-die\n",
+               __FILE__, __LINE__, __FUNCTION__, (void *)functionPointer, name.c_str());
       } else {
         if (system_dladdr_had_problem) {
-          printf("%s:%d:%s   The system dladdr had a problem but clasp's dladdr found the symbol - the clasp dladdr name is: %s\n", __FILE__, __LINE__, __FUNCTION__, claspDladdrName.c_str() );
+          printf("%s:%d:%s   The system dladdr had a problem but clasp's dladdr found the symbol - the clasp dladdr name is: %s\n",
+                 __FILE__, __LINE__, __FUNCTION__, claspDladdrName.c_str());
         }
       }
-      if (system_dladdr_had_problem) return;
+      if (system_dladdr_had_problem)
+        return;
       global_mangledSymbols.insert(info.dli_sname);
       global_goodPointerCount++;
       global_addresses.insert((uintptr_t)functionPointer);
@@ -1794,8 +1717,8 @@ void maybe_register_symbol_using_dladdr_ep(void* functionPointer, size_t size, c
   }
 }
 
-void maybe_register_symbol_using_dladdr(void* functionPointer, size_t size, const std::string& name, size_t arityCode ) {
-  maybe_register_symbol_using_dladdr_ep(functionPointer,size,name,arityCode);
+void maybe_register_symbol_using_dladdr(void *functionPointer, size_t size, const std::string &name, size_t arityCode) {
+  maybe_register_symbol_using_dladdr_ep(functionPointer, size, name, arityCode);
 }
 
 namespace core {
@@ -1804,33 +1727,36 @@ DOCGROUP(clasp);
 CL_DEFUN void core__mangledSymbols(T_sp stream_designator) {
   T_sp stream = coerce::outputStreamDesignator(stream_designator);
   write_bf_stream(fmt::sprintf("# Dumping %lu mangled function names\n", global_mangledSymbols.size()), stream);
-  for ( auto entry : ::global_mangledSymbols ) {
+  for (auto entry : ::global_mangledSymbols) {
 #ifdef _TARGET_OS_DARWIN
-    clasp_write_char('_',stream);
+    clasp_write_char('_', stream);
 #endif
-    clasp_write_string(entry,stream);
+    clasp_write_string(entry, stream);
     clasp_terpri(stream);
   }
   if (comp::_sym_STARprimitivesSTAR.boundp() && comp::_sym_STARprimitivesSTAR->symbolValue().notnilp()) {
     List_sp keys = gc::As<HashTable_sp>(comp::_sym_STARprimitivesSTAR->symbolValue())->keysAsCons();
-    for ( auto cur : keys ) {
-      T_sp key = CONS_CAR(cur);      
-      clasp_write_char('_',stream);
-      clasp_write_string(gc::As<String_sp>(key)->get_std_string(),stream);
+    for (auto cur : keys) {
+      T_sp key = CONS_CAR(cur);
+      clasp_write_char('_', stream);
+      clasp_write_string(gc::As<String_sp>(key)->get_std_string(), stream);
       clasp_terpri(stream);
     }
   }
-  clasp_write_string("__mh_execute_header",stream); clasp_terpri(stream);
-  clasp_write_string("_cc_throw",stream); clasp_terpri(stream);
-  clasp_write_string("_llvm_orc_registerJITLoaderGDBWrapper",stream); clasp_terpri(stream);
-  clasp_write_string("___jit_debug_descriptor",stream); clasp_terpri(stream);
-  clasp_write_string("___jit_debug_register_code",stream); clasp_terpri(stream);
-//  clasp_write_string("_start_of_snapshot",stream); clasp_terpri(stream);
-//  clasp_write_string("_end_of_snapshot",stream); clasp_terpri(stream);
-  clasp_write_string("__ZTIN4core6UnwindE",stream);
+  clasp_write_string("__mh_execute_header", stream);
+  clasp_terpri(stream);
+  clasp_write_string("_cc_throw", stream);
+  clasp_terpri(stream);
+  clasp_write_string("_llvm_orc_registerJITLoaderGDBWrapper", stream);
+  clasp_terpri(stream);
+  clasp_write_string("___jit_debug_descriptor", stream);
+  clasp_terpri(stream);
+  clasp_write_string("___jit_debug_register_code", stream);
+  clasp_terpri(stream);
+  //  clasp_write_string("_start_of_snapshot",stream); clasp_terpri(stream);
+  //  clasp_write_string("_end_of_snapshot",stream); clasp_terpri(stream);
+  clasp_write_string("__ZTIN4core6UnwindE", stream);
   clasp_terpri(stream);
 };
 
-};
-
-
+}; // namespace core

--- a/src/koga/configure.lisp
+++ b/src/koga/configure.lisp
@@ -912,6 +912,9 @@ the function to the overall configuration."
   "Configure a library with the current configuration state."
   (apply #'configure-library *configuration* rest))
 
+(defun framework (name)
+  (append-ldlibs *configuration* (format nil "-framework ~a" name)))
+
 (defun includes (&rest paths)
   "Add C include directories to the current configuration."
   (let ((*root-paths* (list* :build #P""

--- a/src/koga/packages.lisp
+++ b/src/koga/packages.lisp
@@ -4,6 +4,7 @@
   (:documentation "A lisp based metabuilder for Clasp.")
   (:export #:configure
            #:*extensions*
+           #:framework
            #:help
            #:includes
            #:library


### PR DESCRIPTION
- Add noAutoExport and setf policy
- Add frameworks for Darwin
- Remove unused function declaration functions

The first commit has the changes. Second commit is just clang-format.