### PR TITLE
Bytecode diagnostics

### DIFF
--- a/include/clasp/core/bytecode_compiler.h
+++ b/include/clasp/core/bytecode_compiler.h
@@ -327,23 +327,28 @@ public:
   int _receiving;
   List_sp _dynenv;
   T_sp _cfunction;
+  T_sp _source_info;
 public:
-  Context(int receiving, T_sp dynenv, T_sp cfunction)
-    : _receiving(receiving), _dynenv(dynenv), _cfunction(cfunction) {}
+  Context(int receiving, T_sp dynenv, T_sp cfunction, T_sp source_info)
+    : _receiving(receiving), _dynenv(dynenv), _cfunction(cfunction),
+      _source_info(source_info){}
   // Sub constructors
   Context(const Context& parent, int receiving)
     : _receiving(receiving), _dynenv(parent.dynenv()),
-      _cfunction(parent.cfunction()) {}
+      _cfunction(parent.cfunction()), _source_info(parent.source_info())
+  {}
   // Plop the de on the front.
   Context(const Context& parent, T_sp de)
     : _receiving(parent.receiving()),
       _dynenv(Cons_O::create(de, parent.dynenv())),
-      _cfunction(parent.cfunction()) {}
+      _cfunction(parent.cfunction()),
+      _source_info(parent.source_info()) {}
   int receiving() const { return this->_receiving; }
   List_sp dynenv() const { return this->_dynenv; }
   Cfunction_sp cfunction() const {
     return gc::As<Cfunction_sp>(this->_cfunction);
   }
+  T_sp source_info() const { return this->_source_info; }
   Module_sp module() const;
 public:
   size_t literal_index(T_sp literal) const;

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -1044,16 +1044,18 @@ static T_sp expand_macro(Function_sp expander, T_sp form, Lexenv_sp env) {
 // Redefined in compiler-conditions.lisp.
 SYMBOL_EXPORT_SC_(CompPkg, expand_compiler_macro_safely);
 CL_DEFUN T_sp cmp__expand_compiler_macro_safely(Function_sp expander, T_sp form,
-                                                Lexenv_sp env) {
+                                                Lexenv_sp env,
+                                                T_sp source_info) {
+  (void)source_info;
   return expand_macro(expander, form, env);
 }
 
 static T_sp expand_compiler_macro(Function_sp expander, T_sp form,
-                                  Lexenv_sp env) {
+                                  Lexenv_sp env, T_sp source_info) {
   // Go through symbolFunction to make it sensitive to redefinition.
   // Also, slower! Too bad.
   return eval::funcall(_sym_expand_compiler_macro_safely->symbolFunction(),
-                       expander, form, env);
+                       expander, form, env, source_info);
 }
 
 SYMBOL_EXPORT_SC_(CompPkg, warn_undefined_global_variable);
@@ -2181,7 +2183,7 @@ void compile_combination(T_sp head, T_sp rest, Lexenv_sp env, const Context cont
             && (head != cl::_sym_typep) && (head != cl::_sym_case)) {
           // Compiler macroexpand
           T_sp form = Cons_O::create(head, rest);
-          T_sp expansion = expand_compiler_macro(gc::As<Function_sp>(cmexpander), form, env);
+          T_sp expansion = expand_compiler_macro(gc::As<Function_sp>(cmexpander), form, env, context.source_info());
           if (expansion != form) {
             compile_form(expansion, env, context);
             return;

--- a/src/lisp/kernel/cmp/cmputil.lisp
+++ b/src/lisp/kernel/cmp/cmputil.lisp
@@ -106,11 +106,14 @@
                                           :source-pos-info cspi))))))
 
 (defun register-global-function-ref (name &optional (origin (ext:current-source-location)))
-  ;; Can't do (push ... (gethash ...)) because we're too early.
-  (let ((existing-refs (gethash name *global-function-refs*))
-        (new-ref
-          (make-global-function-ref :name name :source-pos-info origin)))
-    (setf (gethash name *global-function-refs*) (cons new-ref existing-refs))))
+  (when (boundp '*global-function-refs*)
+    ;; Can't do (push ... (gethash ...)) because we're too early.
+    (let ((existing-refs (gethash name *global-function-refs*))
+          (new-ref
+            (make-global-function-ref :name name
+                                      :source-pos-info origin)))
+      (setf (gethash name *global-function-refs*)
+            (cons new-ref existing-refs)))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/src/lisp/kernel/cmp/cmputil.lisp
+++ b/src/lisp/kernel/cmp/cmputil.lisp
@@ -33,7 +33,6 @@
 
 (defvar *global-function-defs*)
 (defvar *global-function-refs*)
-(defvar *compilation-messages*)
 
 (defvar *warnings-p*)
 (defvar *failure-p*)
@@ -45,102 +44,6 @@
   '((compilation-speed 1)
     (debug 1) (space 1) (speed 1) (safety 1)))
 (defvar *policy* ())
