### PR TITLE
Bytecode opt

### DIFF
--- a/include/clasp/core/bytecode.h
+++ b/include/clasp/core/bytecode.h
@@ -74,42 +74,6 @@ public:
 };
 }; // namespace core
 
-namespace core {
-FORWARD(GFBytecodeModule);
-class GFBytecodeModule_O : public core::CxxObject_O {
-  LISP_CLASS(core, CorePkg, GFBytecodeModule_O, "GFBytecodeModule", core::CxxObject_O);
- public:
-  void initialize();
-public:
-  typedef T_O                        Literals_O_Type;
-  typedef T_O                        GFBytecode_O_Type;
-  typedef T_sp                       Literals_sp_Type;
-  typedef T_sp                       GFBytecode_sp_Type;
-  Literals_sp_Type                   _Literals;
-  GFBytecode_sp_Type                 _GFBytecode;
-  T_sp                               _CompileInfo;
-
-public:
-  CL_LISPIFY_NAME(GFBytecodeModule/make)
-  CL_DEF_CLASS_METHOD
-  static GFBytecodeModule_sp make() {
-    // When we can gc code allocate entire block in GC memory
-    GFBytecodeModule_sp codeblock = gctools::GC<GFBytecodeModule_O>::allocate<gctools::RuntimeStage>();
-    return codeblock;
-  };
-
-  Literals_sp_Type literals() const;
-  void setf_literals(T_sp obj);
-  GFBytecode_sp_Type bytecode() const;
-  void setf_bytecode(T_sp obj);
-  GFBytecode_sp_Type compileInfo() const;
-  void setf_compileInfo(T_sp obj);
-  GFBytecodeModule_O() {};
-};
-
-};
-
-
 extern "C" {
 gctools::return_type bytecode_call(unsigned char* pc, core::T_O* lcc_closure,
                                    size_t lcc_nargs, core::T_O** lcc_args);

--- a/include/clasp/core/bytecode_compiler.h
+++ b/include/clasp/core/bytecode_compiler.h
@@ -253,17 +253,20 @@ class Context_O : public General_O {
   LISP_CLASS(comp, CompPkg, Context_O, "Context", General_O);
 public:
   T_sp _receiving;
+  List_sp _dynenv;
   T_sp _cfunction;
 public:
-  Context_O(T_sp receiving, T_sp cfunction)
-    : _receiving(receiving), _cfunction(cfunction) {}
+  Context_O(T_sp receiving, T_sp dynenv, T_sp cfunction)
+    : _receiving(receiving), _dynenv(dynenv), _cfunction(cfunction) {}
   CL_LISPIFY_NAME(Context/make)
   CL_DEF_CLASS_METHOD
-  static Context_sp make(T_sp receiving, T_sp cfunction) {
-    return gctools::GC<Context_O>::allocate<gctools::RuntimeStage>(receiving, cfunction);
+  static Context_sp make(T_sp receiving, T_sp dynenv, T_sp cfunction) {
+    return gctools::GC<Context_O>::allocate<gctools::RuntimeStage>(receiving, dynenv, cfunction);
   }
   CL_LISPIFY_NAME(context/receiving)
   CL_DEFMETHOD T_sp receiving() { return this->_receiving; }
+  CL_LISPIFY_NAME(context/dynenv)
+  CL_DEFMETHOD List_sp dynenv() { return this->_dynenv; }
   CL_DEFMETHOD Cfunction_sp cfunction() {
     return gc::As<Cfunction_sp>(this->_cfunction);
   }
@@ -272,7 +275,13 @@ public:
   // Make a new context that's like this one but with a possibly-different
   // RECEIVING.
   CL_DEFMETHOD Context_sp sub(T_sp receiving) {
-    return Context_O::make(receiving, this->_cfunction);
+    return Context_O::make(receiving, this->_dynenv, this->_cfunction);
+  }
+  // Make a new context that's like this one but with the given thing
+  // plopped on the dynenv.
+  CL_DEFMETHOD Context_sp subde(T_sp de) {
+    return Context_O::make(this->_receiving, Cons_O::create(de, this->_dynenv),
+                           this->_cfunction);
   }
   CL_DEFMETHOD size_t literal_index(T_sp literal);
   CL_DEFMETHOD size_t new_literal_index(T_sp literal);
@@ -285,9 +294,11 @@ public:
                           uint8_t opcode8, uint8_t opcode16, uint8_t opcode24);
   CL_DEFMETHOD void emit_jump(Label_sp label);
   CL_DEFMETHOD void emit_jump_if(Label_sp label);
-  CL_DEFMETHOD void emit_entry(LexicalVarInfo_sp info);
+  CL_DEFMETHOD void emit_entry_or_save_sp(LexicalVarInfo_sp info);
+  CL_DEFMETHOD void emit_ref_or_restore_sp(LexicalVarInfo_sp info);
   CL_DEFMETHOD void emit_exit(Label_sp label);
-  CL_DEFMETHOD void emit_entry_close(LexicalVarInfo_sp info);
+  CL_DEFMETHOD void emit_exit_or_jump(LexicalVarInfo_sp info, Label_sp label);
+  CL_DEFMETHOD void maybe_emit_entry_close(LexicalVarInfo_sp info);
   CL_DEFMETHOD void emit_catch(Label_sp label);
   CL_DEFMETHOD void emit_jump_if_supplied(Label_sp label, size_t indx);
   CL_DEFMETHOD void reference_lexical_info(LexicalVarInfo_sp info);
@@ -542,6 +553,45 @@ public:
 public:
   virtual void emit(size_t position, SimpleVector_byte8_t_sp code);
   virtual size_t resize();
+};
+
+// Generate a ref or restore_sp for a (possibly nonlocal) exit.
+FORWARD(RestoreSPFixup);
+class RestoreSPFixup_O : public LexFixup_O {
+  LISP_CLASS(comp, CompPkg, RestoreSPFixup_O, "RestoreSPFixup", LexFixup_O);
+public:
+  RestoreSPFixup_O() : LexFixup_O() {}
+  RestoreSPFixup_O(LexicalVarInfo_sp lex) : LexFixup_O(lex, 0) {}
+  CL_LISPIFY_NAME(RestoreSPFixup/make)
+  CL_DEF_CLASS_METHOD
+  static RestoreSPFixup_sp make(LexicalVarInfo_sp lex) {
+    return gctools::GC<RestoreSPFixup_O>::allocate<gctools::RuntimeStage>(lex);
+  }
+public:
+  virtual void emit(size_t position, SimpleVector_byte8_t_sp code);
+  virtual size_t resize();
+};
+
+// Generate an exit or jump.
+FORWARD(ExitFixup);
+class ExitFixup_O : public LabelFixup_O {
+  LISP_CLASS(comp, CompPkg, ExitFixup_O, "ExitFixup", LexFixup_O);
+public:
+  // Clasp doesn't like C++ multiple inheritance.
+  LexicalVarInfo_sp _lex;
+public:
+  ExitFixup_O() : LabelFixup_O() {}
+  ExitFixup_O(LexicalVarInfo_sp lex, Label_sp label)
+    : LabelFixup_O(label, 2), _lex(lex) {}
+  CL_LISPIFY_NAME(ExitFixup/make)
+  CL_DEF_CLASS_METHOD
+  static ExitFixup_sp make(LexicalVarInfo_sp lex, Label_sp label) {
+    return gctools::GC<ExitFixup_O>::allocate<gctools::RuntimeStage>(lex, label);
+  }
+public:
+  virtual void emit(size_t position, SimpleVector_byte8_t_sp code);
+  virtual size_t resize();
+  LexicalVarInfo_sp lex() { return this->_lex; }
 };
 
 // Similar to EntryFixup, adds a vm_entry_close.

--- a/include/clasp/core/function.h
+++ b/include/clasp/core/function.h
@@ -23,7 +23,6 @@ namespace core {
   FORWARD(BuiltinClosure);
   FORWARD(Closure);
   FORWARD(BytecodeModule);
-  FORWARD(GFBytecodeModule);
   FORWARD(SimpleVector_byte32_t);
 };
 

--- a/include/clasp/core/multipleValues.h
+++ b/include/clasp/core/multipleValues.h
@@ -106,6 +106,19 @@ public: // Functions here
     this->setSize(val.number_of_values());
   }
 
