### PR TITLE
Bytecode debug

### DIFF
--- a/include/clasp/core/backtrace.h
+++ b/include/clasp/core/backtrace.h
@@ -30,18 +30,19 @@ public:
   void fields(Record_sp node) override;
   std::string __repr__() const;
   DebuggerFrame_O(T_sp a_fname, T_sp a_return_address, T_sp a_sp, T_sp a_fd,
-                  T_sp a_closure, T_sp a_args, bool a_av, T_sp a_lang,
-                  bool a_is_xep)
-      : fname(a_fname), return_address(a_return_address),
+                  T_sp a_closure, T_sp a_args, bool a_av, List_sp a_locals,
+                  T_sp a_lang, bool a_is_xep)
+    : fname(a_fname), return_address(a_return_address),
       source_position(a_sp), function_description(a_fd),
-      closure(a_closure), args(a_args), args_available(a_av), is_xep(a_is_xep),
+      closure(a_closure), args(a_args), args_available(a_av),
+      locals(a_locals), is_xep(a_is_xep),
       lang(a_lang), up(nil<T_O>()), down(nil<T_O>())
   {}
   static DebuggerFrame_sp make(T_sp fname, T_sp ra,
                                T_sp sp, T_sp fd,
                                T_sp closure, T_sp args, bool args_available,
-                               T_sp lang, bool is_xep) {
-    auto  ret = gctools::GC<DebuggerFrame_O>::allocate( fname, ra, sp, fd, closure, args, args_available, lang, is_xep);
+                               List_sp locals, T_sp lang, bool is_xep) {
+    auto  ret = gctools::GC<DebuggerFrame_O>::allocate( fname, ra, sp, fd, closure, args, args_available, locals, lang, is_xep);
     return ret;
   }
   T_sp returnAddress() const;
@@ -53,6 +54,7 @@ public:
   T_sp closure;
   T_sp args;
   bool args_available;
+  List_sp locals;
   T_sp lang;
   T_sp up;
   T_sp down;

--- a/include/clasp/core/bytecode.h
+++ b/include/clasp/core/bytecode.h
@@ -37,14 +37,17 @@ public:
   Literals_sp_Type                   _Literals;
   Bytecode_sp_Type                   _Bytecode;
   T_sp                               _CompileInfo;
-  T_sp                               _DebugInfo;
+  T_sp                               _DebugInfo = nil<T_O>();
 
 public:
+  BytecodeModule_O() {};
   CL_LISPIFY_NAME(BytecodeModule/make)
   CL_DEF_CLASS_METHOD
   static BytecodeModule_sp make() {
     // When we can gc code allocate entire block in GC memory
     BytecodeModule_sp codeblock = gctools::GC<BytecodeModule_O>::allocate<gctools::RuntimeStage>();
+    // Register the new module for the debugger
+    codeblock->register_for_debug();
     return codeblock;
   };
 
@@ -57,7 +60,9 @@ public:
   CL_LISPIFY_NAME(BytecodeModule/debugInfo)
   CL_DEFMETHOD T_sp debugInfo() const { return this->_DebugInfo; }
   void setf_debugInfo(T_sp info) { this->_DebugInfo = info; }
-  BytecodeModule_O() {};
+
+  // Add the module to *all-bytecode-modules* for the debugger.
+  void register_for_debug();
 };
 
 // Dynenv used for VM call frames to ensure the unwinder properly

--- a/include/clasp/core/bytecode.h
+++ b/include/clasp/core/bytecode.h
@@ -59,7 +59,8 @@ public:
   void setf_compileInfo(T_sp obj);
   CL_LISPIFY_NAME(BytecodeModule/debugInfo)
   CL_DEFMETHOD T_sp debugInfo() const { return this->_DebugInfo; }
-  void setf_debugInfo(T_sp info) { this->_DebugInfo = info; }
+  CL_LISPIFY_NAME(BytecodeModule/setfDebugInfo)
+  CL_DEFMETHOD void setf_debugInfo(T_sp info) { this->_DebugInfo = info; }
 
   // Add the module to *all-bytecode-modules* for the debugger.
   void register_for_debug();
@@ -72,6 +73,8 @@ class BytecodeDebugVars_O : public General_O {
 public:
   BytecodeDebugVars_O(T_sp start, T_sp end, List_sp bindings)
     : _start(start), _end(end), _bindings(bindings) {}
+  CL_LISPIFY_NAME(BytecodeDebugVars/make)
+  CL_DEF_CLASS_METHOD
   static BytecodeDebugVars_sp make(T_sp start, T_sp end, List_sp bindings) {
     return gctools::GC<BytecodeDebugVars_O>::allocate<gctools::RuntimeStage>(start, end, bindings);
   }

--- a/include/clasp/core/bytecode.h
+++ b/include/clasp/core/bytecode.h
@@ -37,6 +37,7 @@ public:
   Literals_sp_Type                   _Literals;
   Bytecode_sp_Type                   _Bytecode;
   T_sp                               _CompileInfo;
+  T_sp                               _DebugInfo;
 
 public:
   CL_LISPIFY_NAME(BytecodeModule/make)
@@ -53,6 +54,8 @@ public:
   void setf_bytecode(T_sp obj);
   Bytecode_sp_Type compileInfo() const;
   void setf_compileInfo(T_sp obj);
+  T_sp debugInfo() const { return this->_DebugInfo; }
+  void setf_debugInfo(T_sp info) { this->_DebugInfo = info; }
   BytecodeModule_O() {};
 };
 

--- a/include/clasp/core/bytecode.h
+++ b/include/clasp/core/bytecode.h
@@ -65,6 +65,31 @@ public:
   void register_for_debug();
 };
 
+// Debug information structure for bindings.
+FORWARD(BytecodeDebugVars);
+class BytecodeDebugVars_O : public General_O {
+  LISP_CLASS(core, CorePkg, BytecodeDebugVars_O, "BytecodeDebugVars", core::General_O);
+public:
+  BytecodeDebugVars_O(T_sp start, T_sp end, List_sp bindings)
+    : _start(start), _end(end), _bindings(bindings) {}
+  static BytecodeDebugVars_sp make(T_sp start, T_sp end, List_sp bindings) {
+    return gctools::GC<BytecodeDebugVars_O>::allocate<gctools::RuntimeStage>(start, end, bindings);
+  }
+public:
+  T_sp _start;
+  T_sp _end;
+  List_sp _bindings;
+public:
+  CL_LISPIFY_NAME(BytecodeDebugVars/start)
+  CL_DEFMETHOD T_sp start() const { return this->_start; }
+  void setStart(T_sp start) { this->_start = start; }
+  CL_LISPIFY_NAME(BytecodeDebugVars/end)
+  CL_DEFMETHOD T_sp end() const { return this->_end; }
+  void setEnd(T_sp end) { this->_end = end; }
+  CL_LISPIFY_NAME(BytecodeDebugVars/bindings)
+  CL_DEFMETHOD List_sp bindings() const { return this->_bindings; }
+};
+
 // Dynenv used for VM call frames to ensure the unwinder properly
 // cleans up stack frames.
 class VMFrameDynEnv_O : public DynEnv_O {
@@ -93,6 +118,8 @@ namespace core {
 
 bool bytecode_module_contains_address_p(BytecodeModule_sp, void*);
 bool bytecode_function_contains_address_p(GlobalBytecodeSimpleFun_sp, void*);
+T_sp bytecode_function_for_pc(BytecodeModule_sp, void*);
+List_sp bytecode_bindings_for_pc(BytecodeModule_sp, void*, T_O**);
 void* bytecode_pc();
 
 }; // namespace core

--- a/include/clasp/core/bytecode_compiler.h
+++ b/include/clasp/core/bytecode_compiler.h
@@ -349,6 +349,7 @@ public:
   size_t literal_index(T_sp literal) const;
   size_t new_literal_index(T_sp literal) const;
   size_t closure_index(T_sp info) const;
+  void push_debug_info(T_sp info) const;
   void assemble0(uint8_t opcode) const;
   void assemble1(uint8_t opcode, size_t operand1) const;
   void assemble2(uint8_t opcode, size_t operand1, size_t operand2) const;
@@ -704,13 +705,18 @@ class Module_O : public General_O {
 public:
   ComplexVector_T_sp _cfunctions;
   ComplexVector_T_sp _literals;
+  ComplexVector_T_sp _debugInfo;
 public:
   Module_O()
     : _cfunctions(ComplexVector_T_O::make(1, nil<T_O>(), clasp_make_fixnum(0))),
-      _literals(ComplexVector_T_O::make(0, nil<T_O>(), clasp_make_fixnum(0))) {}
+      _literals(ComplexVector_T_O::make(0, nil<T_O>(), clasp_make_fixnum(0))),
+      _debugInfo(ComplexVector_T_O::make(0, nil<T_O>(), clasp_make_fixnum(0)))
+  {}
   Module_O(ComplexVector_T_sp literals)
     : _cfunctions(ComplexVector_T_O::make(1, nil<T_O>(), clasp_make_fixnum(0))),
-      _literals(literals) {}
+      _literals(literals),
+      _debugInfo(ComplexVector_T_O::make(0, nil<T_O>(), clasp_make_fixnum(0)))
+  {}
   CL_LISPIFY_NAME(Module/make)
   CL_DEF_CLASS_METHOD
   static Module_sp make() {
@@ -725,6 +731,8 @@ public:
   CL_DEFMETHOD ComplexVector_T_sp cfunctions() { return this->_cfunctions; }
   CL_LISPIFY_NAME(module/literals) // avoid defining cmp::literals
   CL_DEFMETHOD ComplexVector_T_sp literals() { return this->_literals; }
+  ComplexVector_T_sp debugInfo() { return this->_debugInfo; }
+  void push_debug_info(T_sp info);
 public:
   // Use the optimistic bytecode vector sizes to initialize the optimistic
   // cfunction position.

--- a/include/clasp/core/bytecode_compiler.h
+++ b/include/clasp/core/bytecode_compiler.h
@@ -51,7 +51,7 @@ public:
   }
   // Does the variable need a cell?
   bool indirectLexicalP() const {
-    return this->closedOverP() || this->setP();
+    return this->closedOverP() && this->setP();
   }
 };
 

--- a/include/clasp/core/bytecode_compiler.h
+++ b/include/clasp/core/bytecode_compiler.h
@@ -731,7 +731,8 @@ public:
   CL_DEFMETHOD ComplexVector_T_sp cfunctions() { return this->_cfunctions; }
   CL_LISPIFY_NAME(module/literals) // avoid defining cmp::literals
   CL_DEFMETHOD ComplexVector_T_sp literals() { return this->_literals; }
-  ComplexVector_T_sp debugInfo() { return this->_debugInfo; }
+  CL_LISPIFY_NAME(module/debugInfo)
+  CL_DEFMETHOD ComplexVector_T_sp debugInfo() { return this->_debugInfo; }
   void push_debug_info(T_sp info);
 public:
   // Use the optimistic bytecode vector sizes to initialize the optimistic
@@ -742,6 +743,8 @@ public:
   CL_DEFMETHOD void resolve_fixup_sizes();
   // The size of the module bytecode vector.
   CL_DEFMETHOD size_t bytecode_size();
+  // Fix up the debug info with resolved labels.
+  void resolve_debug_info();
   // Create the bytecode module vector. We scan over the fixups in the
   // module and copy segments of bytecode between fixup positions.
   CL_DEFMETHOD SimpleVector_byte8_t_sp create_bytecode();
@@ -828,7 +831,8 @@ public:
     this->_extra = next;
     return next;
   }
