### PR TITLE
Repair compiler-macros used with funcall forms

### DIFF
--- a/src/lisp/kernel/lsp/evalmacros.lisp
+++ b/src/lisp/kernel/lsp/evalmacros.lisp
@@ -168,7 +168,7 @@ VARIABLE doc and can be retrieved by (DOCUMENTATION 'SYMBOL 'VARIABLE)."
             (eq (car (cadr form)) 'cl:function)
             (let ((expander (compiler-macro-function (cadr (cadr form)) env)))
               (if expander
-                  (funcall *macroexpand-hook* expander (cons (cadr (cadr form)) (cddr form)) env)
+                  (funcall *macroexpand-hook* expander form env)
                   form)))
        (let ((expander (compiler-macro-function (car form) env)))
          (if expander

--- a/src/lisp/regression-tests/environment01.lisp
+++ b/src/lisp/regression-tests/environment01.lisp
@@ -13,12 +13,14 @@
       (* arg 2)
       form))
 
-(test-true DOCUMENTATION.LIST.COMPILER-MACRO.2
-           (let ((doc "Buh"))
-             (setf (documentation '%%test%% 'compiler-macro) doc)
-             (string= doc (documentation '%%test%% 'compiler-macro))))
+(test DOCUMENTATION.LIST.COMPILER-MACRO.2
+      (progn (setf (documentation '%%test%% 'compiler-macro) "Buh")
+             (documentation '%%test%% 'compiler-macro))
+      ("Buh"))
 
-;;; (funcall (compiler-macro-function '%%test%%) '(%%test%% 2) nil)
-
+(test funcall-compiler-macro
+      (funcall (compiler-macro-function '%%test%%)
+               '(funcall #'%%test%% 2) nil)
+      (4))
 
 


### PR DESCRIPTION
I accidentally broke this when I put in the fancy names.

This change also simplifies compiler-macroexpand-1 into just calling the cmf without taking apart a funcall form, because the compiler macroexpander function itself needs to be able to do that and if c-m-1 does it masks this problem.