+  // saveToTemp and loadFromTemp are like returnTypeSaveToTemp below,
+  // but only use the MultipleValues structure.
+  inline void saveToTemp(size_t nvals, T_O** temp) {
+    for (size_t i = 0; i < nvals; ++i)
+      temp[i] = this->_Values[i];
+  }
+
+  inline void loadFromTemp(size_t nvals, T_O** temp) {
+    this->setSize(nvals);
+    for (size_t i = 0; i < nvals; ++i)
+      this->_Values[i] = temp[i];
+  }
+
   void valueSet(int i, T_sp val) {
     this->_Values[i] = val.raw_();
   }
@@ -403,22 +416,6 @@ namespace core {
      mv._Values[i] = temp[i];
    }
    return gctools::return_type(nvals == 0 ? nil<core::T_O>().raw_() : temp[0], nvals);
- }
-
- // Similar to returnTypeSaveToTemp, but saves only from lisp_multipleValues.
- inline void multipleValuesSaveToTemp(size_t nvals, T_O** temp) {
-   core::MultipleValues& mv = core::lisp_multipleValues();
-   for (size_t i = 0; i < nvals; ++i) {
-     temp[i] = mv._Values[i];
-   }
- }
- // Similar to returnTypeLoadFromTemp, but just writes into lisp_multipleValues.
- inline void multipleValuesLoadFromTemp(size_t nvals, T_O** temp) {
-   core::MultipleValues& mv = core::lisp_multipleValues();
-   mv.setSize(nvals);
-   for (size_t i = 0; i < nvals; ++i) {
-     mv._Values[i] = temp[i];
-   }
  }
 };
 