-  size_t final_size() {
+  CL_LISPIFY_NAME(Cfunction/final_size)
+  CL_DEFMETHOD size_t final_size() {
     return this->bytecode()->length() + this->extra();
   }
   CL_LISPIFY_NAME(Cfunction/index)

--- a/include/clasp/core/bytecode_compiler.h
+++ b/include/clasp/core/bytecode_compiler.h
@@ -820,6 +820,9 @@ public:
     this->_extra = next;
     return next;
   }
+  size_t final_size() {
+    return this->bytecode()->length() + this->extra();
+  }
   CL_LISPIFY_NAME(Cfunction/index)
   CL_DEFMETHOD size_t iindex() { return _index; }
   CL_LISPIFY_NAME(Cfunction/setf-index)

--- a/include/clasp/core/function.h
+++ b/include/clasp/core/function.h
@@ -335,16 +335,19 @@ FORWARD(GlobalBytecodeSimpleFun);
   // Entry point into the bytes vector in the containing module.
   // This is an offset instead of an interior pointer to make dumping/loading/GC considerations easier.
    unsigned int     _EntryPcN;
+   // Size of this function in bytes - used for debugging
+   unsigned int     _BytecodeSize;
    BytecodeTrampolineFunction _Trampoline;
  public:
   // Accessors
    GlobalBytecodeSimpleFun_O(FunctionDescription_sp fdesc,
-                              const ClaspXepFunction& entry_point,
-                              T_sp code,
-                              unsigned short localsFrameSize,
-                              unsigned int environmentSize,
-                              unsigned int entryPcN,
-                              BytecodeTrampolineFunction trampoline);
+                             const ClaspXepFunction& entry_point,
+                             T_sp code,
+                             unsigned short localsFrameSize,
+                             unsigned int environmentSize,
+                             unsigned int entryPcN,
+                             unsigned int bytecodeSize,
+                             BytecodeTrampolineFunction trampoline);
 
  public:
    virtual Pointer_sp defaultEntryAddress() const;
@@ -356,7 +359,8 @@ FORWARD(GlobalBytecodeSimpleFun);
    CL_DEFMETHOD Fixnum localsFrameSize() const { return this->_LocalsFrameSize; };
    CL_DEFMETHOD Fixnum environmentSize() const { return this->_EnvironmentSize; };
    size_t entryPcN() const;
-
+   CL_LISPIFY_NAME(GlobalBytecodeSimpleFun/bytecode-size)
+   CL_DEFMETHOD Fixnum bytecodeSize() const { return this->_BytecodeSize; }
  };
 
 
@@ -435,11 +439,12 @@ GlobalSimpleFun_sp makeGlobalSimpleFunAndFunctionDescription(T_sp functionName,
 
 
 GlobalBytecodeSimpleFun_sp core__makeGlobalBytecodeSimpleFun(FunctionDescription_sp fdesc,
-                                                               BytecodeModule_sp module,
-                                                               size_t localsFrameSize,
-                                                               size_t environmentSize,
-                                                               size_t pcIndex,
-                                                               Pointer_sp trampoline);
+                                                             BytecodeModule_sp module,
+                                                             size_t localsFrameSize,
+                                                             size_t environmentSize,
+                                                             size_t pcIndex,
+                                                             size_t bytecodeSize,
+                                                             Pointer_sp trampoline);
 
 
 GlobalSimpleFun_sp makeGlobalSimpleFunFromGenerator(GlobalSimpleFunGenerator_sp ep, gctools::GCRootsInModule* roots, void** fptrs);

--- a/include/clasp/core/lisp.h
+++ b/include/clasp/core/lisp.h
@@ -316,6 +316,7 @@ public:
     std::atomic<T_sp>          _AllLibraries;
     std::atomic<T_sp>          _AllObjectFiles;
     std::atomic<T_sp>          _AllCodeBlocks;
+    std::atomic<T_sp>          _AllBytecodeModules;
     GlobalSimpleFun_sp        _UnboundSymbolFunctionEntryPoint;
     GlobalSimpleFun_sp        _UnboundSetfSymbolFunctionEntryPoint;
     T_sp                       _TerminalIO;

--- a/include/clasp/gctools/threadlocal.h
+++ b/include/clasp/gctools/threadlocal.h
@@ -93,6 +93,9 @@ struct VirtualMachine {
   core::T_O**    _stackTop;
   core::T_O**    _stackGuard;
   core::T_O**    _stackPointer;
+  // only used by debugger
+  // has to be initialized because bytecode_call reads it
+  core::T_O**    _framePointer = NULL;
 #ifdef DEBUG_VIRTUAL_MACHINE
   core::T_O*     _data;
   core::T_O*     _data1;

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -549,6 +549,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::GlobalBytecodeSimpleFun_O"
              :layout-offset-field-names ("_EntryPcN")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::GlobalBytecodeSimpleFun_O"
+             :layout-offset-field-names ("_BytecodeSize")}
 {fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
              :offset-base-ctype "core::GlobalBytecodeSimpleFun_O"
              :layout-offset-field-names ("_Trampoline")}
@@ -971,6 +974,9 @@
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::BytecodeModule_O"
              :layout-offset-field-names ("_CompileInfo")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::BytecodeModule_O" :layout-offset-field-names ("_DebugInfo")}
 {class-kind :stamp-name "STAMPWTAG_asttooling__PresumedLoc_O"
             :stamp-key "asttooling::PresumedLoc_O" :parent-class "core::CxxObject_O"
             :lisp-class-base "core::CxxObject_O" :root-class "core::T_O" :stamp-wtag 3

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -640,6 +640,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
              :offset-base-ctype "core::VMFrameDynEnv_O" :layout-offset-field-names ("old_sp")}
