### PR TITLE
Fix format directive parser so that parameters are not allowed after colon or at sign

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,6 +6,7 @@
 * Return correct values for `listen` when applied to file streams. This is done
   by checking for available bytes using read when poll/select indicate the next
   read will not block. Otherwise use non-blocking read. Fixes [#1404][].
+* Prevent format parameters from appearing after colon or at sign modifiers.
 
 # Version 2.1.0 (LLVM14) 2023-01-01
 

--- a/src/lisp/kernel/lsp/format.lisp
+++ b/src/lisp/kernel/lsp/format.lisp
@@ -266,7 +266,8 @@
                  (schar string posn))))
       (loop
          (let ((char (get-char)))
-           (cond ((or (char<= #\0 char #\9) (char= char #\+) (char= char #\-))
+           (cond ((and (not colonp) (not atsignp)
+                       (or (char<= #\0 char #\9) (char= char #\+) (char= char #\-)))
                   (multiple-value-bind
                         (param new-posn)
                       (parse-integer string :start posn :junk-allowed t)
@@ -278,7 +279,8 @@
                        (decf posn))
                       (t
                        (return)))))
-                 ((or (char= char #\v) (char= char #\V))
+                 ((and (not colonp) (not atsignp)
+                       (or (char= char #\v) (char= char #\V)))
                   (push (cons posn :arg) params)
                   (incf posn)
                   (case (get-char)
@@ -287,7 +289,8 @@
                      (decf posn))
                     (t
                      (return))))
-                 ((char= char #\#)
+                 ((and (not colonp) (not atsignp)
+                       (char= char #\#))
                   (push (cons posn :remaining) params)
                   (incf posn)
                   (case (get-char)
@@ -296,13 +299,15 @@
                      (decf posn))
                     (t
                      (return))))
-                 ((char= char #\')
+                 ((and (not colonp) (not atsignp)
+                       (char= char #\'))
                   (incf posn)
                   (push (cons posn (get-char)) params)
                   (incf posn)
                   (unless (char= (get-char) #\,)
                    (decf posn)))
-                 ((char= char #\,)
+                 ((and (not colonp) (not atsignp)
+                       (char= char #\,))
                   (push (cons posn nil) params))
                  ((char= char #\:)
                   (if colonp

--- a/src/lisp/regression-tests/printer01.lisp
+++ b/src/lisp/regression-tests/printer01.lisp
@@ -535,3 +535,35 @@ BBBBCCCC**DDDD"))
 (test ansi-test-format-e
       (FORMAT NIL "~,2,,2e" 0.05)
       ("50.0e-3"))
+
+(test-expect-error format-parameters-colon-at-01
+                   (format nil "a~@4A" nil)
+                   :type error)
+
+(test-expect-error format-parameters-colon-at-02
+                   (format nil "a~:4A" nil)
+                   :type error)
+
+(test-expect-error format-parameters-colon-at-03
+                   (format nil "a~:@4A" nil)
+                   :type error)
+
+(test-expect-error format-parameters-colon-at-04
+                   (format nil "a~@:4A" nil)
+                   :type error)
+
+(test format-parameters-colon-at-05
+      (format nil "a~4@A" nil)
+      ("a NIL"))
+
+(test format-parameters-colon-at-06
+      (format nil "a~4:A" nil)
+      ("a()  "))
+
+(test format-parameters-colon-at-07
+      (format nil "a~4:@A" nil)
+      ("a  ()"))
+
+(test format-parameters-colon-at-08
+      (format nil "a~4@:A" nil)
+      ("a  ()"))


### PR DESCRIPTION
Port of https://gitlab.com/embeddable-common-lisp/ecl/-/merge_requests/282