### PR TITLE
Inline some fixnum arithmetic

### DIFF
--- a/include/clasp/core/bignum.h
+++ b/include/clasp/core/bignum.h
@@ -52,7 +52,7 @@ public:
   }
 public:
   typedef mp_limb_t value_type;
-private: // instance variables here
+public: // instance variables here
   gctools::GCArraySignedLength_moveable<mp_limb_t> _limbs;
 
 public: // Functions here

--- a/src/core/bignum.cc
+++ b/src/core/bignum.cc
@@ -845,4 +845,42 @@ CL_DEFUN int core__next_compare(Bignum_sp left,
   }
 }
 
+
+CL_DEFUN Bignum_sp core__dump_bignum(Bignum_sp bignum)
+{
+  int64_t len = bignum->_limbs.signedLength();
+  printf("%s:%d:%s len = %ld\n", __FILE__, __LINE__, __FUNCTION__, len );
+  for (size_t ii = 0; ii<bignum->_limbs.size(); ii++ ) {
+    printf("%s:%d:%s  limb[%lu] = %lx\n", __FILE__, __LINE__, __FUNCTION__, ii, bignum->_limbs[ii] );
+  }
+  return bignum;
+}
+
+CL_DEFUN Bignum_sp core__bignum_from_fixnum_add_over(int64_t add_over)
+{
+  printf("%s:%d:%s       add_over = %lx\n", __FILE__, __LINE__, __FUNCTION__, add_over );
+  mp_limb_t limb;
+  int64_t len;
+  if ( add_over<0 ) { // positive
+    len = 1;
+    limb = ((uint64_t)add_over)>>2;
+  } if (add_over>0 ) { // negative
+    len = -1;
+    limb = ((uint64_t)((~add_over)+1))>>2;
+  } else { // add_over == 0
+    len = -1;
+    limb = 0x4000000000000000;
+  }
+  printf("%s:%d:%s  len = %2ld limb = %lx\n", __FILE__, __LINE__, __FUNCTION__, len, limb );
+  return Bignum_O::create_from_limbs(len,limb,true);
+}
+
+CL_DEFUN Bignum_sp core__bignum_do_fixnum_add_over(T_sp x, T_sp y)
+{
+  printf("%s:%d:%s x = %p y = %p\n", __FILE__, __LINE__, __FUNCTION__, x.raw_(), y.raw_() );
+  int64_t add_over = (int64_t)x.raw_() + (int64_t)y.raw_();
+  return core__bignum_from_fixnum_add_over(add_over);
+}
+
+
 }; // namespace core

--- a/src/lisp/kernel/cleavir/bir-to-bmir.lisp
+++ b/src/lisp/kernel/cleavir/bir-to-bmir.lisp
@@ -230,11 +230,12 @@
   (deflog2 core:logior-2op core::fixnum-logior)
   (deflog2 core:logxor-2op core::fixnum-logxor))
 
-;;; This is a very KLUDGEy way to find additions of fixnums whose result is
-;;; a fixnum as well. Plus it hardcodes the number of fixnum bits. FIXME
 (deftransform-wr core:two-arg-+ core::fixnum-add fixnum fixnum fixnum)
 (deftransform-wr core:two-arg-- core::fixnum-sub fixnum fixnum fixnum)
 (deftransform-wr core:two-arg-* core::fixnum-mul fixnum fixnum fixnum)
+
+(deftransform core:two-arg-+ core::fixnum-add-over fixnum fixnum)
+(deftransform core:two-arg-- core::fixnum-sub-over fixnum fixnum)
 
 (deftransform logcount core::fixnum-positive-logcount (and fixnum unsigned-byte))
 