--- a/include/clasp/core/unwind.h
+++ b/include/clasp/core/unwind.h
@@ -213,11 +213,12 @@ T_mv funwind_protect(Protf&& protected_thunk, Cleanupf&& cleanup_thunk) {
     // itself unwinds.
     T_sp dest = my_thread->_UnwindDest;
     size_t dindex = my_thread->_UnwindDestIndex;
-    size_t nvals = lisp_multipleValues().getSize();
+    MultipleValues& multipleValues = lisp_multipleValues();
+    size_t nvals = multipleValues.getSize();
     T_O* mv_temp[nvals];
-    multipleValuesSaveToTemp(nvals, mv_temp);
+    multipleValues.saveToTemp(nvals, mv_temp);
     cleanup_thunk();
-    multipleValuesLoadFromTemp(nvals, mv_temp);
+    multipleValues.loadFromTemp(nvals, mv_temp);
     my_thread->_UnwindDestIndex = dindex;
     my_thread->_UnwindDest = dest;
     // Continue unwinding.
@@ -231,11 +232,12 @@ T_mv funwind_protect(Protf&& protected_thunk, Cleanupf&& cleanup_thunk) {
       DynEnvPusher dep(my_thread, sa_ec.asSmartPtr());
       result = protected_thunk();
     } catch (...) { // C++ unwind. Do the same shit then rethrow
-      size_t nvals = lisp_multipleValues().getSize();
+      MultipleValues& multipleValues = core::lisp_multipleValues();
+      size_t nvals = multipleValues.getSize();
       T_O* mv_temp[nvals];
-      multipleValuesSaveToTemp(nvals, mv_temp);
+      multipleValues.saveToTemp(nvals, mv_temp);
       cleanup_thunk();
-      multipleValuesLoadFromTemp(nvals, mv_temp);
+      multipleValues.loadFromTemp(nvals, mv_temp);
       throw;
     }
     size_t nvals = result.number_of_values();

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -15,16 +15,15 @@
                           "core::SimpleMDArrayBaseChar_O" "llvmo::DILocation_O"
                           "llvmo::DWARFUnit_O" "core::SimpleMDArray_O" "core::Stream_O"
                           "core::VMFrameDynEnv_O" "core::SymbolClassHolderPair"
-                          "comp::EncageFixup_O" "core::GFBytecodeModule_O" "llvmo::MDString_O"
-                          "core::ShortFloat_O" "core::Number_O" "core::T_O"
-                          "llvmo::DICompileUnit_O" "core::BindingDynEnv_O"
-                          "core::AbstractSimpleVector_O" "core::SimpleMDArray_byte16_t_O"
-                          "core::Pathname_O" "core::Str8Ns_O" "llvmo::FunctionPass_O"
-                          "core::SimpleVector_byte4_t_O" "llvmo::UndefValue_O" "llvmo::CallBase_O"
-                          "core::Path_O" "mp::SharedMutex_O"
-                          "asttooling::DerivableASTFrontendAction" "core::InstanceCreator_O"
-                          "core::IOStreamStream_O" "core::Scope_O" "comp::Context_O"
-                          "llvmo::InsertPoint_O" "core::FunctionDescription_O"
+                          "comp::EncageFixup_O" "llvmo::MDString_O" "core::ShortFloat_O"
+                          "core::Number_O" "core::T_O" "llvmo::DICompileUnit_O"
+                          "core::BindingDynEnv_O" "core::AbstractSimpleVector_O"
+                          "core::SimpleMDArray_byte16_t_O" "core::Pathname_O" "core::Str8Ns_O"
+                          "llvmo::FunctionPass_O" "core::SimpleVector_byte4_t_O"
+                          "llvmo::UndefValue_O" "llvmo::CallBase_O" "core::Path_O"
+                          "mp::SharedMutex_O" "asttooling::DerivableASTFrontendAction"
+                          "core::InstanceCreator_O" "core::IOStreamStream_O" "core::Scope_O"
+                          "comp::Context_O" "llvmo::InsertPoint_O" "core::FunctionDescription_O"
                           "core::ComplexVector_double_O" "core::StrWNs_O" "core::UnknownDynEnv_O"
                           "core::EchoStream_O" "core::HashTableBase_O" "core::SimpleMDArrayBit_O"
                           "core::MDArrayBit_O" "core::ComplexVector_byte16_t_O"
@@ -68,11 +67,12 @@
                           "core::UserData_O" "core::ExternalObject_O" "llvmo::DINode_O"
                           "llvmo::GlobalVariable_O" "core::BroadcastStream_O" "core::General_O"
                           "llvmo::ObjectFile_O" "llvmo::Library_O" "core::Closure_O"
-                          "core::ComplexVector_size_t_O" "mpip::Mpi_O" "llvmo::DINodeArray_O"
-                          "llvmo::ConstantDataArray_O" "core::SmallMap_O" "core::Instance_O"
-                          "llvmo::TargetOptions_O" "clasp_ffi::ForeignTypeSpec_O"
-                          "core::Unused_dummy_O" "llvmo::DWARFContext_O" "core::HashTableEqual_O"
-                          "llvmo::Triple_O" "core::SimpleMDArray_byte64_t_O" "core::BitVectorNs_O"
+                          "core::ComplexVector_size_t_O" "comp::RestoreSPFixup_O" "mpip::Mpi_O"
+                          "llvmo::DINodeArray_O" "llvmo::ConstantDataArray_O" "core::SmallMap_O"
+                          "core::Instance_O" "llvmo::TargetOptions_O"
+                          "clasp_ffi::ForeignTypeSpec_O" "core::Unused_dummy_O"
+                          "llvmo::DWARFContext_O" "core::HashTableEqual_O" "llvmo::Triple_O"
+                          "core::SimpleMDArray_byte64_t_O" "core::BitVectorNs_O"
                           "core::CoreExposer_O" "comp::JumpIfSuppliedFixup_O" "core::KeyValuePair"
                           "llvmo::NamedMDNode_O" "core::SimpleVector_byte16_t_O"
                           "llvmo::ThreadSafeContext_O" "llvmo::TargetMachine_O"
@@ -112,14 +112,16 @@
                           "llvmo::Type_O" "core::Pointer_O" "llvmo::UnreachableInst_O"
                           "core::ComplexVector_int64_t_O" "core::FileScope_O" "core::Float_O"
                           "core::SimpleMDArray_byte4_t_O" "llvmo::DIDerivedType_O"
-                          "core::SimpleVector_int64_t_O" "llvmo::ConstantDataSequential_O"
+                          "comp::EntryCloseFixup_O" "core::SimpleVector_int64_t_O"
+                          "llvmo::ConstantDataSequential_O" "comp::EntryFixup_O"
                           "core::MDArray_double_O" "llvmo::StoreInst_O" "llvmo::DebugLoc_O"
                           "core::WeakPointer_O" "core::DestDynEnv_O" "core::IOFileStream_O"
                           "comp::Annotation_O" "core::DynEnv_O" "comp::LexSetFixup_O"
                           "core::SimpleMDArray_byte8_t_O" "comp::SymbolMacroVarInfo_O"
                           "core::UnwindProtectDynEnv_O" "llvmo::Instruction_O" "core::FileStream_O"
-                          "core::Rational_O" "core::CatchDynEnv_O" "core::MDArrayCharacter_O"
-                          "llvmo::LandingPadInst_O" "core::ImmobileObject_O" "core::Function_O"
+                          "comp::ExitFixup_O" "core::Rational_O" "core::CatchDynEnv_O"
+                          "core::MDArrayCharacter_O" "llvmo::LandingPadInst_O"
+                          "core::ImmobileObject_O" "core::Function_O"
                           "core::SimpleMDArray_int2_t_O" "core::HashTableEql_O"
                           "mp::ConditionVariable_O" "core::Real_O" "core::Lisp"
                           "core::MDArray_byte8_t_O" "core::FuncallableInstanceCreator_O"
@@ -684,6 +686,29 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<comp::Label_O>"
              :offset-base-ctype "comp::LabelFixup_O" :layout-offset-field-names ("_label")}