+{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
+             :offset-base-ctype "core::VMFrameDynEnv_O" :layout-offset-field-names ("old_fp")}
 {class-kind :stamp-name "STAMPWTAG_comp__Annotation_O" :stamp-key "comp::Annotation_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -73,10 +73,10 @@
                           "clasp_ffi::ForeignTypeSpec_O" "core::Unused_dummy_O"
                           "llvmo::DWARFContext_O" "core::HashTableEqual_O" "llvmo::Triple_O"
                           "core::SimpleMDArray_byte64_t_O" "core::BitVectorNs_O"
-                          "core::CoreExposer_O" "comp::JumpIfSuppliedFixup_O" "core::KeyValuePair"
-                          "llvmo::NamedMDNode_O" "core::SimpleVector_byte16_t_O"
-                          "llvmo::ThreadSafeContext_O" "llvmo::TargetMachine_O"
-                          "core::SimpleVector_byte64_t_O" "llvmo::Value_O"
+                          "core::CoreExposer_O" "core::BytecodeDebugVars_O"
+                          "comp::JumpIfSuppliedFixup_O" "core::KeyValuePair" "llvmo::NamedMDNode_O"
+                          "core::SimpleVector_byte16_t_O" "llvmo::ThreadSafeContext_O"
+                          "llvmo::TargetMachine_O" "core::SimpleVector_byte64_t_O" "llvmo::Value_O"
                           "core::SimpleBaseString_O" "core::Test_O" "llvmo::Metadata_O"
                           "core::MDArray_O" "core::LocalSimpleFun_O" "clbind::ClassRep_O"
                           "llvmo::ConstantInt_O" "comp::SpecialVarInfo_O"
@@ -212,6 +212,9 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::ComplexVector_T_O>"
              :offset-base-ctype "comp::Module_O" :layout-offset-field-names ("_literals")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::ComplexVector_T_O>"
+             :offset-base-ctype "comp::Module_O" :layout-offset-field-names ("_debugInfo")}
 {class-kind :stamp-name "STAMPWTAG_llvmo__AttributeSet_O" :stamp-key "llvmo::AttributeSet_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -3489,6 +3492,20 @@
 {fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
              :offset-base-ctype "llvmo::StructLayout_O"
              :layout-offset-field-names ("_StructLayout")}
+{class-kind :stamp-name "STAMPWTAG_core__BytecodeDebugVars_O"
+            :stamp-key "core::BytecodeDebugVars_O" :parent-class "core::General_O"
+            :lisp-class-base "core::General_O" :root-class "core::T_O" :stamp-wtag 3
+            :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::BytecodeDebugVars_O" :layout-offset-field-names ("_start")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::BytecodeDebugVars_O" :layout-offset-field-names ("_end")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>"
+             :offset-base-ctype "core::BytecodeDebugVars_O"
+             :layout-offset-field-names ("_bindings")}
 {class-kind :stamp-name "STAMPWTAG_clasp_ffi__ForeignTypeSpec_O"
             :stamp-key "clasp_ffi::ForeignTypeSpec_O" :parent-class "core::General_O"
             :lisp-class-base "core::General_O" :root-class "core::T_O" :stamp-wtag 3
@@ -4536,6 +4553,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::DebuggerFrame_O"
              :layout-offset-field-names ("args_available")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>"
+             :offset-base-ctype "core::DebuggerFrame_O" :layout-offset-field-names ("locals")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::DebuggerFrame_O" :layout-offset-field-names ("lang")}
@@ -6633,6 +6653,9 @@
 {fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::Lisp"
              :layout-offset-field-names ("_Roots" "._AllCodeBlocks")}
+{fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::Lisp"
+             :layout-offset-field-names ("_Roots" "._AllBytecodeModules")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::GlobalSimpleFun_O>"
              :offset-base-ctype "core::Lisp"

--- a/src/analysis/clasp_gc_cando.sif
+++ b/src/analysis/clasp_gc_cando.sif
@@ -122,8 +122,9 @@
                           "llvmo::DWARFContext_O" "chem::EnergyOutOfZPlane_O"
                           "adapt::IterateCons_O" "core::HashTableEqual_O" "llvmo::Triple_O"
                           "core::SimpleMDArray_byte64_t_O" "geom::GeomExposer_O"
-                          "core::CoreExposer_O" "chem::EnergyRigidBodyComponent_O"
-                          "core::BitVectorNs_O" "chem::AtomIdMap_O" "comp::JumpIfSuppliedFixup_O"
+                          "core::CoreExposer_O" "core::BytecodeDebugVars_O"
+                          "chem::EnergyRigidBodyComponent_O" "core::BitVectorNs_O"
+                          "chem::AtomIdMap_O" "comp::JumpIfSuppliedFixup_O"
                           "geom::SimpleVectorCoordinate_O" "core::KeyValuePair" "chem::FFItor_O"
                           "llvmo::NamedMDNode_O" "core::SimpleVector_byte16_t_O"
                           "chem::ChemInfoGraph_O" "chem::EnergyOutOfZPlane"
@@ -6003,6 +6004,9 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::ComplexVector_T_O>"
              :offset-base-ctype "comp::Module_O" :layout-offset-field-names ("_literals")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::ComplexVector_T_O>"
+             :offset-base-ctype "comp::Module_O" :layout-offset-field-names ("_debugInfo")}
 {class-kind :stamp-name "STAMPWTAG_core__ImmobileObject_O" :stamp-key "core::ImmobileObject_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -8606,6 +8610,20 @@
 {fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
              :offset-base-ctype "llvmo::StructLayout_O"
              :layout-offset-field-names ("_StructLayout")}
+{class-kind :stamp-name "STAMPWTAG_core__BytecodeDebugVars_O"
+            :stamp-key "core::BytecodeDebugVars_O" :parent-class "core::General_O"
+            :lisp-class-base "core::General_O" :root-class "core::T_O" :stamp-wtag 3
+            :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::BytecodeDebugVars_O" :layout-offset-field-names ("_start")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::BytecodeDebugVars_O" :layout-offset-field-names ("_end")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>"
+             :offset-base-ctype "core::BytecodeDebugVars_O"
+             :layout-offset-field-names ("_bindings")}
 {class-kind :stamp-name "STAMPWTAG_core__ExternalObject_O" :stamp-key "core::ExternalObject_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -9554,6 +9572,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::DebuggerFrame_O"
              :layout-offset-field-names ("args_available")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>"
+             :offset-base-ctype "core::DebuggerFrame_O" :layout-offset-field-names ("locals")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::DebuggerFrame_O" :layout-offset-field-names ("lang")}
@@ -13082,6 +13103,9 @@
 {fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::Lisp"
              :layout-offset-field-names ("_Roots" "._AllCodeBlocks")}
+{fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::Lisp"
+             :layout-offset-field-names ("_Roots" "._AllBytecodeModules")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::GlobalSimpleFun_O>"
              :offset-base-ctype "core::Lisp"

--- a/src/analysis/clasp_gc_cando.sif
+++ b/src/analysis/clasp_gc_cando.sif
@@ -636,6 +636,9 @@
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::BytecodeModule_O"
              :layout-offset-field-names ("_CompileInfo")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::BytecodeModule_O" :layout-offset-field-names ("_DebugInfo")}
 {class-kind :stamp-name "STAMPWTAG_chem__NumericalFunction_O"
             :stamp-key "chem::NumericalFunction_O" :parent-class "core::CxxObject_O"
             :lisp-class-base "core::CxxObject_O" :root-class "core::T_O" :stamp-wtag 3
@@ -6302,6 +6305,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::GlobalBytecodeSimpleFun_O"
              :layout-offset-field-names ("_EntryPcN")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::GlobalBytecodeSimpleFun_O"
+             :layout-offset-field-names ("_BytecodeSize")}
 {fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
              :offset-base-ctype "core::GlobalBytecodeSimpleFun_O"
              :layout-offset-field-names ("_Trampoline")}

--- a/src/analysis/clasp_gc_cando.sif
+++ b/src/analysis/clasp_gc_cando.sif
@@ -260,6 +260,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
              :offset-base-ctype "core::VMFrameDynEnv_O" :layout-offset-field-names ("old_sp")}
+{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
+             :offset-base-ctype "core::VMFrameDynEnv_O" :layout-offset-field-names ("old_fp")}
 {class-kind :stamp-name "STAMPWTAG_core__UnwindProtectDynEnv_O"
             :stamp-key "core::UnwindProtectDynEnv_O" :parent-class "core::DynEnv_O"
             :lisp-class-base "core::DynEnv_O" :root-class "core::T_O" :stamp-wtag 3

--- a/src/core/backtrace.cc
+++ b/src/core/backtrace.cc
@@ -465,7 +465,7 @@ static DebuggerFrame_sp make_bytecode_frame(size_t frameIndex,
     fp = (T_O**)(*fp);
   }
   // Find the bytecode module containing the current pc.
-  List_sp modules = core::_sym_STARallBytecodeModulesSTAR->symbolValue();
+  List_sp modules = _lisp->_Roots._AllBytecodeModules.load();
   for (auto mods : modules) {
     BytecodeModule_sp mod = gc::As_assert<BytecodeModule_sp>(oCar(mods));
     if (bytecode_module_contains_address_p(mod, bpc)) {

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -77,6 +77,18 @@ void BytecodeModule_O::setf_compileInfo(T_sp o) {
   this->_CompileInfo = o;
 }
 
+void BytecodeModule_O::register_for_debug() {
+  // An atomic push, as the variable is shared.
+  T_sp old = core::_sym_STARallBytecodeModulesSTAR->symbolValue();
+  Cons_sp newc = Cons_O::create(this->asSmartPtr(), old);
+  while (true) {
+    T_sp next = core::_sym_STARallBytecodeModulesSTAR->cas_globalValue(old, newc);
+    if (next == old) break;
+    old = next;
+    newc->setCdr(old);
+  }
+}
+
 static inline int16_t read_s16(unsigned char* pc) {
   uint8_t byte0 = *pc;
   uint8_t byte1 = *(pc + 1);

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -1343,13 +1343,16 @@ bool bytecode_function_contains_address_p(GlobalBytecodeSimpleFun_sp fun,
 }
 
 T_sp bytecode_function_for_pc(BytecodeModule_sp module, void* pc) {
-  for (auto info : *(gc::As_assert<SimpleVector_sp>(module->debugInfo()))) {
-    if (gc::IsA<GlobalBytecodeSimpleFun_sp>(info)
-        && bytecode_function_contains_address_p(gc::As_unsafe<GlobalBytecodeSimpleFun_sp>(info), pc))
-      return info;
-  }
+  T_sp debuginfo = module->debugInfo();
+  if (debuginfo.notnilp()) {
+    for (auto info : *(gc::As_assert<SimpleVector_sp>(module->debugInfo()))) {
+      if (gc::IsA<GlobalBytecodeSimpleFun_sp>(info)
+          && bytecode_function_contains_address_p(gc::As_unsafe<GlobalBytecodeSimpleFun_sp>(info), pc))
+        return info;
+    }
   // Should be impossible, but we don't want to err while a backtrace
   // is getting put together. TODO: Issue warning?
+  }
   return nil<T_O>();
 }
 

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -79,14 +79,10 @@ void BytecodeModule_O::setf_compileInfo(T_sp o) {
 
 void BytecodeModule_O::register_for_debug() {
   // An atomic push, as the variable is shared.
-  T_sp old = core::_sym_STARallBytecodeModulesSTAR->symbolValue();
+  T_sp old = _lisp->_Roots._AllBytecodeModules.load();
   Cons_sp newc = Cons_O::create(this->asSmartPtr(), old);
-  while (true) {
-    T_sp next = core::_sym_STARallBytecodeModulesSTAR->cas_globalValue(old, newc);
-    if (next == old) break;
-    old = next;
+  while (!_lisp->_Roots._AllBytecodeModules.compare_exchange_weak(old, newc))
     newc->setCdr(old);
-  }
 }
 
 static inline int16_t read_s16(unsigned char* pc) {

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -282,10 +282,12 @@ gctools::return_type bytecode_vm(VirtualMachine& vm,
       T_O* func = *(vm.stackref(sp, nargs));
       T_O** args = vm.stackref(sp, nargs-1);
       ASSERT(gctools::tagged_generalp<T_O*>(func));
+      vm.push(sp, (T_O*)pc);
+      vm._pc = pc;
       vm._stackPointer = sp;
       T_mv res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
       multipleValues.setN(res.raw_(),res.number_of_values());
-      vm.drop(sp, nargs+1);
+      vm.drop(sp, nargs+2);
       pc++;
       break;
     }
@@ -303,9 +305,11 @@ gctools::return_type bytecode_vm(VirtualMachine& vm,
         VM_RECORD_PLAYBACK(args[ii],name_args.str().c_str() );
       }
 #endif
+      vm.push(sp, (T_O*)pc);
+      vm._pc = pc;
       vm._stackPointer = sp;
       T_sp res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
-      vm.drop(sp, nargs+1);
+      vm.drop(sp, nargs+2);
       vm.push(sp, res.raw_());
       VM_RECORD_PLAYBACK(res.raw_(),"vm_call_receive_one");
       pc++;
@@ -317,9 +321,11 @@ gctools::return_type bytecode_vm(VirtualMachine& vm,
       DBG_VM("call-receive-fixed %" PRIu8 " %" PRIu8 "\n", nargs, nvals);
       T_O* func = *(vm.stackref(sp, nargs));
       T_O** args = vm.stackref(sp, nargs-1);
+      vm.push(sp, (T_O*)pc);
+      vm._pc = pc;
       vm._stackPointer = sp;
       T_mv res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
-      vm.drop(sp, nargs+1);
+      vm.drop(sp, nargs+2);
       if (nvals != 0) {
         vm.push(sp, res.raw_()); // primary
         size_t svalues = multipleValues.getSize();
@@ -660,8 +666,11 @@ gctools::return_type bytecode_vm(VirtualMachine& vm,
       size_t nargs = multipleValues.getSize();
       T_O* args[nargs];
       multipleValues.saveToTemp(nargs, args);
+      vm.push(sp, (T_O*)pc);
+      vm._pc = pc;
       vm._stackPointer = sp;
       T_mv res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
+      vm.drop(sp, 1); // pc
       multipleValues.setN(res.raw_(),res.number_of_values());
       pc++;
       break;
@@ -672,8 +681,11 @@ gctools::return_type bytecode_vm(VirtualMachine& vm,
       size_t nargs = multipleValues.getSize();
       T_O* args[nargs];
       multipleValues.saveToTemp(nargs, args);
+      vm.push(sp, (T_O*)pc);
+      vm._pc = pc;
       vm._stackPointer = sp;
       T_sp res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
+      vm.drop(sp, 1); // pc
       multipleValues.set1(res);
       vm.push(sp, res.raw_());
       pc++;
@@ -686,8 +698,11 @@ gctools::return_type bytecode_vm(VirtualMachine& vm,
       size_t nargs = multipleValues.getSize();
       T_O* args[nargs];
       multipleValues.saveToTemp(nargs, args);
+      vm.push(sp, (T_O*)pc);
+      vm._pc = pc;
       vm._stackPointer = sp;
       T_mv res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
+      vm.drop(sp, 1); // pc
       if (nvals != 0) {
         vm.push(sp, res.raw_()); // primary
         size_t svalues = multipleValues.getSize();
@@ -905,10 +920,12 @@ static unsigned char *long_dispatch(VirtualMachine& vm,
     DBG_VM1("long call %" PRIu16 "\n", nargs);
     T_O* func = *(vm.stackref(sp, nargs));
     T_O** args = vm.stackref(sp, nargs-1);
+    vm.push(sp, (T_O*)pc);
+    vm._pc = pc;
     vm._stackPointer = sp;
     T_mv res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
     multipleValues.setN(res.raw_(),res.number_of_values());
-    vm.drop(sp, nargs+1);
+    vm.drop(sp, nargs+2);
     pc += 3;
     break;
   }
@@ -927,9 +944,11 @@ static unsigned char *long_dispatch(VirtualMachine& vm,
       VM_RECORD_PLAYBACK(args[ii],name_args.str().c_str() );
     }
 #endif
+    vm.push(sp, (T_O*)pc);
+    vm._pc = pc;
     vm._stackPointer = sp;
     T_sp res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
-    vm.drop(sp, nargs+1);
+    vm.drop(sp, nargs+2);
     vm.push(sp, res.raw_());
     VM_RECORD_PLAYBACK(res.raw_(),"vm_call_receive_one");
     pc += 3;
@@ -943,9 +962,11 @@ static unsigned char *long_dispatch(VirtualMachine& vm,
     DBG_VM("long call-receive-fixed %" PRIu16 " %" PRIu16 "\n", nargs, nvals);
     T_O* func = *(vm.stackref(sp, nargs));
     T_O** args = vm.stackref(sp, nargs-1);
+    vm.push(sp, (T_O*)pc);
+    vm._pc = pc;
     vm._stackPointer = sp;
     T_mv res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
-    vm.drop(sp, nargs+1);
+    vm.drop(sp, nargs+2);
     if (nvals != 0) {
       vm.push(sp, res.raw_()); // primary
       size_t svalues = multipleValues.getSize();
@@ -1166,8 +1187,11 @@ static unsigned char *long_dispatch(VirtualMachine& vm,
     size_t nargs = multipleValues.getSize();
     T_O* args[nargs];
     multipleValues.saveToTemp(nargs, args);
+    vm.push(sp, (T_O*)pc);
+    vm._pc = pc;
     vm._stackPointer = sp;
     T_mv res = funcall_general<core::Function_O>((gc::Tagged)func, nargs, args);
+    vm.drop(sp, 1); // pc
     if (nvals != 0) {
       vm.push(sp, res.raw_()); // primary
       size_t svalues = multipleValues.getSize();
@@ -1223,7 +1247,9 @@ static unsigned char *long_dispatch(VirtualMachine& vm,
 }
 
 void VMFrameDynEnv_O::proceed() {
-  my_thread->_VM._stackPointer = this->old_sp;
+  VirtualMachine& vm = my_thread->_VM;
+  vm._stackPointer = this->old_sp;
+  vm._framePointer = this->old_fp;
 }
 
 }; // namespace core
@@ -1252,10 +1278,13 @@ gctools::return_type bytecode_call(unsigned char* pc, core::T_O* lcc_closure, si
   // use a local variable. This means we start new frames appropriately when
   // we're called from wherever, and also that we use the correct sp when
   // being unwound to.
-  core::T_O** fp = vm._stackPointer;
+  core::T_O** old_fp = vm._framePointer;
+  core::T_O** old_sp = vm._stackPointer;
+  vm.push(vm._stackPointer, (core::T_O*)old_fp);
+  core::T_O** fp = vm._framePointer = vm._stackPointer;
   core::T_O** sp = vm.push_frame(fp, nlocals);
   try {
-    gctools::StackAllocate<core::VMFrameDynEnv_O> frame(fp);
+    gctools::StackAllocate<core::VMFrameDynEnv_O> frame(old_sp, old_fp);
     gctools::StackAllocate<core::Cons_O> sa_ec(frame.asSmartPtr(),
                                                my_thread->dynEnvStackGet());
     core::DynEnvPusher dep(my_thread, sa_ec.asSmartPtr());
@@ -1287,5 +1316,26 @@ CL_DEFUN void core__vm_stack_trigger(size_t trigger) {
   global_stackTrigger = trigger;
 }
 #endif
+
+bool bytecode_module_contains_address_p(BytecodeModule_sp module, void* pc) {
+  // FIXME: Not sure if this is the best way to go about it.
+  Array_sp bytecode = gc::As_assert<Array_sp>(module->bytecode());
+  void* start = bytecode->rowMajorAddressOfElement_(0);
+  void* end = (byte8_t*)start + bytecode->length() * sizeof(byte8_t);
+  return (start <= pc) && (pc <= end);
+}
+
+bool bytecode_function_contains_address_p(GlobalBytecodeSimpleFun_sp fun,
+                                          void* pc) {
+  BytecodeModule_sp module = fun->code();
+  Array_sp bytecode = gc::As_assert<Array_sp>(module->bytecode());
+  void* start = bytecode->rowMajorAddressOfElement_(fun->entryPcN());
+  void* end = (byte8_t*)bytecode->rowMajorAddressOfElement_(fun->entryPcN() + fun->bytecodeSize()) + sizeof(byte8_t);
+  return (start <= pc) && (pc <= end);
+}
+
+void* bytecode_pc() {
+  return my_thread->_VM._pc;
+}
 
 }; // namespace core

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -213,13 +213,13 @@ SYMBOL_EXPORT_SC_(KeywordPkg, name);
 #ifdef DEBUG_VIRTUAL_MACHINE
 __attribute__((optnone))
 #endif
-static gctools::return_type bytecode_vm(VirtualMachine& vm,
-                                        T_O** literals, T_O** closed,
-                                        Closure_O* closure,
-                                        core::T_O** fp, // frame pointer
-                                        core::T_O** sp, // stack pointer
-                                        size_t lcc_nargs,
-                                        core::T_O** lcc_args) {
+gctools::return_type bytecode_vm(VirtualMachine& vm,
+                                 T_O** literals, T_O** closed,
+                                 Closure_O* closure,
+                                 core::T_O** fp, // frame pointer
+                                 core::T_O** sp, // stack pointer
+                                 size_t lcc_nargs,
+                                 core::T_O** lcc_args) {
   ASSERT( literals==NULL || (uintptr_t)literals>65536);
   ASSERT((((uintptr_t)literals)&0x7)==0); // must be aligned
   ASSERT((((uintptr_t)closure)&0x7)==0); // must be aligned

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -901,12 +901,6 @@ SimpleVector_byte8_t_sp Module_O::link() {
   return cmodule->create_bytecode();
 }
 
-void register_bytecode_module(BytecodeModule_sp mod) {
-  T_sp old = core::_sym_STARallBytecodeModulesSTAR->symbolValue();
-  Cons_sp c = Cons_O::create(mod, old);
-  core::_sym_STARallBytecodeModulesSTAR->setf_symbolValue(c);
-}
-
 void Module_O::link_load(T_sp compile_info) {
   Module_sp cmodule = this->asSmartPtr();
   SimpleVector_byte8_t_sp bytecode = cmodule->link();
@@ -917,8 +911,7 @@ void Module_O::link_load(T_sp compile_info) {
   ComplexVector_T_sp cfunctions = cmodule->cfunctions();
   SimpleVector_sp functions = SimpleVector_O::make(cfunctions->length());
   size_t function_index = 0;
-  // Register the bytecode module for the debugger.
-  register_bytecode_module(bytecode_module);
+  // Set up info the debugger can use.
   bytecode_module->setf_debugInfo(functions);
   // Create the real function objects.
   for (T_sp tfun : *cfunctions) {

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -901,6 +901,12 @@ SimpleVector_byte8_t_sp Module_O::link() {
   return cmodule->create_bytecode();
 }
 
+void register_bytecode_module(BytecodeModule_sp mod) {
+  T_sp old = core::_sym_STARallBytecodeModulesSTAR->symbolValue();
+  Cons_sp c = Cons_O::create(mod, old);
+  core::_sym_STARallBytecodeModulesSTAR->setf_symbolValue(c);
+}
+
 void Module_O::link_load(T_sp compile_info) {
   Module_sp cmodule = this->asSmartPtr();
   SimpleVector_byte8_t_sp bytecode = cmodule->link();
@@ -909,6 +915,8 @@ void Module_O::link_load(T_sp compile_info) {
   SimpleVector_sp literals = SimpleVector_O::make(literal_length);
   BytecodeModule_sp bytecode_module = BytecodeModule_O::make();
   ComplexVector_T_sp cfunctions = cmodule->cfunctions();
+  // Register the bytecode module for the debugger.
+  register_bytecode_module(bytecode_module);
   // Create the real function objects.
   for (T_sp tfun : *cfunctions) {
     Cfunction_sp cfunction = gc::As_assert<Cfunction_sp>(tfun);

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -839,7 +839,7 @@ size_t Module_O::bytecode_size() {
   ComplexVector_T_sp cfunctions = this->cfunctions();
   T_sp tlast_cfunction = (*cfunctions)[cfunctions->length() - 1];
   Cfunction_sp last_cfunction = gc::As_assert<Cfunction_sp>(tlast_cfunction);
-  return last_cfunction->pposition() + last_cfunction->bytecode()->length() + last_cfunction->extra();
+  return last_cfunction->pposition() + last_cfunction->final_size();
 }
 
 // Replacement for CL:REPLACE, which isn't available here.
@@ -929,8 +929,7 @@ void Module_O::link_load(T_sp compile_info) {
                                                            sourcePathname, lineno, column, filepos);
     Fixnum_sp ep = clasp_make_fixnum(cfunction->entry_point()->module_position());
     Pointer_sp trampoline = llvmo::cmp__compile_trampoline(cfunction->nname());
-    GlobalBytecodeSimpleFun_sp func = core__makeGlobalBytecodeSimpleFun(
-        fdesc, bytecode_module, cfunction->nlocals(), cfunction->closed()->length(), ep.unsafe_fixnum(), trampoline);
+    GlobalBytecodeSimpleFun_sp func = core__makeGlobalBytecodeSimpleFun(fdesc, bytecode_module, cfunction->nlocals(), cfunction->closed()->length(), ep.unsafe_fixnum(), cfunction->final_size(), trampoline);
     cfunction->setInfo(func);
   }
   // Replace the cfunctions in the cmodule literal vector with

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -354,6 +354,10 @@ size_t Context::closure_index(T_sp info) const {
   return nind.unsafe_fixnum();
 }
 
+void Context::push_debug_info(T_sp info) const {
+  this->cfunction()->module()->push_debug_info(info);
+}
+
 void Context::emit_jump(Label_sp label) const {
   ControlLabelFixup_O::make(label, vm_jump_8, vm_jump_16, vm_jump_24)->contextualize(*this);
 }
@@ -786,6 +790,10 @@ size_t EntryCloseFixup_O::resize() {
   return (this->lex()->closedOverP()) ? 1 : 0;
 }
 
+void Module_O::push_debug_info(T_sp info) {
+  this->_debugInfo->vectorPushExtend(info);
+}
+
 void Module_O::initialize_cfunction_positions() {
   size_t position = 0;
   ComplexVector_T_sp cfunctions = this->cfunctions();
@@ -901,18 +909,49 @@ SimpleVector_byte8_t_sp Module_O::link() {
   return cmodule->create_bytecode();
 }
 
+// Resolve the labels to fixnums, and LVInfos to frame locations.
+// If a variable is stored in a cell, we indicate this by wrapping its
+// frame location in a cons.
+static void fixup_debug_info(BytecodeDebugVars_sp info) {
+  T_sp open_label = info->start();
+  if (gc::IsA<Label_sp>(open_label))
+    info->setStart(clasp_make_fixnum(gc::As_unsafe<Label_sp>(open_label)->module_position()));
+  else // compiler screwed up, but this is just debug info, don't raise stink
+    info->setStart(clasp_make_fixnum(0));
+  T_sp close_label = info->end();
+  if (gc::IsA<Label_sp>(close_label))
+    info->setEnd(clasp_make_fixnum(gc::As_unsafe<Label_sp>(close_label)->module_position()));
+  else
+    info->setEnd(clasp_make_fixnum(0));
+  for (Cons_sp cur : info->bindings()) {
+    T_sp tentry = cur->ocar();
+    if (gc::IsA<Cons_sp>(tentry)) {
+      Cons_sp entry = gc::As_unsafe<Cons_sp>(tentry);
+      T_sp tlvinfo = entry->cdr();
+      if (gc::IsA<LexicalVarInfo_sp>(tlvinfo)) {
+        LexicalVarInfo_sp lvinfo = gc::As_unsafe<LexicalVarInfo_sp>(tlvinfo);
+        T_sp index = clasp_make_fixnum(lvinfo->frameIndex());
+        if (lvinfo->indirectLexicalP())
+          entry->setCdr(Cons_O::createList(index));
+        else
+          entry->setCdr(index);
+      }
+    }
+  }
+}
+
 void Module_O::link_load(T_sp compile_info) {
   Module_sp cmodule = this->asSmartPtr();
   SimpleVector_byte8_t_sp bytecode = cmodule->link();
   ComplexVector_T_sp cmodule_literals = cmodule->literals();
   size_t literal_length = cmodule_literals->length();
   SimpleVector_sp literals = SimpleVector_O::make(literal_length);
+  ComplexVector_T_sp cmodule_debug_info = cmodule->debugInfo();
+  size_t debug_info_length = cmodule_debug_info->length();
+  SimpleVector_sp debug_info = SimpleVector_O::make(debug_info_length);
   BytecodeModule_sp bytecode_module = BytecodeModule_O::make();
   ComplexVector_T_sp cfunctions = cmodule->cfunctions();
-  SimpleVector_sp functions = SimpleVector_O::make(cfunctions->length());
   size_t function_index = 0;
-  // Set up info the debugger can use.
-  bytecode_module->setf_debugInfo(functions);
   // Create the real function objects.
   for (T_sp tfun : *cfunctions) {
     Cfunction_sp cfunction = gc::As_assert<Cfunction_sp>(tfun);
@@ -935,7 +974,6 @@ void Module_O::link_load(T_sp compile_info) {
     Pointer_sp trampoline = llvmo::cmp__compile_trampoline(cfunction->nname());
     GlobalBytecodeSimpleFun_sp func = core__makeGlobalBytecodeSimpleFun(fdesc, bytecode_module, cfunction->nlocals(), cfunction->closed()->length(), ep.unsafe_fixnum(), cfunction->final_size(), trampoline);
     cfunction->setInfo(func);
-    (*functions)[function_index++] = func;
   }
   // Replace the cfunctions in the cmodule literal vector with
   // real bytecode functions in the module vector.
@@ -949,9 +987,22 @@ void Module_O::link_load(T_sp compile_info) {
     else
       (*literals)[i] = lit;
   }
+  // Copy the debug info.
+  for (size_t i = 0; i < debug_info_length; ++i) {
+    T_sp info = (*cmodule_debug_info)[i];
+    if (gc::IsA<Cfunction_sp>(info))
+      (*debug_info)[i] = gc::As_unsafe<Cfunction_sp>(info)->info();
+    else if (gc::IsA<BytecodeDebugVars_sp>(info)) {
+      fixup_debug_info(gc::As_unsafe<BytecodeDebugVars_sp>(info));
+      (*debug_info)[i] = info;
+    }
+    else
+      (*debug_info)[i] = info;
+  }
   // Now just install the bytecode and Bob's your uncle.
   bytecode_module->setf_literals(literals);
   bytecode_module->setf_bytecode(bytecode);
+  bytecode_module->setf_debugInfo(debug_info);
   bytecode_module->setf_compileInfo(compile_info);
 }
 
@@ -1085,6 +1136,11 @@ void compile_let(List_sp bindings, List_sp body, Lexenv_sp env, const Context ct
   size_t lexical_binding_count = 0;
   size_t special_binding_count = 0;
   Lexenv_sp post_binding_env = env->add_specials(specials);
+  // debug info
+  Label_sp begin_label = Label_O::make();
+  Label_sp end_label = Label_O::make();
+  ql::list debug_bindings; // alist (name . stack-location)
+  // now get processing
   for (auto cur : bindings) {
     T_sp binding = oCar(cur);
     Symbol_sp var;
@@ -1104,13 +1160,20 @@ void compile_let(List_sp bindings, List_sp body, Lexenv_sp env, const Context ct
       // FIXME: We don't need to cons actual lexenvs here.
       post_binding_env = post_binding_env->bind1var(var, ctxt);
       ++lexical_binding_count;
-      ctxt.maybe_emit_make_cell(gc::As_assert<comp::LexicalVarInfo_sp>(post_binding_env->variableInfo(var)));
+     LexicalVarInfo_sp lvinfo
+        = gc::As_assert<LexicalVarInfo_sp>(post_binding_env->variableInfo(var));
+     debug_bindings << Cons_O::create(var, lvinfo);
+     ctxt.maybe_emit_make_cell(lvinfo);
     }
   }
   ctxt.emit_bind(lexical_binding_count, env->frameEnd());
   post_binding_env = post_binding_env->add_notinlines(decl_notinlines(declares));
+  begin_label->contextualize(ctxt);
   compile_progn(code, post_binding_env, Context(ctxt, Integer_O::create(special_binding_count)));
   ctxt.emit_unbind(special_binding_count);
+  end_label->contextualize(ctxt);
+  // Add the debug info
+  ctxt.push_debug_info(BytecodeDebugVars_O::make(begin_label, end_label, debug_bindings.cons()));
 }
 
 void compile_letSTAR(List_sp bindings, List_sp body, Lexenv_sp env, const Context ectxt) {
@@ -1122,6 +1185,7 @@ void compile_letSTAR(List_sp bindings, List_sp body, Lexenv_sp env, const Contex
   size_t special_binding_count = 0;
   Lexenv_sp new_env = env;
   Context ctxt = ectxt;
+  Label_sp end_label = Label_O::make();
   for (auto cur : bindings) {
     T_sp binding = oCar(cur);
     Symbol_sp var;
@@ -1140,10 +1204,16 @@ void compile_letSTAR(List_sp bindings, List_sp body, Lexenv_sp env, const Contex
       ctxt.emit_special_bind(var);
       ctxt = Context(ctxt, Integer_O::create(1));
     } else {
+      Label_sp begin_label = Label_O::make();
       size_t frame_start = new_env->frameEnd();
       new_env = new_env->bind1var(var, ctxt);
-      ctxt.maybe_emit_make_cell(gc::As_assert<comp::LexicalVarInfo_sp>(new_env->variableInfo(var)));
+      LexicalVarInfo_sp lvinfo = gc::As_assert<LexicalVarInfo_sp>(new_env->variableInfo(var));
+      ctxt.maybe_emit_make_cell(lvinfo);
       ctxt.assemble1(vm_set, frame_start);
+      // Set up debug info
+      begin_label->contextualize(ctxt);
+      ctxt.push_debug_info(BytecodeDebugVars_O::make(begin_label, end_label,
+                                                     Cons_O::createList(Cons_O::create(var, lvinfo))));
     }
   }
   new_env = new_env->add_notinlines(decl_notinlines(declares));
@@ -1153,6 +1223,7 @@ void compile_letSTAR(List_sp bindings, List_sp body, Lexenv_sp env, const Contex
   // here, but that's not a big deal.
   compile_progn(code, new_env->add_specials(specials), ctxt);
   ctxt.emit_unbind(special_binding_count);
+  end_label->contextualize(ctxt);
 }
 
 // copied from evaluator.cc (on the premise that that will be deleted or
@@ -1261,6 +1332,7 @@ void compile_with_lambda_list(T_sp lambda_list, List_sp body, Lexenv_sp env, con
   size_t optional_count = optionals.size();
   size_t max_count = min_count + optional_count;
   bool morep = restarg._ArgTarget.notnilp() || key_flag.notnilp();
+  Label_sp end_label = Label_O::make(); // for debug info
   ql::list lreqs;
   for (auto &it : reqs)
     lreqs << it._ArgTarget;
@@ -1279,8 +1351,10 @@ void compile_with_lambda_list(T_sp lambda_list, List_sp body, Lexenv_sp env, con
       context.assemble1(vm_check_arg_count_LE, max_count);
   }
   if (min_count > 0) {
+    Label_sp begin_label = Label_O::make();
     // Bind the required arguments.
     context.assemble1(vm_bind_required_args, min_count);
+    ql::list debugbindings;
     ql::list sreqs; // required parameters that are special
     for (auto &it : reqs) {
       // We account for special declarations in outer environments/globally
@@ -1293,10 +1367,13 @@ void compile_with_lambda_list(T_sp lambda_list, List_sp body, Lexenv_sp env, con
         context.emit_special_bind(var);
         ++special_binding_count; // not in lisp - bug?
       } else {
-        context.maybe_emit_encage(gc::As_assert<LexicalVarInfo_sp>(lvinfo));
+        context.maybe_emit_encage(lvinfo);
+        debugbindings << Cons_O::create(var, lvinfo);
       }
     }
     new_env = new_env->add_specials(sreqs.cons());
+    begin_label->contextualize(context); // after encages
+    context.push_debug_info(BytecodeDebugVars_O::make(begin_label, end_label, debugbindings.cons()));
   }
   Lexenv_sp optkey_env = new_env;
   if (optional_count > 0) {
@@ -1355,10 +1432,18 @@ void compile_with_lambda_list(T_sp lambda_list, List_sp body, Lexenv_sp env, con
       bool supplied_special_p = supplied_var.notnilp() && special_binding_p(supplied_var, specials, env);
       new_env = compile_optional_or_key_item(optional_var, defaulting_form, varinfo, supplied_var, next_optional_label,
                                              optional_special_p, supplied_special_p, context, new_env);
+      ql::list debugbindings;
       if (optional_special_p)
         ++special_binding_count;
+      else
+        debugbindings << Cons_O::create(optional_var, varinfo);
       if (supplied_special_p)
         ++special_binding_count;
+      else if (supplied_var.notnilp()) {
+        auto svarinfo = gc::As_assert<LexicalVarInfo_sp>(var_info(supplied_var, new_env));
+        debugbindings << Cons_O::create(supplied_var, svarinfo);
+      }
+      context.push_debug_info(BytecodeDebugVars_O::make(next_optional_label, end_label, debugbindings.cons()));
       optional_label = next_optional_label;
       next_optional_label = Label_O::make();
     }
@@ -1381,8 +1466,12 @@ void compile_with_lambda_list(T_sp lambda_list, List_sp body, Lexenv_sp env, con
       context.emit_special_bind(rest);
       ++special_binding_count;
       new_env = new_env->add_specials(Cons_O::createList(rest));
-    } else
+    } else {
       context.maybe_emit_encage(lvinfo);
+      Label_sp begin_label = Label_O::make();
+      begin_label->contextualize(context);
+      context.push_debug_info(BytecodeDebugVars_O::make(begin_label, end_label, Cons_O::createList(Cons_O::create(rest, lvinfo))));
+    }
   }
   // Generate defaulting code for key args, and special-bind them if necessary
   if (key_flag.notnilp()) {
@@ -1398,10 +1487,18 @@ void compile_with_lambda_list(T_sp lambda_list, List_sp body, Lexenv_sp env, con
       bool supplied_special_p = supplied_var.notnilp() && special_binding_p(supplied_var, specials, env);
       new_env = compile_optional_or_key_item(key_var, defaulting_form, varinfo, supplied_var, next_key_label, key_special_p,
                                              supplied_special_p, context, new_env);
+      ql::list debugbindings;
       if (key_special_p)
         ++special_binding_count;
+      else
+        debugbindings << Cons_O::create(key_var, varinfo);
       if (supplied_special_p)
         ++special_binding_count;
+      else if (supplied_var.notnilp()) {
+        auto svarinfo = gc::As_assert<LexicalVarInfo_sp>(var_info(supplied_var, new_env));
+        debugbindings << Cons_O::create(supplied_var, svarinfo);
+      }
+      context.push_debug_info(BytecodeDebugVars_O::make(next_key_label, end_label, debugbindings.cons()));
       key_label = next_key_label;
       next_key_label = Label_O::make();
     }
@@ -1421,6 +1518,7 @@ void compile_with_lambda_list(T_sp lambda_list, List_sp body, Lexenv_sp env, con
   compile_letSTAR(auxbinds.cons(), lbody, new_env, context);
   // Finally, clean up any special bindings.
   context.emit_unbind(special_binding_count);
+  end_label->contextualize(context);
 }
 
 // Compile the lambda expression in MODULE, returning the resulting CFUNCTION.
@@ -1445,6 +1543,8 @@ CL_DEFUN Cfunction_sp compile_lambda(T_sp lambda_list, List_sp body, Lexenv_sp e
   Lexenv_sp lenv = Lexenv_O::make(env->vars(), env->tags(), env->blocks(), env->funs(), env->notinlines(), 0);
   Fixnum_sp ind = module->cfunctions()->vectorPushExtend(function);
   function->setIndex(ind.unsafe_fixnum());
+  // Stick the new function into the debug info.
+  module->push_debug_info(function);
   // We pass the original body w/declarations to compile-with-lambda-list
   // so that it can do its own handling of specials, etc.
   compile_with_lambda_list(lambda_list, body, lenv, context);

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -915,8 +915,11 @@ void Module_O::link_load(T_sp compile_info) {
   SimpleVector_sp literals = SimpleVector_O::make(literal_length);
   BytecodeModule_sp bytecode_module = BytecodeModule_O::make();
   ComplexVector_T_sp cfunctions = cmodule->cfunctions();
+  SimpleVector_sp functions = SimpleVector_O::make(cfunctions->length());
+  size_t function_index = 0;
   // Register the bytecode module for the debugger.
   register_bytecode_module(bytecode_module);
+  bytecode_module->setf_debugInfo(functions);
   // Create the real function objects.
   for (T_sp tfun : *cfunctions) {
     Cfunction_sp cfunction = gc::As_assert<Cfunction_sp>(tfun);
@@ -939,6 +942,7 @@ void Module_O::link_load(T_sp compile_info) {
     Pointer_sp trampoline = llvmo::cmp__compile_trampoline(cfunction->nname());
     GlobalBytecodeSimpleFun_sp func = core__makeGlobalBytecodeSimpleFun(fdesc, bytecode_module, cfunction->nlocals(), cfunction->closed()->length(), ep.unsafe_fixnum(), cfunction->final_size(), trampoline);
     cfunction->setInfo(func);
+    (*functions)[function_index++] = func;
   }
   // Replace the cfunctions in the cmodule literal vector with
   // real bytecode functions in the module vector.

--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -303,11 +303,6 @@ SYMBOL_EXPORT_SC_(CorePkg, dump_module);
 SYMBOL_EXPORT_SC_(CorePkg, STARfunctions_to_inlineSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARfunctions_to_notinlineSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, coerce_fdesignator);
-// This is a list of all bytecode modules created so far. It is used for
-// keeping track of debug information, similar to _Roots._AllObjectFiles.
-// NOTE: If we could garbage collect code, this would need to be full of
-// weak references to let modules ever be collectable.
-SYMBOL_EXPORT_SC_(CorePkg, STARallBytecodeModulesSTAR);
 SYMBOL_SC_(CorePkg, printf);
 
 // SYMBOL_EXPORT_SC_(CorePkg, asin);
@@ -1201,7 +1196,6 @@ void CoreExposer_O::define_essential_globals(LispPtr lisp) {
   _sym_STARbuiltin_single_dispatch_method_namesSTAR->defparameter(nil<core::T_O>());
   _sym_STARbuiltin_macro_function_namesSTAR->defparameter(nil<core::T_O>());
   _sym_STARbuiltin_setf_function_namesSTAR->defparameter(nil<core::T_O>());
-  _sym_STARallBytecodeModulesSTAR->defparameter(nil<core::T_O>());
   _sym_STARdebug_dispatchSTAR->defparameter(nil<core::T_O>());
   _sym_STARdebug_valuesSTAR->defparameter(nil<core::T_O>());
   _sym_STARdebug_hash_tableSTAR->defparameter(nil<core::T_O>());

--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -303,6 +303,11 @@ SYMBOL_EXPORT_SC_(CorePkg, dump_module);
 SYMBOL_EXPORT_SC_(CorePkg, STARfunctions_to_inlineSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARfunctions_to_notinlineSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, coerce_fdesignator);
+// This is a list of all bytecode modules created so far. It is used for
+// keeping track of debug information, similar to _Roots._AllObjectFiles.
+// NOTE: If we could garbage collect code, this would need to be full of
+// weak references to let modules ever be collectable.
+SYMBOL_EXPORT_SC_(CorePkg, STARallBytecodeModulesSTAR);
 SYMBOL_SC_(CorePkg, printf);
 
 // SYMBOL_EXPORT_SC_(CorePkg, asin);
@@ -1196,6 +1201,7 @@ void CoreExposer_O::define_essential_globals(LispPtr lisp) {
   _sym_STARbuiltin_single_dispatch_method_namesSTAR->defparameter(nil<core::T_O>());
   _sym_STARbuiltin_macro_function_namesSTAR->defparameter(nil<core::T_O>());
   _sym_STARbuiltin_setf_function_namesSTAR->defparameter(nil<core::T_O>());
+  _sym_STARallBytecodeModulesSTAR->defparameter(nil<core::T_O>());
   _sym_STARdebug_dispatchSTAR->defparameter(nil<core::T_O>());
   _sym_STARdebug_valuesSTAR->defparameter(nil<core::T_O>());
   _sym_STARdebug_hash_tableSTAR->defparameter(nil<core::T_O>());

--- a/src/core/debugger.cc
+++ b/src/core/debugger.cc
@@ -31,10 +31,6 @@ THE SOFTWARE.
 #include <execinfo.h>
 #include <iomanip>
 #include <clasp/core/foundation.h>
-#ifdef USE_LIBUNWIND
-#define UNW_LOCAL_ONLY
-#include <libunwind.h>
-#endif
 #include <dlfcn.h>
 #ifdef _TARGET_OS_DARWIN
 #include <sys/mman.h>

--- a/src/core/function.cc
+++ b/src/core/function.cc
@@ -104,16 +104,18 @@ GlobalSimpleFun_O::GlobalSimpleFun_O(FunctionDescription_sp fdesc, const ClaspXe
 };
 
 GlobalBytecodeSimpleFun_O::GlobalBytecodeSimpleFun_O(FunctionDescription_sp fdesc,
-                                                       const ClaspXepFunction& entry_point,
-                                                       T_sp module,
-                                                       uint16_t localsFrameSize,
-                                                       unsigned int environmentSize,
-                                                       unsigned int entryPcN,
-                                                       BytecodeTrampolineFunction trampoline )
+                                                     const ClaspXepFunction& entry_point,
+                                                     T_sp module,
+                                                     uint16_t localsFrameSize,
+                                                     unsigned int environmentSize,
+                                                     unsigned int entryPcN,
+                                                     unsigned int bytecodeSize,
+                                                     BytecodeTrampolineFunction trampoline )
 : GlobalSimpleFunBase_O(fdesc, entry_point, module),
   _LocalsFrameSize(localsFrameSize),
   _EnvironmentSize(environmentSize),
   _EntryPcN(entryPcN),
+  _BytecodeSize(bytecodeSize),
   _Trampoline(trampoline)
 {
   llvmo::validateEntryPoint( module, entry_point );
@@ -463,22 +465,24 @@ struct BytecodeClosureEntryPoint {
 CL_LISPIFY_NAME(GlobalBytecodeSimpleFun/make);
 CL_DEFUN
 GlobalBytecodeSimpleFun_sp core__makeGlobalBytecodeSimpleFun(FunctionDescription_sp fdesc,
-                                                               BytecodeModule_sp module,
-                                                               size_t localsFrameSize,
-                                                               size_t environmentSize,
-                                                               size_t pcIndex,
-                                                               Pointer_sp trampoline )
+                                                             BytecodeModule_sp module,
+                                                             size_t localsFrameSize,
+                                                             size_t environmentSize,
+                                                             size_t pcIndex,
+                                                             size_t bytecodeSize,
+                                                             Pointer_sp trampoline )
 {
   size_t idx = 0;
   ClaspXepFunction xep;
   xep.setup<BytecodeClosureEntryPoint>();
   auto entryPoint = gctools::GC<GlobalBytecodeSimpleFun_O>::allocate( fdesc,
-                                                                       xep,
-                                                                       module,
-                                                                       localsFrameSize,
-                                                                       environmentSize,
-                                                                       pcIndex,
-                                                                       (BytecodeTrampolineFunction)trampoline->ptr() );
+                                                                      xep,
+                                                                      module,
+                                                                      localsFrameSize,
+                                                                      environmentSize,
+                                                                      pcIndex,
+                                                                      bytecodeSize,
+                                                                      (BytecodeTrampolineFunction)trampoline->ptr() );
   return entryPoint;
 }
 

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -199,6 +199,7 @@ Lisp::GCRoots::GCRoots() :
   _AllObjectFiles(nil<T_O>()),
   _AllCodeBlocks(nil<T_O>()),
   _AllLibraries(nil<T_O>()),
+  _AllBytecodeModules(nil<T_O>()),
 #ifdef CLASP_THREADS
     _UnboundSymbolFunctionEntryPoint(unbound<GlobalSimpleFun_O>()),
     _UnboundSetfSymbolFunctionEntryPoint(unbound<GlobalSimpleFun_O>()),

--- a/src/lisp/kernel/cmp/cmpltv.lisp
+++ b/src/lisp/kernel/cmp/cmpltv.lisp
@@ -210,7 +210,7 @@
 (defclass attribute (effect)
   (;; Creator for the name of the attribute, a string.
    ;; FIXME: Do this more cleanly.
-   (%name :reader name :type creator)))
+   (%name :reader name :initarg :name :type creator)))
 
 #+clasp
 (defclass spi-attr (attribute)

--- a/src/lisp/kernel/lsp/debug.lisp
+++ b/src/lisp/kernel/lsp/debug.lisp
@@ -279,7 +279,7 @@ The delimiters and visibility may be ignored by using the lower level FRAME-UP, 
   `(call-with-stack (lambda (,stack) (declare (core:lambda-name with-stack-lambda)) ,@body)
                     ,@kwargs))
 
-(defparameter *frame-filters* (list 'non-lisp-frame-p
+(defparameter *frame-filters* (list 'c++-frame-p
                                     'redundant-xep-p
                                     'package-hider
                                     'fname-hider)
@@ -393,8 +393,8 @@ Note that as such, the frame returned may not be visible."
 
 ;;; Some filters
 
-(defun non-lisp-frame-p (frame)
-  (not (eq (frame-language frame) :lisp)))
+(defun c++-frame-p (frame)
+  (eq (frame-language frame) :c++))
 
 ;;; With how Clasp works at this time, any given Lisp function has two "real"
 ;;; functions - an eXternal Entry Point (XEP), and a "local function". The XEP

--- a/src/lisp/kernel/lsp/loadltv.lisp
+++ b/src/lisp/kernel/lsp/loadltv.lisp
@@ -492,7 +492,7 @@ Tried to define constant #~d, but it was already defined"
 (defmethod %load-instruction ((mnemonic (eql 'make-bytecode-function)) stream)
   (let ((index (read-index stream))
         (entry-point (read-ub32 stream))
-        (size (if (and (= *major* 0) (>= *minor* 8)) (read-ub32 stream) 0))
+        (size (if (and (= *major* 0) (< *minor* 8)) 0 (read-ub32 stream)))
         (nlocals (read-ub16 stream))
         (nclosed (read-ub16 stream))
         (modulei (when (>= *minor* 2) (read-index stream)))

--- a/src/lisp/kernel/lsp/loadltv.lisp
+++ b/src/lisp/kernel/lsp/loadltv.lisp
@@ -86,7 +86,7 @@
 
 ;; Bounds for major and minor version understood by this loader.
 (defparameter *min-version* '(0 0))
-(defparameter *max-version* '(0 7))
+(defparameter *max-version* '(0 8))
 
 (defun loadable-version-p (major minor)
   (and
@@ -492,6 +492,7 @@ Tried to define constant #~d, but it was already defined"
 (defmethod %load-instruction ((mnemonic (eql 'make-bytecode-function)) stream)
   (let ((index (read-index stream))
         (entry-point (read-ub32 stream))
+        (size (if (and (= *major* 0) (>= *minor* 8)) (read-ub32 stream) 0))
         (nlocals (read-ub16 stream))
         (nclosed (read-ub16 stream))
         (modulei (when (>= *minor* 2) (read-index stream)))
@@ -519,7 +520,7 @@ Tried to define constant #~d, but it was already defined"
               :function-name name :lambda-list lambda-list :docstring docstring
               :source-pathname source-pathname
               :lineno lineno :column column :filepos filepos)
-             module nlocals nclosed entry-point
+             module nlocals nclosed entry-point size
              (cmp:compile-trampoline name)))))
   (+ *index-bytes* 4 2 2 *index-bytes* *index-bytes* *index-bytes*))
 
@@ -591,11 +592,8 @@ Tried to define constant #~d, but it was already defined"
 (defparameter *attributes*
   (let ((ht (make-hash-table :test #'equal)))
     #+clasp (setf (gethash "clasp:source-pos-info" ht) 'source-pos-info)
-    ht)
-  #+(or)
-  (alexandria:alist-hash-table
-   '(#+clasp("clasp:source-pos-info" . source-pos-info))
-   :test #'equal))
+    #+clasp (setf (gethash "clasp:module-debug-info" ht) 'module-debug-info)
+    ht))
 
 (defgeneric %load-attribute (mnemonic stream))
 
@@ -618,6 +616,33 @@ Tried to define constant #~d, but it was already defined"
     (dbgprint " (source-pos-info ~s ~s ~d ~d ~d)"
               function path lineno column filepos)
     (core:function/set-source-pos-info function path filepos lineno column)))
+
+(defun read-debug-bindings (stream)
+  (let ((nbinds (read-ub16 stream)))
+    (loop repeat nbinds
+          collect (let ((name (constant (read-index stream)))
+                        (flag (read-byte stream))
+                        (framei (read-ub16 stream)))
+                    (cons name (ecase flag
+                                 (0 framei)
+                                 (1 (list framei))))))))
+
+#+clasp
+(defmethod %load-attribute ((mnemonic (eql 'module-debug-info)) stream)
+  (read-ub32 stream) ; ignore size
+  (let* ((mod (constant (read-index stream)))
+         (ncfunctions (read-ub16 stream))
+         (cfunctions (loop repeat ncfunctions
+                           collect (constant (read-index stream))))
+         (nvars (read-ub32 stream))
+         (vars (loop repeat nvars
+                     collect (let* ((start (read-ub32 stream))
+                                    (end (read-ub32 stream))
+                                    (binds (read-debug-bindings stream)))
+                               (core:bytecode-debug-vars/make start end binds)))))
+    (core:bytecode-module/setf-debug-info
+     mod
+     (concatenate 'simple-vector cfunctions vars))))
 
 (defun load-attribute (stream)
   (let ((aname (constant (read-index stream))))

--- a/src/lisp/regression-tests/debug.lisp
+++ b/src/lisp/regression-tests/debug.lisp
@@ -171,6 +171,18 @@
    (last (funcall (fdefinition 'bc1)) 2)) ; avoid compiler warning, hopefully
   ((bc1 bc2)))
 
+(test bytecode-frame-locals
+  (progn
+    (funcall (cmp:bytecompile
+              '(lambda ()
+                (defun bcl (x)
+                  (clasp-debug:map-backtrace
+                   (lambda (frame)
+                     (when (eq (clasp-debug:frame-function-name frame) 'bcl)
+                       (return-from bcl (clasp-debug:frame-locals frame)))))))))
+    (bcl 137))
+  (((x . 137))))
+
 ;;; ...that print errors don't escape print-backtrace
 ;;; Note that this result is meaningless if frame-arguments fails.
 (defclass unprintable-object () ())

--- a/src/lisp/regression-tests/debug.lisp
+++ b/src/lisp/regression-tests/debug.lisp
@@ -151,7 +151,25 @@
                  (return (clasp-debug:frame-function-documentation frame))))
              stack)))
          nil))
-      ("Dummy function for use in tests."))
+  ("Dummy function for use in tests."))
+
+;;; And now for bytecode frames.
+(test bytecode-frame-function-name
+  (progn
+    (funcall (cmp:bytecompile
+              '(lambda ()
+                (defun bc2 ()
+                  (let ((frames nil))
+                    (clasp-debug:map-backtrace
+                     (lambda (frame)
+                       (when (eq (clasp-debug:frame-language frame)
+                                 :bytecode)
+                         (push (clasp-debug:frame-function-name frame)
+                               frames))))
+                    frames))
+                (defun bc1 () (bc2)))))
+   (last (funcall (fdefinition 'bc1)) 2)) ; avoid compiler warning, hopefully
+  ((bc1 bc2)))
 
 ;;; ...that print errors don't escape print-backtrace
 ;;; Note that this result is meaningless if frame-arguments fails.


### PR DESCRIPTION
Adds some debugging capabilities for bytecode. Specifically, `disassemble` is slightly nicer, and more importantly, there is a "line tables" system that records where to find local variables. Precise source locations are not in yet, though.