-
-(core:defconstant-equal +note-format+        "Note:          {}")
-(core:defconstant-equal +style-warn-format+  "Style warning: {}")
-(core:defconstant-equal +warn-format+        "Warning:       {}")
-(core:defconstant-equal +error-format+       "Error:         {}")
-(core:defconstant-equal +fatal-format+       "Fatal-error:   {}")
-
-(defstruct (compiler-message (:type vector))
-  (format +note-format+)
-  message
-  source-pos-info)
-
-(defstruct (compiler-note (:include compiler-message)
-                          (:type vector)))
-
-(defstruct (compiler-warning
-             (:type vector)
-             (:include compiler-message
-              (format +warn-format+))))
-
-(defstruct (compiler-error
-             (:type vector)
-             (:include compiler-message
-              (format +error-format+))))
-
-(defstruct (compiler-fatal-error
-             (:type vector)
-             (:include compiler-error
-              (format +fatal-format+))))
-
-(defstruct (compiler-style-warning
-             (:type vector)
-             (:include compiler-warning
-              (format +style-warn-format+))))
-
-;;; defined analogously to WARN, etc.
-(defun coerce-compiler-message (datum args)
-  (cond ((stringp datum) ; it's a fmt string
-         (apply #'core:fmt nil datum args))
-        ((null args) ; it's some kind of object, e.g. a condition
-         (princ-to-string datum))
-        (t (error "BUG: Bad arguments to compiler-warn/error/something: ~a ~a"
-                  datum args))))
-
-(defun compiler-error (spi datum &rest args)
-  (setf *failure-p* (setf *warnings-p* t))
-  (let* ((cspi (or spi (ext:current-source-location)))
-         (err (make-compiler-error :message (coerce-compiler-message datum args)
-                                   :source-pos-info cspi)))
-      (push err *compilation-messages*)))
-
-(defun compiler-warn (spi datum &rest args)
-  (setf *failure-p* (setf *warnings-p* t))
-  (let* ((cspi (or spi (ext:current-source-location)))
-         (err (make-compiler-warning :message (coerce-compiler-message datum args)
-                                     :source-pos-info cspi)))
-    (push err *compilation-messages*)))
-
-;;; We redefine all these warn-specific-thing functions later to signal actual
-;;; conditions using actual format strings.
-
-(defun warn-undefined-global-variable (spi var)
-  (compiler-warn spi "Undefined variable {}" var))
-
-(defun warn-undefined-type (spi type)
-  (compiler-style-warn spi "Undefined type {}" type))
-
-(defun warn-cannot-coerce (spi type)
-  (compiler-style-warn spi "Cannot coerce to type {}: unknown or not defined for coerce" type))
-
-(defun warn-invalid-number-type (spi type)
-  (compiler-warn spi "Invalid number type: {}" type))
-
-(defun warn-icsp-iesp-both-specified (spi)
-  (compiler-warn
-   spi ":initial-contents and :initial-element both specified"))
-
-(defun compiler-style-warn (spi datum &rest args)
-  (setf *warnings-p* t)
-  (let* ((cspi (or spi (ext:current-source-location)))
-         (err (make-compiler-style-warning :message (coerce-compiler-message datum args)
-                                           :source-pos-info cspi)))
-    (push err *compilation-messages*)))
-
-(defun describe-source-location (spi)
-  (let* ((lineno (source-pos-info-lineno spi))
-         (filepos (source-pos-info-filepos spi))
-         (file-scope (file-scope spi))
-         (pathname (file-scope-pathname file-scope)))
-  (core:fmt nil "{} filepos: {}  lineno: {}" (namestring pathname) filepos lineno)))
-
-(defun print-compiler-message (c stream)
-  (let ((msg (core:fmt nil (compiler-message-format c) (compiler-message-message c))))
-    (fresh-line stream)
-    (core:fmt stream ";;; {}%N" msg)
-    (core:fmt stream ";;;     at {} %N" (describe-source-location (compiler-message-source-pos-info c)))))
 
 ;;; (setq core::*echo-repl-read* t)
 
@@ -167,39 +70,10 @@
 
 (defvar *active-protection* nil)
 
-;;; Will be redefined in compiler-conditions.lisp
-(defun do-compilation-unit (closure &key override)
-  (if (or (not *active-protection*) ; we're not in a do-compilation-unit
-          override) ; we are, but we're overriding it
-      (let* ((*active-protection* t)
-             (*compilation-messages* nil)
-             (*global-function-defs* (make-global-function-defs-table))
-             (*global-function-refs* (make-global-function-refs-table)))
-        (unwind-protect
-             (funcall closure) ; --> result*
-          (compilation-unit-finished *compilation-messages*)))
-      (funcall closure)))
-
-;;; Redefined in compiler-conditions.lisp
-(defun compilation-unit-finished (messages)
-  ;; Add messages for global function references that were never satisfied
-  (maphash (lambda (name references)
-             (unless (or (fboundp name)
-                         (gethash name *global-function-defs*))
-               (dolist (ref references)
-                 (pushnew (make-compiler-style-warning
-                           :message (core:fmt nil "Undefined function {}" name)
-                           :source-pos-info (global-function-ref-source-pos-info ref))
-                          messages :test #'equalp))))
-           *global-function-refs*)
-  (dolist (m (reverse messages))
-    (print-compiler-message m *error-output*)))
-
 (defstruct (global-function-def (:type vector) :named)
   type
   name
   source-pos-info)
-
 
 (defstruct (global-function-ref (:type vector) :named)
   name
@@ -210,12 +84,6 @@
        (gethash name *global-function-defs*)))
 
 (export '(known-function-p)) ; FIXME MOVE
-
-;;; Redefined in compiler-conditions.lisp
-(defun warn-redefined-function (name new-type new-origin old-type old-origin)
-  (compiler-warn new-origin "The {} {} was previously defined as a {} at {}%N"
-                 new-type name
-                 old-type (describe-source-location old-origin)))
 
 (defun register-global-function-def (type name)
   (when (boundp '*global-function-defs*)
@@ -251,13 +119,6 @@
 
 (defmacro with-compilation-results ((&rest options) &body body)
   `(call-with-compilation-results (lambda () ,@body) ,@options))
-
-;;; Redefined in compiler-conditions.lisp
-(defun call-with-compilation-results (thunk &rest options)
-  (declare (ignore options)) ; maybe later
-  (let ((*warnings-p* nil)
-        (*failure-p* nil))
-    (values (funcall thunk) *warnings-p* *failure-p*)))
 
 (export 'with-atomic-file-rename)
 (defmacro with-atomic-file-rename ((temp-pathname final-pathname) &body body)

--- a/src/lisp/kernel/cmp/compiler-conditions.lisp
+++ b/src/lisp/kernel/cmp/compiler-conditions.lisp
@@ -122,12 +122,13 @@
 ;; to survive compiler macros signaling errors.
 ;; This is kind of a KLUDGE, and doesn't do all the nice encapsulation
 ;;  that we do in Cleavir. Plus we have no source location.
-(defun cmp:expand-compiler-macro-safely (expander form env)
+(defun cmp:expand-compiler-macro-safely (expander form env
+                                         &optional (origin (ext:current-source-location)))
   (handler-case
       (funcall *macroexpand-hook* expander form env)
     (error (c)
       (warn 'compiler-macro-expansion-error-warning
-            :condition c)
+            :condition c :origin origin)
       form)))
 
 ;; This condition is signaled when an attempt at constant folding fails

--- a/src/lisp/kernel/lsp/claspmacros.lisp
+++ b/src/lisp/kernel/lsp/claspmacros.lisp
@@ -115,6 +115,10 @@
      (,cmp:+wrapped-where-tag+ ,wrapped)
      (,cmp:+header-where-tag+ ,header)))
 
+;;; Sham function for bytecode; cleavir special cases away calls
+(defun cleavir-primop:unreachable ()
+  (error "BUG: Reached code marked unreachable"))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; core:debug-message is a macro to mimic the core:debug-message special operator


### PR DESCRIPTION
Make the bytecode compiler signal warnings with accurate source locations on unknown functions and variables, and give compiler macro expansion warnings accurate source locations as well.