### PR TITLE
Policy

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # Version 2.2.0 (LLVM14) Pending
 
+## Added
+* `ext:describe-compiler-policy` to get information about the current
+  behavior of the compiler.
+
 ## Fixes
 * Ensure that `print-unreadable-object` can accept output stream designators.
 * Set stream column to zero after printing the prompt in a REPL. Fixes [#1348][].

--- a/src/lisp/kernel/cleavir/inline-prep.lisp
+++ b/src/lisp/kernel/cleavir/inline-prep.lisp
@@ -18,11 +18,11 @@
        (destructuring-bind (type &rest vnames) (cdr decl)
          (proclaim-type type vnames)))
       ((eq head 'cl:optimize)
-       (setf *global-optimize*
+       (setf cmp:*optimize*
              (policy:normalize-optimize
-              (append (rest decl) *global-optimize*) *clasp-env*)
-             *global-policy*
-             (policy:compute-policy *global-optimize* *clasp-env*)))
+              (append (rest decl) cmp:*optimize*) *clasp-env*)
+             cmp:*policy*
+             (policy:compute-policy cmp:*optimize* *clasp-env*)))
       ;; Add other clauses here
       (t #+(or)(warn "Add support for proclaim ~s~%" decl)))))
 

--- a/src/lisp/kernel/cleavir/policy.lisp
+++ b/src/lisp/kernel/cleavir/policy.lisp
@@ -110,10 +110,7 @@
     (note-untransformed-calls boolean t)
     (note-boxing boolean t)
     (note-consing-&rest boolean t)
-    (core::insert-array-bounds-checks boolean t)
-    (ext:assume-right-type boolean nil)
-    (do-type-inference boolean t)
-    (do-dx-analysis boolean t)))
+    (core::insert-array-bounds-checks boolean t)))
 ;;; FIXME: Can't just punt like normal since it's an APPEND method combo.
 (defmethod policy:policy-qualities append ((env null))
   '((save-register-args boolean t)
@@ -126,10 +123,7 @@
     (note-untransformed-calls boolean t)
     (note-boxing boolean t)
     (note-consing-&rest boolean t)
-    (core::insert-array-bounds-checks boolean t)
-    (ext:assume-right-type boolean nil)
-    (do-type-inference boolean t)
-    (do-dx-analysis boolean t)))
+    (core::insert-array-bounds-checks boolean t)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -164,30 +158,6 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
-;;; Policies DO-TYPE-INFERENCE, DO-DX-ANALYSIS.
-;;;
-;;; Since Kildall analyses are tragically slow at the moment,
-;;; they need to be suppessed for reasonable compile times.
-;;; If DO-TYPE-INFERENCE is false no type inference is done.
-;;; If DO-DX-ANALYSIS is false no DX analysis is done.
-;;; See MY-HIR-TRANSFORMATIONS for use.
-
-(defmethod policy:compute-policy-quality
-    ((quality (eql 'do-type-inference))
-     optimize
-     (environment clasp-global-environment))
-  (> (policy:optimize-value optimize 'speed)
-     (policy:optimize-value optimize 'compilation-speed)))
-
-(defmethod policy:compute-policy-quality
-    ((quality (eql 'do-dx-analysis))
-     optimize
-     (environment clasp-global-environment))
-  (> (policy:optimize-value optimize 'space)
-     (policy:optimize-value optimize 'compilation-speed)))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;
 ;;; Policy CORE::INSERT-ARRAY-BOUNDS-CHECKS
 
 ;;; Should calls to aref and such do a bounds check?
@@ -198,26 +168,6 @@
      optimize
      (environment clasp-global-environment))
   (> (policy:optimize-value optimize 'safety) 0))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;
-;;; POLICY EXT:ASSUME-RIGHT-TYPE
-;;;
-;;; Should type declarations be trusted for unsafe transforms?
-;;; If this is true, crashes can result if type declarations
-;;; are wrong, so per the definition of "safe code" it must be
-;;; false at safety 3.
-;;; NOTE: This is only really necessary because of our non
-;;; existent type inference. Policies need a FIXME rethink
-;;; once things are less broken.
-
-(defmethod policy:compute-policy-quality
-    ((quality (eql 'ext:assume-right-type))
-     optimize
-     (environment clasp-global-environment))
-  (let ((safety (policy:optimize-value optimize 'safety)))
-    (and (zerop safety)
-         (> (policy:optimize-value optimize 'speed) safety))))
 
 ;;;
 

--- a/src/lisp/kernel/cleavir/policy.lisp
+++ b/src/lisp/kernel/cleavir/policy.lisp
@@ -3,9 +3,9 @@
 (core:defconstant-equal +optimize-qualities+
     '(compilation-speed speed space safety debug))
 (defvar *policy-qualities* nil)
-(defvar *policy-level-descriptions* nil)
+(defvar *policy-descriptions* nil)
 
-(defmacro define-policy (name compute (&rest levels))
+(defmacro define-policy (name compute (&rest levels) &optional documentation)
   `(progn
      (defmethod policy:compute-policy-quality
          ((quality (eql ',name)) optimize (env clasp-global-environment))
@@ -15,7 +15,7 @@
                     collect `(,qual (policy:optimize-value optimize ',qual))))
          (declare (ignorable ,@+optimize-qualities+))
          ,compute))
-     (push '(,name ,@levels) *policy-level-descriptions*)
+     (push '(,name ,documentation ,@levels) *policy-descriptions*)
      (push '(,name (member ,@(mapcar #'car levels)) ,(caar (last levels)))
            *policy-qualities*)
      ',name))
@@ -24,110 +24,100 @@
     (quality optimize (environment null))
   (policy:compute-policy-quality quality optimize *clasp-env*))
 
-;;; The type policies work as follows.
-;;; If the value is 0, type assertions of the given kind are believed by
-;;; the compiler and are not checked. Very unsafe.
-;;; If the value is 1, type assertions are noted by the compiler but
-;;; not believed nor checked. The compiler will not use the information to
-;;; perform optimizations, but can note it to e.g. warn about type conflicts.
-;;; If 2 or 3, type assertions are checked and believed.
+(defmethod documentation ((name symbol) (dt (eql 'cmp:policy)))
+  (second (assoc name *policy-descriptions*)))
 
-;;; This policy is used for THE as well as TYPE declarations on variables.
+;;; 
+
 (define-policy type-check-the
     (if (> safety 0) 3 0)
   ((0 "believed-unsafely") (1 "noted")
-                           (2 "believed-safely") (3 "believed-safely")))
+                           (2 "believed-safely") (3 "believed-safely"))
+  "This policy is used for THE as well as TYPE declarations on variables.
 
+If the value is 0, type assertions are believed by the compiler and are not checked. Very unsafe.
+If the value is 1, type assertions are noted by the compiler but not believed nor checked.
+The compiler will not use the information to perform optimizations, but can note it to e.g. warn about type conflicts.
+If 2 or 3, type assertions are checked and believed.")
 
-;;; This policy is used for type assertions derived from arguments to a call
-;;; to a function with declared FTYPE.
 (define-policy type-check-ftype-arguments
     (ecase safety ((0) 0) ((1 2) 1) ((3) 3))
   ((0 "believed-unsafely") (1 "noted")
-                           (2 "believed-safely") (3 "believed-safely")))
+                           (2 "believed-safely") (3 "believed-safely"))
+  "This policy is used for type assertions derived from arguments to a call to a function with declared FTYPE.
 
-;;; This policy is used for type assertions derived from the return values of
-;;; a call to a function with declared FTYPE.
+See TYPE-CHECK-THE for an explanation of the values.")
+
 (define-policy type-check-ftype-return-values
     (ecase safety ((0) 0) ((1 2) 1) ((3) 3))
   ((0 "believed-unsafely") (1 "noted")
-                           (2 "believed-safely") (3 "believed-safely")))
+                           (2 "believed-safely") (3 "believed-safely"))
+  "This policy is used for type assertions derived from the return values of a call to a function with declared FTYPE.
 
-;;; This policy is used in transform.lisp to determine whether to flush unused
-;;; calls, even if this will not preserve some error that the call might signal.
-;;; If this policy is not in place, such calls may be flushed.
+See TYPE-CHECK-THE for an explanation of the values.")
+
 (define-policy flush-safely
     (= safety 3)
-  ((nil "no") (t "yes")))
+  ((nil "no") (t "yes"))
+  "Should calls to pure functions with unused results be flushed, even if this will not preserve some error that the call might signal?
+If this policy is not in place, such calls may be flushed.")
 
-;;; Should the compiler insert code to signal step conditions? This has
-;;; some overhead, so it's only done at debug 3.
 (define-policy insert-step-conditions
     (>= debug 3)
-  ((nil "no") (t "yes")))
+  ((nil "no") (t "yes"))
+  "Should the compiler insert code to signal step conditions? This adds a bit of overhead to every call.")
 
-;;; This policy indicates that the compiler should note calls that could be
-;;; transformed (i.e. eliminated by inlining, replacement with a primop, etc.)
-;;; but couldn't be due to lack of information.
 (define-policy note-untransformed-calls
-  ;; at present, type inference is not good enough to handle actually
+  ;; at present, type inference is not good enough to handle a lot of actually
   ;; optimizable code (e.g. (and (consp x) (... (car x) ...))). as such, for
   ;; the time being at least, you have to manually request this policy
   ;; as by (declare (optimize clasp-cleavir::note-untransformed-calls))
   nil ; (= speed 3)
-  ((nil "no") (t "yes")))
+  ((nil "no") (t "yes"))
+  "Should the compiler note calls that could be transformed (eliminated by inlining, replaced by a primop, etc.) but couldn't be due to lack of information?")
 
-;;; This policy indicates that the compiler should note when it's forced
-;;; to emit expensive boxing instructions. Note that this does not result
-;;; in notes for calling functions that may box internally - FIXME?
 (define-policy note-boxing
   nil ; (= speed 3)
-  ((nil "no") (t "yes")))
+  ((nil "no") (t "yes"))
+  "Should the compiler note when it's forced to emit expensive boxing instructions?
+Note that calls to functions that may box internally do not result in notes - FIXME?")
 
-;;; This policy tells the compiler to note when a &rest parameter must
-;;; be consed into a list (i.e. the optimization in vaslist.lisp does not fire).
-;;; It must also be specifically requested.
 (define-policy note-consing-&rest
-  nil ; (= space 3)
-  ((nil "no") (t "yes")))
+  nil ; (= space 3) ; must be specifically requested.
+  ((nil "no") (t "yes"))
+  "Should the compiler note when a &rest parameter must be consed into a list (i.e. the optimization in vaslist.lisp does not fire)?")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Policy SAVE-REGISTER-ARGS.
 ;;;
-;;; Clasp presently maintains a stack trace by doing things
-;;; at runtime. This is expensive but doing otherwise is
-;;; slow going. If SAVE-REGISTER-ARGS is false this stuff
-;;; is not inserted, so functions so compiled won't show up
-;;; in backtraces.
 
 (define-policy save-register-args
   #-debug-cclasp-lisp (= debug 3)
   #+debug-cclasp-lisp (> debug 0)
-  ((nil "no") (t "yes")))
+  ((nil "no") (t "yes"))
+  "Clasp presently maintains a stack trace by saving registers when functions are called. This takes time. If SAVE-REGISTER-ARGS is false, code to save registers is not inserted into functions, so functions so compiled won't show up in backtraces.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Policy PERFORM-OPTIMIZATION.
 ;;;
-;;; If this policy is not on, Clasp will perform only minimal
-;;; optimization. At present this just puts the "optnone" attribute
-;;; on functions for LLVM.
 
 (define-policy perform-optimization
     (< debug 3)
-  ((nil "no") (t "yes")))
+  ((nil "no") (t "yes"))
+  "If this policy is not on, Clasp will perform only minimal optimization. At present this just puts the \"optnone\" attribute on functions for LLVM.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Policy CORE::INSERT-ARRAY-BOUNDS-CHECKS
 
-;;; Should calls to aref and such do a bounds check?
 ;;; In CORE package so we can use it in earlier code.
 
 (define-policy core::insert-array-bounds-checks
     (> safety 0)
-  ((nil "no") (t "yes")))
+  ((nil "no") (t "yes"))
+  "Should calls to AREF and such do a bounds check? Note that this policy only affects calls that the compiler can inline.")
 
 ;;;
 
@@ -142,6 +132,9 @@
   *policy-qualities*)
 
 (defun ext:describe-compiler-policy (&optional optimize)
+  "Print the global compiler policy to standard output.
+
+OPTIMIZE should be the arguments of a CL:OPTIMIZE declaration specifier, e.g. ((SPEED 3) (SAFETY 1)). The policy printed is that that would be in place with current global policy augmented by the specifier. If OPTIMIZE is not provided, the unaugmented current global policy is printed."
   (let* ((optimize
            (policy:normalize-optimize (append optimize cmp:*optimize*)
                                       *clasp-env*))
@@ -153,7 +146,7 @@
     ;; Describe computed policies
     (format t "  Compilation policies:~%")
     (loop for (quality . value) in policy
-          for level-info = (cdr (assoc quality *policy-level-descriptions*))
+          for level-info = (cddr (assoc quality *policy-descriptions*))
           for desc = (second (assoc value level-info))
           do (format t "~s = ~d" quality value)
           when desc

--- a/src/lisp/kernel/cleavir/setup.lisp
+++ b/src/lisp/kernel/cleavir/setup.lisp
@@ -303,26 +303,17 @@
 
 (defmethod env:declarations ((env cmp:lexenv)) (env:declarations *clasp-env*))
 
-(eval-when (:compile-toplevel :load-toplevel :execute)
-  (defvar *global-optimize*
-    ;; initial value, changed by de/proclaim
-    '((compilation-speed 1)
-      (debug 1)
-      (space 1)
-      (speed 1)
-      (safety 1))))
-
 (eval-when (:compile-toplevel)
   (format t "about to compute-policy~%"))
 
-(defvar *global-policy*
-  '#.(policy:compute-policy *global-optimize* *clasp-env*))
+(setf cmp:*policy*
+  '#.(policy:compute-policy cmp:*optimize* *clasp-env*))
 
 (defmethod env:optimize-info ((environment clasp-global-environment))
   ;; The default values are all 3.
   (make-instance 'env:optimize-info
-    :optimize *global-optimize*
-    :policy *global-policy*))
+    :optimize cmp:*optimize*
+    :policy cmp:*policy*))
 
 (defmethod env:optimize-info ((environment NULL))
   (env:optimize-info *clasp-env*))

--- a/src/lisp/kernel/cmp/cmpexports.lisp
+++ b/src/lisp/kernel/cmp/cmpexports.lisp
@@ -24,6 +24,7 @@
             load-bitcode
             *irbuilder*
             *compile-file-unique-symbol-prefix*
+            *optimize* *policy*
             %ltv*%
             irc-function-create
             irc-make-function-description

--- a/src/lisp/kernel/cmp/cmpexports.lisp
+++ b/src/lisp/kernel/cmp/cmpexports.lisp
@@ -25,6 +25,7 @@
             *irbuilder*
             *compile-file-unique-symbol-prefix*
             *optimize* *policy*
+            policy ; used as a doc-type
             %ltv*%
             irc-function-create
             irc-make-function-description

--- a/src/lisp/kernel/cmp/cmputil.lisp
+++ b/src/lisp/kernel/cmp/cmputil.lisp
@@ -38,6 +38,14 @@
 (defvar *warnings-p*)
 (defvar *failure-p*)
 
+;;; Global OPTIMIZE declaration and derived policy.
+;;; This can be changed later by OPTIMIZE proclamations.
+;;; The policy is computed later in cleavir/setup.lisp.
+(defvar *optimize*
+  '((compilation-speed 1)
+    (debug 1) (space 1) (speed 1) (safety 1)))
+(defvar *policy* ())
+
 (core:defconstant-equal +note-format+        "Note:          {}")
 (core:defconstant-equal +style-warn-format+  "Style warning: {}")
 (core:defconstant-equal +warn-format+        "Warning:       {}")

--- a/src/lisp/kernel/cmp/compile-file.lisp
+++ b/src/lisp/kernel/cmp/compile-file.lisp
@@ -304,6 +304,7 @@ Compile a Lisp source stream and return a corresponding LLVM module."
     (let ((output-path (apply #'compile-file-pathname input-file args))
           (*compilation-module-index* 0) ; FIXME: necessary?
           (*readtable* *readtable*) (*package* *package*)
+          (*optimize* *optimize*) (*policy* *policy*)
           (*compile-file-pathname*
             (pathname (merge-pathnames input-file)))
           (*compile-file-truename*

--- a/src/lisp/kernel/lsp/loop2.lisp
+++ b/src/lisp/kernel/lsp/loop2.lisp
@@ -106,7 +106,9 @@
 ;;;; Miscellaneous Environment Things
 
 (defmacro loop-unsafe (&rest x)
-  `(locally (declare (optimize ext:assume-right-type)) ,@x))
+  ;; This is mostly in so as to elide type checks.
+  ;; See cleavir/policy.lisp for details of when Clasp inserts type checks.
+  `(locally (declare (optimize (safety 0))) ,@x))
 
 (defun loop-optimization-quantities (env)
   ;; The ANSI conditionalization here is for those lisps that implement
@@ -471,7 +473,7 @@ a LET-like macro, and a SETQ-like macro, which perform LOOP-style destructuring.
 	     (do ((tail var)) ((not (consp tail)) tail)
 	       (when (find-non-null (pop tail)) (return t))))
 	   (loop-desetq-internal (var val &optional temp)
-	     ;; if the value is declared 'unsafe', then the assignemnt
+	     ;; if the value is declared 'unsafe', then the assignment
 	     ;; is also unsafe.
 	     (when (and (consp val)
 			(eq (first val) 'LOOP-UNSAFE))

--- a/src/lisp/kernel/lsp/packages.lisp
+++ b/src/lisp/kernel/lsp/packages.lisp
@@ -224,6 +224,8 @@
             tpl-frame tpl-argument tpl-arguments
             ;; GC
             garbage-collect finalize save-lisp-and-die
-            ;; Misc
+            ;; Compiler
+            describe-compiler-policy
             with-current-source-form
+            ;; Misc
             printing-char-p)))

--- a/src/lisp/kernel/lsp/packages.lisp
+++ b/src/lisp/kernel/lsp/packages.lisp
@@ -174,7 +174,6 @@
             sequence-stream
             all-encodings
             make-encoding
-            assume-right-type
             assert-error
             float-nan-p
             float-infinity-p


### PR DESCRIPTION
Makes compiler policy a little more transparent through `ext:describe-compiler-policy`.