### PR TITLE
Fix #1382

### DIFF
--- a/src/lisp/kernel/cleavir/representation-selection.lisp
+++ b/src/lisp/kernel/cleavir/representation-selection.lisp
@@ -668,14 +668,12 @@
 (defmethod insert-casts ((instruction bir:local-call))
   ;; KLUDGE: For now, we only consider required arguments as being
   ;; possible to pass unboxed.
-  (loop with requiredp = t
-        for item in (bir:lambda-list (bir:callee instruction))
-        for arg in (rest (bir:inputs instruction))
-        unless (typep item 'bir:argument)
-          do (setf requiredp nil)
-        do (maybe-cast-before instruction arg (if requiredp
-                                                  (cc-bmir:rtype item)
-                                                  '(:object))))
+  (let ((args (rest (bir:inputs instruction))))
+    (loop for item in (bir:lambda-list (bir:callee instruction))
+          while (typep item 'bir:argument)
+          do (maybe-cast-before instruction (pop args) (cc-bmir:rtype item)))
+    (loop until (null args)
+          do (maybe-cast-before instruction (pop args) '(:object))))
   (cast-local-call-output instruction))
 (defmethod insert-casts ((instruction bir:mv-local-call))
   (let* ((inputs (bir:inputs instruction))

--- a/src/lisp/regression-tests/misc.lisp
+++ b/src/lisp/regression-tests/misc.lisp
@@ -267,3 +267,11 @@
                                (ignore-errors (>= x (the real nil))))))
                0)
       (nil))
+
+(test issue-1382
+      (nth-value 2
+                 (compile nil
+                          '(lambda ()
+                            ((lambda (&key x y z) (list x y z))
+                             :x 0s0 :y 0s0 :z (coerce (random 100) 'single-float)))))
+      (nil))


### PR DESCRIPTION
The iteration in insert-casts for local-call ended early sometimes, since for e.g. keyword parameters there are more arguments than the lambda list has elements.