### PR TITLE
Update print-unreadable-object

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,8 @@
   replaced with options to specify image or snapshot file (`--image` or
   `--snapshot`) and `--base` option for loading base image when extensions
   are present.
+* `print-unreadable-object` now prints qualified symbols for the `:type t`
+  option and uses `pprint-logical-block` when pretty printing.
   
 ## Fixes
 * `ext:run-program` works with string streams.

--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -646,7 +646,7 @@ void clasp_write_characters(const char *buf, int sz, T_sp strm);
  void writestr_stream(const char *str, T_sp strm = cl::_sym_STARstandard_outputSTAR->symbolValue());
 void write_bf_stream(const std::string& fmt, T_sp strm = cl::_sym_STARstandard_outputSTAR->symbolValue());
 void writeln_bf_stream(const std::string& fmt, T_sp strm = cl::_sym_STARstandard_outputSTAR->symbolValue());
- void clasp_write_addr(T_sp x, T_sp strm);
+void core__write_addr(T_sp x, T_sp strm);
 claspCharacter clasp_write_char(claspCharacter c, T_sp strm);
 
 

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -5069,7 +5069,11 @@ void writeln_bf_stream(const std::string& fmt, T_sp strm)
   clasp_terpri(strm);
 }
 
-void clasp_write_addr(T_sp x, T_sp strm) {
+CL_LAMBDA(oject stream);
+CL_DECLARE();
+CL_DOCSTRING("Write the address of an object to the stream.");
+DOCGROUP(clasp);
+CL_DEFUN void core__write_addr(T_sp x, T_sp strm) {
   stringstream ss;
   ss << (void *)x.raw_();
   writestr_stream(ss.str().c_str(), strm);

--- a/src/core/print.cc
+++ b/src/core/print.cc
@@ -177,44 +177,6 @@ CL_DEFUN T_sp cl__write(T_sp x, T_sp strm, T_sp array, T_sp base,
   return Values(x);
 };
 
-
-CL_LAMBDA(o stream type id function);
-CL_DECLARE();
-CL_DOCSTRING(R"dx(print-unreadable-object-function: What CL:PRINT-UNREADABLE-OBJECT expands into.)dx");
-DOCGROUP(clasp);
-CL_DEFUN T_sp core__print_unreadable_object_function(T_sp object, T_sp output_stream_desig, T_sp type, T_sp id, T_sp function) {
-  if (clasp_print_readably()) {
-    PRINT_NOT_READABLE_ERROR(object);
-  } else if (object.unboundp()) {
-    SIMPLE_ERROR(("Error! printUnreadableObjectFunction object is Unbound"));
-  } else {
-    stringstream ss;
-    ss << "#<";
-    if (type.notnilp()) {
-      type = cl__type_of(object);
-      if (!gc::IsA<Symbol_sp>(type)) {
-        type = cl::_sym_standard_object;
-      }
-      Symbol_sp typesym = gc::As<Symbol_sp>(type);
-      ss << typesym->symbolNameAsString();
-      ss << " ";
-    }
-    T_sp ostream = coerce::outputStreamDesignator(output_stream_desig);
-    clasp_write_string(ss.str(), ostream);
-    if (function.notnilp()) {
-      eval::funcall(function);
-    }
-    stringstream stail;
-    if (id.notnilp()) {
-      stail << " @";
-      stail << object.raw_();
-    }
-    stail << ">";
-    clasp_write_string(stail.str(), ostream);
-  }
-  return nil<T_O>();
-};
-
 CL_LAMBDA(obj &optional stream);
 CL_DECLARE();
 CL_DOCSTRING(R"dx(pprint)dx");

--- a/src/lisp/kernel/clos/print.lisp
+++ b/src/lisp/kernel/clos/print.lisp
@@ -280,6 +280,10 @@ printer and we should rather use MAKE-LOAD-FORM."
     (write-string ")" stream)
     obj))
 
+(defmethod print-object ((object standard-object) stream)
+  (print-unreadable-object (object stream :type t :identity t))
+  object)
+
 #-staging
 (defmethod print-object ((l cons) stream)
   (if (cdr l)

--- a/src/lisp/kernel/lsp/pprint.lisp
+++ b/src/lisp/kernel/lsp/pprint.lisp
@@ -1213,3 +1213,18 @@
 			:key #'pprint-dispatch-entry-type
 			:test #'equal))))
   nil)
+
+;;; The guts of print-unreadable-object, inspired by SBCL. This is
+;;; a redefinition of the function in iolib.lisp which add support
+;;; for pprint-logical-block.
+(defun %print-unreadable-object (object stream type identity body)
+  (cond (*print-readably*
+         (error 'print-not-readable :object object))
+        ((and *print-pretty* (pretty-stream-p stream))
+         (pprint-logical-block (stream nil :prefix "#<" :suffix ">")
+           (print-unreadable-object-contents object stream type identity body)))
+        (t
+         (write-string "#<" stream)
+         (print-unreadable-object-contents object stream type identity body)
+         (write-char #\> stream)))
+  nil)


### PR DESCRIPTION
There several places in Cando that do this kind of thing:

```lisp
(defmethod print-object ((o fu:bar) s)
  (print-unreadable-object (o s :identity t)
    (write-string "FU:BAR" s))
  o)
```

The current PRINT-UNREADABLE-OBJECT is in C and doesn't really respect the various print dynamic variables or the current package when printing the type. Also, SBCL uses PPRINT-LOGICAL-BLOCK to print the #< ,,, > block when pretty printing, which is kind of cool. To resolve both of these issues I've moved the guts of PRINT-UNREADABLE-OBJECT into Lisp and now methods like the above that exist just to print a qualified type name aren't needed.

# Changes
- properly print qualified type names
- use pprint-logical-block when pretty printing