--- a/src/lisp/kernel/cleavir/primop.lisp
+++ b/src/lisp/kernel/cleavir/primop.lisp
@@ -398,6 +398,8 @@
          (big (%intrinsic-invoke-if-landing-pad-or-call
                "cc_overflowed_signed_bignum"
                (list (cmp:irc-extract-value r '(0)))))
+         ;; Necessary because invoke interposes a block.
+         (bigblock (cmp:irc-get-insert-block))
          (_3 (cmp:irc-br after-block))
          (_4 (cmp:irc-begin-block no-overflow-block))
          (fix (cmp:irc-int-to-ptr (cmp:irc-extract-value r '(0)) cmp:%t*%)))
@@ -405,7 +407,33 @@
     (cmp:irc-br after-block)
     (cmp:irc-begin-block after-block)
     (let ((phi (cmp:irc-phi cmp:%t*% 2 "sum")))
-      (cmp:irc-phi-add-incoming phi big overflow-block)
+      (cmp:irc-phi-add-incoming phi big bigblock)
+      (cmp:irc-phi-add-incoming phi fix no-overflow-block)
+      phi)))
+
+(defvprimop (core::fixnum-sub-over :flags (:flushable))
+    ((:object) :fixnum :fixnum) (inst)
+  (let* ((arg1 (in (first (bir:inputs inst))))
+         (arg2 (in (second (bir:inputs inst))))
+         (r (%intrinsic-call "llvm.ssub.with.overflow.i64" (list arg1 arg2)))
+         (overflowp (cmp:irc-extract-value r '(1)))
+         (overflow-block (cmp:irc-basic-block-create "overflow"))
+         (no-overflow-block (cmp:irc-basic-block-create "no-overflow"))
+         (after-block (cmp:irc-basic-block-create "after"))
+         (_1 (cmp:irc-cond-br overflowp overflow-block no-overflow-block))
+         (_2 (cmp:irc-begin-block overflow-block))
+         (big (%intrinsic-invoke-if-landing-pad-or-call
+               "cc_overflowed_signed_bignum"
+               (list (cmp:irc-extract-value r '(0)))))
+         (bigblock (cmp:irc-get-insert-block))
+         (_3 (cmp:irc-br after-block))
+         (_4 (cmp:irc-begin-block no-overflow-block))
+         (fix (cmp:irc-int-to-ptr (cmp:irc-extract-value r '(0)) cmp:%t*%)))
+    (declare (ignore _1 _2 _3 _4))
+    (cmp:irc-br after-block)
+    (cmp:irc-begin-block after-block)
+    (let ((phi (cmp:irc-phi cmp:%t*% 2 "difference")))
+      (cmp:irc-phi-add-incoming phi big bigblock)
       (cmp:irc-phi-add-incoming phi fix no-overflow-block)
       phi)))
 

--- a/src/lisp/kernel/cmp/primitives.lisp
+++ b/src/lisp/kernel/cmp/primitives.lisp
@@ -126,7 +126,7 @@
          (primitive         "__cxa_begin_catch" :i8* (list :i8*) )
          (primitive-unwinds "__cxa_end_catch" :void nil)
          (primitive         "llvm.eh.typeid.for" :i32 (list :i8*))
-    
+         (primitive-unwinds "cc_overflowed_signed_bignum" :t* (list :i64))
          (primitive         "llvm.sadd.with.overflow.i32" :{i32.i1} (list :i32 :i32))
          (primitive         "llvm.sadd.with.overflow.i64" :{i64.i1} (list :i64 :i64))
          (primitive         "llvm.ssub.with.overflow.i32" :{i32.i1} (list :i32 :i32))

--- a/src/llvmo/link_intrinsics.cc
+++ b/src/llvmo/link_intrinsics.cc
@@ -1061,7 +1061,23 @@ extern "C" {
 
 //#define DEBUG_CC
 
-core::T_O* cc_overflowed_signed_bignum(uint64_t n) {
+core::T_O* cc_overflowed_signed_bignum(int64_t add_over) {
+  //printf("%s:%d:%s add_over = %lx\n", __FILE__, __LINE__, __FUNCTION__, add_over );
+  mp_limb_t limb;
+  int64_t len;
+  if ( add_over<0 ) { // positive
+    len = 1;
+    limb = ((uint64_t)add_over)>>2;
+  } else if (add_over>0 ) { // negative
+    len = -1;
+    limb = ((uint64_t)((~add_over)+1))>>2;
+  } else { // add_over == 0
+    len = -1;
+    limb = 0x4000000000000000;
+  }
+  //printf("%s:%d:%s  len = %2ld limb = %lx\n", __FILE__, __LINE__, __FUNCTION__, len, limb );
+  return core::Bignum_O::create_from_limbs(len,limb,true).raw_();
+#if 0
   // Given the mod'd result of an overflowed sum or difference,
   // allocate and return a bignum.
   // This can unwind if we run out of memory or whatnot.
@@ -1071,6 +1087,7 @@ core::T_O* cc_overflowed_signed_bignum(uint64_t n) {
   union { uint64_t u; int64_t i; } c;
   c.u = (n ^ 0x8000000000000000) | ((gc::Fixnum)1 << gc::fixnum_bits);
   return Integer_O::create(c.i >> gc::fixnum_shift).raw_();
+#endif
 }
 
 void cc_setSymbolValue(core::T_O *sym, core::T_O *val)

--- a/src/llvmo/link_intrinsics.cc
+++ b/src/llvmo/link_intrinsics.cc
@@ -1061,8 +1061,18 @@ extern "C" {
 
 //#define DEBUG_CC
 
-#define PROTO_cc_setSymbolValue "void (t* t*)"
-#define CATCH_cc_setSymbolValue false
+core::T_O* cc_overflowed_signed_bignum(uint64_t n) {
+  // Given the mod'd result of an overflowed sum or difference,
+  // allocate and return a bignum.
+  // This can unwind if we run out of memory or whatnot.
+  printf("cc_overflowed_signed_bignum n = %" PRIx64 "\n", n);
+  // FIXME: There's probably a way to avoid this arithmetic.
+  // The problem is that the sign bit was overflowed.
+  union { uint64_t u; int64_t i; } c;
+  c.u = (n ^ 0x8000000000000000) | ((gc::Fixnum)1 << gc::fixnum_bits);
+  return Integer_O::create(c.i >> gc::fixnum_shift).raw_();
+}
+
 void cc_setSymbolValue(core::T_O *sym, core::T_O *val)
 {NO_UNWIND_BEGIN();
   //	core::Symbol_sp s = gctools::smart_ptr<core::Symbol_O>(reinterpret_cast<core::Symbol_O*>(sym));

--- a/src/llvmo/link_intrinsics.cc
+++ b/src/llvmo/link_intrinsics.cc
@@ -1062,9 +1062,8 @@ extern "C" {
 //#define DEBUG_CC
 
 core::T_O* cc_overflowed_signed_bignum(int64_t add_over) {
-  //printf("%s:%d:%s add_over = %lx\n", __FILE__, __LINE__, __FUNCTION__, add_over );
   mp_limb_t limb;
-  int64_t len;
+  mp_size_t len;
   if ( add_over<0 ) { // positive
     len = 1;
     limb = ((uint64_t)add_over)>>2;
@@ -1075,19 +1074,7 @@ core::T_O* cc_overflowed_signed_bignum(int64_t add_over) {
     len = -1;
     limb = 0x4000000000000000;
   }
-  //printf("%s:%d:%s  len = %2ld limb = %lx\n", __FILE__, __LINE__, __FUNCTION__, len, limb );
   return core::Bignum_O::create_from_limbs(len,limb,true).raw_();
-#if 0
-  // Given the mod'd result of an overflowed sum or difference,
-  // allocate and return a bignum.
-  // This can unwind if we run out of memory or whatnot.
-  printf("cc_overflowed_signed_bignum n = %" PRIx64 "\n", n);
-  // FIXME: There's probably a way to avoid this arithmetic.
-  // The problem is that the sign bit was overflowed.
-  union { uint64_t u; int64_t i; } c;
-  c.u = (n ^ 0x8000000000000000) | ((gc::Fixnum)1 << gc::fixnum_bits);
-  return Integer_O::create(c.i >> gc::fixnum_shift).raw_();
-#endif
 }
 
 void cc_setSymbolValue(core::T_O *sym, core::T_O *val)


### PR DESCRIPTION
specifically sums and differences where both arguments are fixnums, even when the compiler can't prove there's no overflow. This is slightly more complicated than the no-overflow case but I don't think it increases code size too much, and SBCL does it.