### PR TITLE
Fixsnapshot

### DIFF
--- a/include/clasp/core/configure_clasp.h
+++ b/include/clasp/core/configure_clasp.h
@@ -35,6 +35,7 @@ THE SOFTWARE.
 
 
 #if 0
+#define DEBUG_BADGE_SSL 1
 //// DEBUG_RUNTIME defined and type errors print more info
 //#define DEBUG_RUNTIME 1
 //#define DEBUG_OBJECT_FILES 1
@@ -43,7 +44,7 @@ THE SOFTWARE.
 //#define DEBUG_EVALUATE 1
 //#define DEBUG_DTORS 1
 //#define DEBUG_DYN_ENV_STACK 1
-#define DEBUG_DTREE_INTERPRETER
+//#define DEBUG_DTREE_INTERPRETER
 //#define DEBUG_VIRTUAL_MACHINE 1
 //#define DEBUG_DRAG_CXX_CALLS 1 // Slows down all calls in CXX wrappers - study impact
 //#define DEBUG_DRAG_NATIVE_CALLS 1

--- a/include/clasp/gctools/gcalloc.h
+++ b/include/clasp/gctools/gcalloc.h
@@ -349,6 +349,8 @@ namespace gctools {
       DO_DRAG_GENERAL_ALLOCATION();
 #if defined(USE_BOEHM)
         Header_s* base = do_boehm_general_allocation(snapshot_save_load_init->_headStart->_badge_stamp_wtag_mtag,sizeWithHeader);
+        // transfer the badge
+        base->_badge_stamp_wtag_mtag._header_badge.store(snapshot_save_load_init->_headStart->_badge_stamp_wtag_mtag._header_badge.load());
 # ifdef DEBUG_GUARD
         // Copy the source from the image save/load memory.
         base->_source = snapshot_save_load_init->_headStart->_source;
@@ -373,6 +375,7 @@ namespace gctools {
         return sp;
 #elif defined(USE_MMTK)
         Header_s* base = do_mmtk_general_allocation(snapshot_save_load_init->_headStart->_badge_stamp_wtag_mtag,sizeWithHeader);
+        base->_badge_stamp_wtag_mtag._header_badge.store(snapshot_save_load_init->_headStart->_badge_stamp_wtag_mtag._header_badge.load());
 # ifdef DEBUG_GUARD
         // Copy the source from the image save/load memory.
         base->_source = snapshot_save_load_init->_headStart->_source;

--- a/src/core/hashTable.cc
+++ b/src/core/hashTable.cc
@@ -99,7 +99,8 @@ void verifyHashTable(bool print, std::ostream& ss, HashTable_O* ht, const char* 
     KeyValuePair& entry = ht->_Table[it];
     if (!entry._Key.no_keyp()&&!entry._Key.deletedp()) {
       if (print) {
-        clasp_write_string(fmt::format("Entry[{}] at {}  key: {}  value: {}\n", it, (void*)&entry, _rep_(entry._Key), (entry._Value)));;
+        clasp_write_string(fmt::format("Entry[{}] at {}  key: {} badge: {}  value: {}\n", it, (void*)&entry, _rep_(entry._Key),
+                                       gctools::lisp_general_badge(gc::As_unsafe<General_sp>(entry._Key)), (entry._Value)));
       }
       keys->vectorPushExtend(entry._Key);
     }

--- a/src/gctools/memoryManagement.cc
+++ b/src/gctools/memoryManagement.cc
@@ -552,6 +552,16 @@ size_t random_tail_size() {
   return ts;
 }
 
+
+BaseHeader_s::BadgeStampWtagMtag::BadgeStampWtagMtag(const BadgeStampWtagMtag& other) : StampWtagMtag((StampWtagMtag&)other) {
+  this->_header_badge.store(other._header_badge.load());
+//  printf("%s:%d:%s my copy ctor\n", __FILE__, __LINE__, __FUNCTION__ );
+}
+
+BaseHeader_s::BaseHeader_s(const BaseHeader_s& other) : _badge_stamp_wtag_mtag(other._badge_stamp_wtag_mtag) {
+  printf("%s:%d:%s my copy ctor\n", __FILE__, __LINE__, __FUNCTION__ );
+}
+
 void BaseHeader_s::signal_invalid_object(const BaseHeader_s* header, const char* msg)
 {
   printf("%s:%d  Invalid object with header @ %p message: %s\n", __FILE__, __LINE__, (void*)header, msg);

--- a/src/gctools/snapshotSaveLoad.cc
+++ b/src/gctools/snapshotSaveLoad.cc
@@ -2258,8 +2258,6 @@ void* snapshot_save_impl(void* data) {
   core::SaveLispAndDie* snapshot_data = (core::SaveLispAndDie*)data;
   global_debugSnapshot = getenv("CLASP_DEBUG_SNAPSHOT")!=NULL;
 
-  printf("%s:%d:%s\n", __FILE__, __LINE__, __FUNCTION__ );
-
   //
   // Gather all objects in memory
   //
@@ -2643,6 +2641,13 @@ void* snapshot_save_impl(void* data) {
 
   
 void snapshot_save(core::SaveLispAndDie& data) {
+
+
+  printf("%s:%d:%s snapshot_save dumping class hash-table\n", __FILE__, __LINE__, __FUNCTION__ );
+  core::HashTable_sp classNames = _lisp->_Roots._ClassTable;
+  printf("%s\n", classNames->hash_table_dump().c_str());
+  printf("%s:%d:%s done dumping class hash-table\n", __FILE__, __LINE__, __FUNCTION__ );
+
   //
   // For real save-lisp-and-die do the following (a simple 19 step plan)
   //
@@ -3819,6 +3824,15 @@ void snapshot_load( void* maybeStartOfSnapshot, void* maybeEndOfSnapshot, const 
       }
     }
   }
+  printf("%s:%d:%s Finished snapshot_load checking room\n", __FILE__, __LINE__, __FUNCTION__ );
+  gctools::cl__room(kw::_sym_test);
+  printf("%s:%d:%s Finished snapshot_load dumping _lisp->_Roots._ClassTable\n", __FILE__, __LINE__, __FUNCTION__ );
+  core::HashTable_sp classNames = _lisp->_Roots._ClassTable;
+  printf("%s\n", classNames->hash_table_dump().c_str());
+  printf("%s:%d:%s Finished snapshot_load checking find_class('cl:restart)\n", __FILE__, __LINE__, __FUNCTION__ );
+  core::T_sp theClass = cl__find_class(cl::_sym_restart, true, nil<core::T_O>());
+  printf("%s:%d:%s theClass = %p\n", __FILE__, __LINE__, __FUNCTION__, theClass.raw_());
+
 }
 
 


### PR DESCRIPTION
This should fix issue #1432.
Hashed object badges were not being snapshot saved or loaded.
This broke hashtables after snapshots were loaded.
