### PR TITLE
fix accessor mp problem

### DIFF
--- a/src/lisp/kernel/clos/boot.lisp
+++ b/src/lisp/kernel/clos/boot.lisp
@@ -113,7 +113,7 @@
     (let* ((location-table (make-hash-table :size (if slots 24 0)))
            (direct-slot-class (find-class 'standard-direct-slot-definition nil))
 	   (direct-slots (loop for slotd in slots
-                               collect (apply #'make-simple-slotd direct-slot-class slotd)))
+                               collect (apply #'make-simple-direct-slotd direct-slot-class slotd)))
            (effective-slot-class (find-class 'standard-effective-slot-definition nil))
 	   (effective-slots (loop for i fixnum from 0
                                   for slotd in slots

--- a/src/lisp/kernel/clos/effective-accessor.lisp
+++ b/src/lisp/kernel/clos/effective-accessor.lisp
@@ -39,55 +39,95 @@
                (slot-unbound (class-of object) object slot-name)
                val))))))
 
-;;; Hash tables from (direct-slotd . location) to methods.
-;;; This is important so that comparing methods to get identical
-;;; effective methods works.
-;;; FIXME: Should be weak-value.
-(defvar *cached-effective-readers* (make-hash-table :test #'equal :thread-safe t))
-(defvar *cached-effective-writers* (make-hash-table :test #'equal :thread-safe t))
+;;; moved here for bootstrapping reasons.
+;;; functions are defined a bit later in slotvalue.lisp.
+#+threads
+(mp:define-atomic-expander slot-value-using-class (class object slotd)
+  (&rest keys)
+  "Same requirements as STANDARD-INSTANCE-ACCESS, except the slot can have
+allocation :class.
+Also, methods on SLOT-VALUE-USING-CLASS, SLOT-BOUNDP-USING-CLASS, and
+(SETF SLOT-VALUE-USING-CLASS) are ignored (not invoked).
+In the future, the CAS behavior may be customizable with a generic function."
+  (declare (ignore keys))
+  (let ((gclass (gensym "CLASS")) (gobject (gensym "OBJECT"))
+        (gslotd (gensym "SLOTD")) (oldv (gensym "OLD")) (newv (gensym "NEWV")))
+    (values (list gclass gobject gslotd) (list class object slotd) oldv newv
+            `(atomic-slot-value-using-class ,gclass ,gobject ,gslotd)
+            `(setf (atomic-slot-value-using-class ,gclass ,gobject ,gslotd)
+                   ,newv)
+            `(cas-slot-value-using-class ,oldv ,newv
+                                         ,gclass ,gobject ,gslotd))))
+
+;;; These can be called (through final-methods) from many threads simultaneously
+;;; and so must be thread-safe.
 
 (defun intern-effective-reader (method location)
-  (let* ((direct-slotd (accessor-method-slot-definition method))
-         (key (cons direct-slotd location)))
-    (or (gethash key *cached-effective-readers*)
-        (setf (gethash key *cached-effective-readers*)
-              (make-effective-accessor-method
-               (find-class 'effective-reader-method)
-               method location
-               (make-effective-reader-function
-                location (slot-definition-name direct-slotd)))))))
+  (loop with direct-slotd = (accessor-method-slot-definition method)
+        for table = (mp:atomic (slot-value direct-slotd '%effective-readers))
+        for existing = (cdr (assoc location table))
+        when existing
+          return existing
+        do (let ((eff
+                   (make-effective-accessor-method
+                    (find-class 'effective-reader-method)
+                    method location
+                    (make-effective-reader-function
+                     location (slot-definition-name direct-slotd)))))
+             (when (eq (mp:cas (slot-value direct-slotd '%effective-readers)
+                               table (acons location eff table))
+                       table)
+               (return eff)))))
 
 (defun early-intern-effective-reader (method location)
   (with-early-accessors (+standard-accessor-method-slots+
-                         +slot-definition-slots+)
-    (let* ((direct-slotd (accessor-method-slot-definition method))
-           (key (cons direct-slotd location)))
-      (or (gethash key *cached-effective-readers*)
-          (setf (gethash key *cached-effective-readers*)
-                (make-effective-accessor-method
-                 (find-class 'effective-reader-method)
-                 method location
-                 (make-effective-reader-function
-                  location (slot-definition-name direct-slotd))))))))
+                         +direct-slot-definition-slots+)
+    (loop with direct-slotd = (accessor-method-slot-definition method)
+          for table = (mp:atomic (%direct-slotd-effective-readers direct-slotd))
+          for existing = (cdr (assoc location table))
+          when existing
+            return existing
+          do (let ((eff
+                     (make-effective-accessor-method
+                      (find-class 'effective-reader-method)
+                      method location
+                      (make-effective-reader-function
+                       location (slot-definition-name direct-slotd)))))
+               (when (eq (mp:cas (%direct-slotd-effective-readers direct-slotd)
+                                 table (acons location eff table))
+                         table)
+                 (return eff))))))
 
 (defun intern-effective-writer (method location)
-  (let* ((direct-slotd (accessor-method-slot-definition method))
-         (key (cons direct-slotd location)))
-    (or (gethash key *cached-effective-writers*)
-        (setf (gethash key *cached-effective-writers*)
-              (make-effective-accessor-method
-               (find-class 'effective-writer-method)
-               method location
-               (make-effective-writer-function location))))))
+  (loop with direct-slotd = (accessor-method-slot-definition method)
+        for table = (mp:atomic (slot-value direct-slotd '%effective-writers))
+        for existing = (cdr (assoc location table))
+        when existing
+          return existing
+        do (let ((eff
+                   (make-effective-accessor-method
+                    (find-class 'effective-writer-method)
+                    method location
+                    (make-effective-writer-function location))))
+             (when (eq (mp:cas (slot-value direct-slotd '%effective-writers)
+                               table (acons location eff table))
+                       table)
+               (return eff)))))
 
 (defun early-intern-effective-writer (method location)
   (with-early-accessors (+standard-accessor-method-slots+
-                         +slot-definition-slots+)
-    (let* ((direct-slotd (accessor-method-slot-definition method))
-           (key (cons direct-slotd location)))
-      (or (gethash key *cached-effective-writers*)
-          (setf (gethash key *cached-effective-writers*)
-                (make-effective-accessor-method
-                 (find-class 'effective-writer-method)
-                 method location
-                 (make-effective-writer-function location)))))))
+                         +direct-slot-definition-slots+)
+    (loop with direct-slotd = (accessor-method-slot-definition method)
+          for table = (mp:atomic (%direct-slotd-effective-writers direct-slotd))
+          for existing = (cdr (assoc location table))
+          when existing
+            return existing
+          do (let ((eff
+                     (make-effective-accessor-method
+                      (find-class 'effective-writer-method)
+                      method location
+                      (make-effective-writer-function location))))
+               (when (eq (mp:cas (%direct-slotd-effective-writers direct-slotd)
+                                 table (acons location eff table))
+                         table)
+                 (return eff))))))

--- a/src/lisp/kernel/clos/hierarchy.lisp
+++ b/src/lisp/kernel/clos/hierarchy.lisp
@@ -254,6 +254,13 @@
                 :accessor %slot-definition-location)
       )))
 
+(eval-when (:compile-toplevel :execute #+clasp :load-toplevel)
+  (core:defconstant-equal +direct-slot-definition-slots+
+    `(,@+slot-definition-slots+
+      ;; see effective-accessor.lisp
+      (%effective-readers :initform nil :reader %direct-slotd-effective-readers)
+      (%effective-writers :initform nil :reader %direct-slotd-effective-writers))))
+
 ;;; ----------------------------------------------------------------------
 ;;; %METHOD-FUNCTION
 ;;;
@@ -388,9 +395,9 @@
          :metaclass nil                 ; Special-cased in boot.lisp
          :direct-slots #.+standard-class-slots+)
         (standard-direct-slot-definition
-         :direct-slots #3=#.+slot-definition-slots+)
+         :direct-slots #3=#.+direct-slot-definition-slots+)
         (standard-effective-slot-definition
-         :direct-slots #3#)
+         :direct-slots #5=#.+slot-definition-slots+)
         (t)
         (class :direct-slots #.+class-slots+)
         (standard-object
@@ -403,22 +410,22 @@
          :direct-superclasses (standard-object))
         (slot-definition
          :direct-superclasses (metaobject)
-         :direct-slots #3#)
+         :direct-slots #5#)
         (standard-slot-definition
          :direct-superclasses (slot-definition)
-         :direct-slots #3#)
+         :direct-slots #5#)
         (direct-slot-definition
          :direct-superclasses (slot-definition)
-         :direct-slots #3#)
+         :direct-slots #5#)
         (effective-slot-definition
          :direct-superclasses (slot-definition)
-         :direct-slots #3#)
+         :direct-slots #5#)
         (standard-direct-slot-definition
          :direct-superclasses (standard-slot-definition direct-slot-definition)
          :direct-slots #3#)
         (standard-effective-slot-definition
          :direct-superclasses (standard-slot-definition effective-slot-definition)
-         :direct-slots #3#)
+         :direct-slots #5#)
         (method-combination
          :direct-superclasses (metaobject)
          :direct-slots #.+method-combination-slots+)

--- a/src/lisp/kernel/clos/slot.lisp
+++ b/src/lisp/kernel/clos/slot.lisp
@@ -39,6 +39,27 @@
 	   :location location)
     slotd))
 
+(defun make-simple-direct-slotd
+    (class &key name (initform +initform-unsupplied+) initfunction
+	     (type 'T) (allocation :instance)
+	     initargs readers writers documentation location)
+  (when (and (eq allocation :class)
+	     (functionp initfunction))
+    (setf initfunction (constantly (funcall initfunction))))
+  (with-early-make-instance +direct-slot-definition-slots+
+    (slotd class
+	   :name name
+	   :initform initform
+	   :initfunction initfunction
+	   :type type
+	   :allocation allocation
+	   :initargs initargs
+	   :readers readers
+	   :writers writers
+	   :documentation documentation
+	   :location location)
+    slotd))
+
 (defun freeze-class-slot-initfunction (slotd)
   (when (eq (getf slotd :allocation) :class)
     (let ((initfunc (getf slotd :initfunction)))
@@ -55,7 +76,7 @@
 	     (apply #'direct-slot-definition-class class
 		    (freeze-class-slot-initfunction slotd))
 	     slotd)
-      (apply #'make-simple-slotd class slotd)))
+      (apply #'make-simple-direct-slotd class slotd)))
 
 ;;; ----------------------------------------------------------------------
 ;;;

--- a/src/lisp/kernel/clos/slotvalue.lisp
+++ b/src/lisp/kernel/clos/slotvalue.lisp
@@ -74,24 +74,6 @@
                          new-value))
       ((:class) (setf (mp:atomic (car loc)) new-value)))))
 
-#+threads
-(mp:define-atomic-expander slot-value-using-class (class object slotd)
-  (&rest keys)
-  "Same requirements as STANDARD-INSTANCE-ACCESS, except the slot can have
-allocation :class.
-Also, methods on SLOT-VALUE-USING-CLASS, SLOT-BOUNDP-USING-CLASS, and
-(SETF SLOT-VALUE-USING-CLASS) are ignored (not invoked).
-In the future, the CAS behavior may be customizable with a generic function."
-  (declare (ignore keys))
-  (let ((gclass (gensym "CLASS")) (gobject (gensym "OBJECT"))
-        (gslotd (gensym "SLOTD")) (oldv (gensym "OLD")) (newv (gensym "NEWV")))
-    (values (list gclass gobject gslotd) (list class object slotd) oldv newv
-            `(atomic-slot-value-using-class ,gclass ,gobject ,gslotd)
-            `(setf (atomic-slot-value-using-class ,gclass ,gobject ,gslotd)
-                   ,newv)
-            `(cas-slot-value-using-class ,oldv ,newv
-                                         ,gclass ,gobject ,gslotd))))
-
 ;;;
 ;;; 3) Error messages related to slot access
 ;;;


### PR DESCRIPTION
Using a global table is easier but kind of bad, since it will make dispatch misses to completely different accessors contend. Putting a lock on the global table would just make that slower.