+{class-kind :stamp-name "STAMPWTAG_comp__ExitFixup_O" :stamp-key "comp::ExitFixup_O"
+            :parent-class "comp::LabelFixup_O" :lisp-class-base "comp::LexFixup_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "comp::ExitFixup_O"
+             :layout-offset-field-names ("_cfunction")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_index")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::ExitFixup_O"
+             :layout-offset-field-names ("_initial_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_size")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_initial_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<comp::Label_O>"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_label")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<comp::LexicalVarInfo_O>"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_lex")}
 {class-kind :stamp-name "STAMPWTAG_comp__ControlLabelFixup_O"
             :stamp-key "comp::ControlLabelFixup_O" :parent-class "comp::LabelFixup_O"
             :lisp-class-base "comp::LabelFixup_O" :root-class "core::T_O" :stamp-wtag 3
@@ -781,6 +806,47 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<comp::LexicalVarInfo_O>"
              :offset-base-ctype "comp::LexSetFixup_O" :layout-offset-field-names ("_lex")}
+{class-kind :stamp-name "STAMPWTAG_comp__EntryFixup_O" :stamp-key "comp::EntryFixup_O"
+            :parent-class "comp::LexFixup_O" :lisp-class-base "comp::LexFixup_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "comp::EntryFixup_O"
+             :layout-offset-field-names ("_cfunction")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryFixup_O" :layout-offset-field-names ("_index")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryFixup_O" :layout-offset-field-names ("_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryFixup_O"
+             :layout-offset-field-names ("_initial_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryFixup_O" :layout-offset-field-names ("_size")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryFixup_O" :layout-offset-field-names ("_initial_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<comp::LexicalVarInfo_O>"
+             :offset-base-ctype "comp::EntryFixup_O" :layout-offset-field-names ("_lex")}
+{class-kind :stamp-name "STAMPWTAG_comp__EntryCloseFixup_O" :stamp-key "comp::EntryCloseFixup_O"
+            :parent-class "comp::LexFixup_O" :lisp-class-base "comp::LexFixup_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "comp::EntryCloseFixup_O" :layout-offset-field-names ("_cfunction")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryCloseFixup_O" :layout-offset-field-names ("_index")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryCloseFixup_O" :layout-offset-field-names ("_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryCloseFixup_O"
+             :layout-offset-field-names ("_initial_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryCloseFixup_O" :layout-offset-field-names ("_size")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryCloseFixup_O"
+             :layout-offset-field-names ("_initial_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<comp::LexicalVarInfo_O>"
+             :offset-base-ctype "comp::EntryCloseFixup_O" :layout-offset-field-names ("_lex")}
 {class-kind :stamp-name "STAMPWTAG_comp__LexRefFixup_O" :stamp-key "comp::LexRefFixup_O"
             :parent-class "comp::LexFixup_O" :lisp-class-base "comp::LexFixup_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -803,6 +869,27 @@
              :offset-base-ctype "comp::LexRefFixup_O" :layout-offset-field-names ("_lex")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_char" :offset-ctype "unsigned char"
              :offset-base-ctype "comp::LexRefFixup_O" :layout-offset-field-names ("_opcode")}
+{class-kind :stamp-name "STAMPWTAG_comp__RestoreSPFixup_O" :stamp-key "comp::RestoreSPFixup_O"
+            :parent-class "comp::LexFixup_O" :lisp-class-base "comp::LexFixup_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "comp::RestoreSPFixup_O" :layout-offset-field-names ("_cfunction")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::RestoreSPFixup_O" :layout-offset-field-names ("_index")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::RestoreSPFixup_O" :layout-offset-field-names ("_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::RestoreSPFixup_O"
+             :layout-offset-field-names ("_initial_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::RestoreSPFixup_O" :layout-offset-field-names ("_size")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::RestoreSPFixup_O"
+             :layout-offset-field-names ("_initial_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<comp::LexicalVarInfo_O>"
+             :offset-base-ctype "comp::RestoreSPFixup_O" :layout-offset-field-names ("_lex")}
 {class-kind :stamp-name "STAMPWTAG_comp__EncageFixup_O" :stamp-key "comp::EncageFixup_O"
             :parent-class "comp::LexFixup_O" :lisp-class-base "comp::LexFixup_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -1051,20 +1138,6 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "mp::SharedMutex_O"
              :layout-offset-field-names ("_SharedMutex" ".mReaders")}
-{class-kind :stamp-name "STAMPWTAG_core__GFBytecodeModule_O" :stamp-key "core::GFBytecodeModule_O"
-            :parent-class "core::CxxObject_O" :lisp-class-base "core::CxxObject_O"
-            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::GFBytecodeModule_O" :layout-offset-field-names ("_Literals")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::GFBytecodeModule_O"
-             :layout-offset-field-names ("_GFBytecode")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::GFBytecodeModule_O"
-             :layout-offset-field-names ("_CompileInfo")}
 {class-kind :stamp-name "STAMPWTAG_mp__Process_O" :stamp-key "mp::Process_O"
             :parent-class "core::CxxObject_O" :lisp-class-base "core::CxxObject_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -4685,6 +4758,9 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "comp::Context_O"
              :layout-offset-field-names ("_receiving")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>" :offset-base-ctype "comp::Context_O"
+             :layout-offset-field-names ("_dynenv")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "comp::Context_O"
              :layout-offset-field-names ("_cfunction")}

--- a/src/analysis/clasp_gc_cando.sif
+++ b/src/analysis/clasp_gc_cando.sif
@@ -31,7 +31,7 @@
                           "core::SimpleMDArray_O" "core::VMFrameDynEnv_O"
                           "core::SymbolClassHolderPair" "comp::EncageFixup_O"
                           "chem::EnergyAnchorRestraint_O" "chem::FFAngle_O" "chem::Smirks_O"
-                          "core::GFBytecodeModule_O" "core::ShortFloat_O" "llvmo::MDString_O"
+                          "core::ShortFloat_O" "llvmo::MDString_O"
                           "chem::EnergyDihedralRestraint_O" "core::T_O" "core::Number_O"
                           "llvmo::DICompileUnit_O" "core::BindingDynEnv_O"
                           "core::AbstractSimpleVector_O" "core::SimpleMDArray_byte16_t_O"
@@ -121,11 +121,11 @@
                           "chem::ConformationExplorerMatch_O" "llvmo::Library_O" "core::Closure_O"
                           "core::ComplexVector_size_t_O" "chem::RestraintAngle_O"
                           "chem::ChemExposer_O" "chem::EnergyStretch" "chem::CandoDatabase_O"
-                          "chem::SpanningInfo_O" "mpip::Mpi_O" "llvmo::DINodeArray_O"
-                          "chem::KeyEntry" "llvmo::ConstantDataArray_O" "llvmo::TargetOptions_O"
-                          "core::Instance_O" "chem::CDText_O" "chem::MessageReport_O"
-                          "core::SmallMap_O" "clasp_ffi::ForeignTypeSpec_O" "chem::BondTest_O"
-                          "core::Unused_dummy_O" "chem::EnergyChiralRestraint"
+                          "comp::RestoreSPFixup_O" "chem::SpanningInfo_O" "mpip::Mpi_O"
+                          "llvmo::DINodeArray_O" "chem::KeyEntry" "llvmo::ConstantDataArray_O"
+                          "llvmo::TargetOptions_O" "core::Instance_O" "chem::CDText_O"
+                          "chem::MessageReport_O" "core::SmallMap_O" "clasp_ffi::ForeignTypeSpec_O"
+                          "chem::BondTest_O" "core::Unused_dummy_O" "chem::EnergyChiralRestraint"
                           "llvmo::DWARFContext_O" "chem::EnergyOutOfZPlane_O"
                           "adapt::IterateCons_O" "core::HashTableEqual_O" "llvmo::Triple_O"
                           "core::SimpleMDArray_byte64_t_O" "geom::GeomExposer_O"
@@ -198,8 +198,9 @@
                           "core::SimpleMDArray_byte4_t_O" "core::Float_O"
                           "chem::EnergySketchStretch" "chem::ResidueTest_O"
                           "chem::RestraintDistance_O" "llvmo::DIDerivedType_O" "chem::SmartsRoot_O"
-                          "chem::TwisterDriver_O" "core::SimpleVector_int64_t_O"
-                          "llvmo::ConstantDataSequential_O" "chem::SuperposeEngine_O"
+                          "chem::TwisterDriver_O" "comp::EntryCloseFixup_O"
+                          "core::SimpleVector_int64_t_O" "llvmo::ConstantDataSequential_O"
+                          "chem::SuperposeEngine_O" "comp::EntryFixup_O"
                           "chem::BeyondThresholdFixedNonbondRestraint" "units::NamedUnit_O"
                           "core::MDArray_double_O" "chem::EntityNameSet_O" "llvmo::StoreInst_O"
                           "llvmo::DebugLoc_O" "chem::ResidueList_O" "core::WeakPointer_O"
@@ -208,8 +209,8 @@
                           "comp::LexSetFixup_O" "core::SimpleMDArray_byte8_t_O"
                           "core::UnwindProtectDynEnv_O" "comp::SymbolMacroVarInfo_O"
                           "chem::VirtualSphere_O" "chem::ProperTorsion_O" "chem::IterateResidues_O"
-                          "llvmo::Instruction_O" "core::FileStream_O" "core::Rational_O"
-                          "core::CatchDynEnv_O" "core::MDArrayCharacter_O"
+                          "llvmo::Instruction_O" "core::FileStream_O" "comp::ExitFixup_O"
+                          "core::Rational_O" "core::CatchDynEnv_O" "core::MDArrayCharacter_O"
                           "llvmo::LandingPadInst_O" "kinematics::KinematicsExposer_O"
                           "core::Function_O" "kinematics::BondedJoint_O"
                           "core::SimpleMDArray_int2_t_O" "core::ImmobileObject_O"
@@ -375,6 +376,29 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<comp::Label_O>"
              :offset-base-ctype "comp::LabelFixup_O" :layout-offset-field-names ("_label")}
+{class-kind :stamp-name "STAMPWTAG_comp__ExitFixup_O" :stamp-key "comp::ExitFixup_O"
+            :parent-class "comp::LabelFixup_O" :lisp-class-base "comp::LexFixup_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "comp::ExitFixup_O"
+             :layout-offset-field-names ("_cfunction")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_index")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::ExitFixup_O"
+             :layout-offset-field-names ("_initial_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_size")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_initial_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<comp::Label_O>"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_label")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<comp::LexicalVarInfo_O>"
+             :offset-base-ctype "comp::ExitFixup_O" :layout-offset-field-names ("_lex")}
 {class-kind :stamp-name "STAMPWTAG_comp__ControlLabelFixup_O"
             :stamp-key "comp::ControlLabelFixup_O" :parent-class "comp::LabelFixup_O"
             :lisp-class-base "comp::LabelFixup_O" :root-class "core::T_O" :stamp-wtag 3
@@ -472,6 +496,68 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<comp::LexicalVarInfo_O>"
              :offset-base-ctype "comp::LexSetFixup_O" :layout-offset-field-names ("_lex")}
+{class-kind :stamp-name "STAMPWTAG_comp__EntryFixup_O" :stamp-key "comp::EntryFixup_O"
+            :parent-class "comp::LexFixup_O" :lisp-class-base "comp::LexFixup_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "comp::EntryFixup_O"
+             :layout-offset-field-names ("_cfunction")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryFixup_O" :layout-offset-field-names ("_index")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryFixup_O" :layout-offset-field-names ("_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryFixup_O"
+             :layout-offset-field-names ("_initial_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryFixup_O" :layout-offset-field-names ("_size")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryFixup_O" :layout-offset-field-names ("_initial_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<comp::LexicalVarInfo_O>"
+             :offset-base-ctype "comp::EntryFixup_O" :layout-offset-field-names ("_lex")}
+{class-kind :stamp-name "STAMPWTAG_comp__EntryCloseFixup_O" :stamp-key "comp::EntryCloseFixup_O"
+            :parent-class "comp::LexFixup_O" :lisp-class-base "comp::LexFixup_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "comp::EntryCloseFixup_O" :layout-offset-field-names ("_cfunction")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryCloseFixup_O" :layout-offset-field-names ("_index")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryCloseFixup_O" :layout-offset-field-names ("_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryCloseFixup_O"
+             :layout-offset-field-names ("_initial_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryCloseFixup_O" :layout-offset-field-names ("_size")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::EntryCloseFixup_O"
+             :layout-offset-field-names ("_initial_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<comp::LexicalVarInfo_O>"
+             :offset-base-ctype "comp::EntryCloseFixup_O" :layout-offset-field-names ("_lex")}
+{class-kind :stamp-name "STAMPWTAG_comp__RestoreSPFixup_O" :stamp-key "comp::RestoreSPFixup_O"
+            :parent-class "comp::LexFixup_O" :lisp-class-base "comp::LexFixup_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "comp::RestoreSPFixup_O" :layout-offset-field-names ("_cfunction")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::RestoreSPFixup_O" :layout-offset-field-names ("_index")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::RestoreSPFixup_O" :layout-offset-field-names ("_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::RestoreSPFixup_O"
+             :layout-offset-field-names ("_initial_position")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::RestoreSPFixup_O" :layout-offset-field-names ("_size")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_long" :offset-ctype "unsigned long"
+             :offset-base-ctype "comp::RestoreSPFixup_O"
+             :layout-offset-field-names ("_initial_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<comp::LexicalVarInfo_O>"
+             :offset-base-ctype "comp::RestoreSPFixup_O" :layout-offset-field-names ("_lex")}
 {class-kind :stamp-name "STAMPWTAG_comp__LexRefFixup_O" :stamp-key "comp::LexRefFixup_O"
             :parent-class "comp::LexFixup_O" :lisp-class-base "comp::LexFixup_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -3120,20 +3206,6 @@
              :offset-ctype "gctools::smart_ptr<chem::CalculatePosition_O>"
              :offset-base-ctype "chem::ConstitutionVirtualAtom_O"
              :layout-offset-field-names ("_CalculatePositionCode")}
-{class-kind :stamp-name "STAMPWTAG_core__GFBytecodeModule_O" :stamp-key "core::GFBytecodeModule_O"
-            :parent-class "core::CxxObject_O" :lisp-class-base "core::CxxObject_O"
-            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::GFBytecodeModule_O" :layout-offset-field-names ("_Literals")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::GFBytecodeModule_O"
-             :layout-offset-field-names ("_GFBytecode")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::GFBytecodeModule_O"
-             :layout-offset-field-names ("_CompileInfo")}
 {class-kind :stamp-name "STAMPWTAG_chem__Smirks_O" :stamp-key "chem::Smirks_O"
             :parent-class "core::CxxObject_O" :lisp-class-base "core::CxxObject_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -6292,6 +6364,9 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "comp::Context_O"
              :layout-offset-field-names ("_receiving")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>" :offset-base-ctype "comp::Context_O"
+             :layout-offset-field-names ("_dynenv")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "comp::Context_O"
              :layout-offset-field-names ("_cfunction")}

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -1274,50 +1274,6 @@ gctools::return_type bytecode_call(unsigned char* pc, core::T_O* lcc_closure, si
 
 }; // extern C
 
-
-
-
-namespace core {
-
-
-void GFBytecodeModule_O::initialize() {
-  this->_Literals = nil<core::T_O>();
-  this->_GFBytecode = nil<core::T_O>();
-}
-
-CL_DEFMETHOD
-GFBytecodeModule_O::Literals_sp_Type GFBytecodeModule_O::literals() const {
-  return this->_Literals;
-}
-
-CL_DEFMETHOD
-void GFBytecodeModule_O::setf_literals(GFBytecodeModule_O::Literals_sp_Type o) {
-  this->_Literals = o;
-}
-
-CL_DEFMETHOD
-GFBytecodeModule_O::GFBytecode_sp_Type GFBytecodeModule_O::bytecode() const {
-  return this->_GFBytecode;
-}
-
-CL_DEFMETHOD
-void GFBytecodeModule_O::setf_bytecode(GFBytecodeModule_O::GFBytecode_sp_Type o) {
-  this->_GFBytecode = o;
-}
-
-CL_DEFMETHOD
-T_sp GFBytecodeModule_O::compileInfo() const {
-  return this->_CompileInfo;
-}
-
-CL_DEFMETHOD
-void GFBytecodeModule_O::setf_compileInfo(T_sp o) {
-  this->_CompileInfo = o;
-}
-
-};
-
-
 namespace core {
 
 

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -656,9 +656,9 @@ static gctools::return_type bytecode_vm(VirtualMachine& vm,
     case vm_mv_call: {
       DBG_VM("mv-call\n");
       T_O* func = vm.pop(sp);
-      size_t nargs = lisp_multipleValues().getSize();
+      size_t nargs = multipleValues.getSize();
       T_O* args[nargs];
-      multipleValuesSaveToTemp(nargs, args);
+      multipleValues.saveToTemp(nargs, args);
       vm._stackPointer = sp;
       T_mv res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
       multipleValues.setN(res.raw_(),res.number_of_values());
@@ -668,9 +668,9 @@ static gctools::return_type bytecode_vm(VirtualMachine& vm,
     case vm_mv_call_receive_one: {
       DBG_VM("mv-call-receive-one\n");
       T_O* func = vm.pop(sp);
-      size_t nargs = lisp_multipleValues().getSize();
+      size_t nargs = multipleValues.getSize();
       T_O* args[nargs];
-      multipleValuesSaveToTemp(nargs, args);
+      multipleValues.saveToTemp(nargs, args);
       vm._stackPointer = sp;
       T_sp res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
       multipleValues.set1(res);
@@ -684,7 +684,7 @@ static gctools::return_type bytecode_vm(VirtualMachine& vm,
       T_O* func = vm.pop(sp);
       size_t nargs = multipleValues.getSize();
       T_O* args[nargs];
-      multipleValuesSaveToTemp(nargs, args);
+      multipleValues.saveToTemp(nargs, args);
       vm._stackPointer = sp;
       T_mv res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
       multipleValues.setN(res.raw_(),res.number_of_values());
@@ -1167,7 +1167,7 @@ static unsigned char *long_dispatch(VirtualMachine& vm,
     T_O* func = vm.pop(sp);
     size_t nargs = multipleValues.getSize();
     T_O* args[nargs];
-    multipleValuesSaveToTemp(nargs, args);
+    multipleValues.saveToTemp(nargs, args);
     vm._stackPointer = sp;
     T_mv res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
     multipleValues.setN(res.raw_(),res.number_of_values());

--- a/src/core/funcallableInstance.cc
+++ b/src/core/funcallableInstance.cc
@@ -195,12 +195,10 @@ void FuncallableInstance_O::describe(T_sp stream) {
   clasp_write_string(ss.str(), stream);
 }
 
+// FIXME: Don't export this.
 DOCGROUP(clasp);
-CL_DEFUN T_mv clos__getFuncallableInstanceFunction(T_sp obj) {
-  if (FuncallableInstance_sp iobj = obj.asOrNull<FuncallableInstance_O>()) {
-    return Values(_lisp->_true(), Pointer_O::create((void *)iobj->entry()));
-  } else
-    return Values(nil<T_O>(), nil<T_O>());
+CL_DEFUN Function_sp clos__getFuncallableInstanceFunction(FuncallableInstance_sp obj) {
+  return obj->REAL_FUNCTION();
 };
 
 DOCGROUP(clasp);

--- a/src/lisp/kernel/clos/package.lisp
+++ b/src/lisp/kernel/clos/package.lisp
@@ -148,6 +148,9 @@
 (export '(no-applicable-method-error))
 
 #+clasp
+(export '(disassemble-discriminator))
+
+#+clasp
 (export '(start-profiling stop-profiling
           report-profiling profiling-data
           with-profiling))

--- a/src/lisp/kernel/cmp/bytecode-reference.lisp
+++ b/src/lisp/kernel/cmp/bytecode-reference.lisp
@@ -1663,6 +1663,8 @@
                               (core:bytecode-module/literals module)))))
   (values))
 
+(export 'disassemble-bytecode-function)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;;  Now the Generic-function dtree interpreter virtual machine instructions
@@ -1692,6 +1694,3 @@
 
 (export '(dump-gf-bytecode-virtual-machine
           dump-python-gf-bytecode-virtual-machine) :clos)
-
-
-

--- a/src/lisp/kernel/cmp/disassemble.lisp
+++ b/src/lisp/kernel/cmp/disassemble.lisp
@@ -69,11 +69,22 @@
   (values))
 
 (defun disassemble (desig &key (type :asm))
-  "If type is :ASM (the default) then disassemble to machine assembly language.
+  "If type is :ASM (the default) then disassemble to assembly language.
 If type is :IR then dump the LLVM-IR for all of the associated functions.
  Because Clasp does not normally store LLVM-IR for compiled functions,
  this case only works if a lambda expression or interpreted function is provided."
   (etypecase desig
+    (core:global-bytecode-simple-fun
+     (unless (eq type :asm)
+       (error "Only disassembly to bytecode is supported for bytecode function: ~a" desig))
+     (cmpref:disassemble-bytecode-function desig))
+    (core:funcallable-instance
+     (disassemble (clos:get-funcallable-instance-function desig) :type type))
+    (core:gfbytecode-simple-fun
+     (unless (eq type :asm)
+       (error "Only disassembly to bytecode is supported for bytecode discriminating function: ~a" desig))
+     ;; Defined later in clos/dtree.lisp.
+     (clos::disassemble-discriminator desig))
     (compiled-function
      (ecase type
        ((:ir)

--- a/src/llvmo/link_intrinsics.cc
+++ b/src/llvmo/link_intrinsics.cc
@@ -1275,13 +1275,13 @@ size_t cc_nvalues()
 
 void cc_save_all_values(size_t nvals, T_O** vector)
 {NO_UNWIND_BEGIN();
-  multipleValuesSaveToTemp(nvals, vector);
+  lisp_multipleValues().saveToTemp(nvals, vector);
   NO_UNWIND_END();
 }
 
 void cc_load_all_values(size_t nvals, T_O** vector)
 {NO_UNWIND_BEGIN();
-  multipleValuesLoadFromTemp(nvals, vector);
+  lisp_multipleValues().loadFromTemp(nvals, vector);
   NO_UNWIND_END();
 }
 


### PR DESCRIPTION
Implements `entry` elision in the bytecode compiler, which i the last optimization "pass" it should need.