### PR TITLE
More BTB

### DIFF
--- a/include/clasp/core/bytecode.h
+++ b/include/clasp/core/bytecode.h
@@ -195,6 +195,33 @@ public:
     CL_DEFMETHOD T_sp name() const { return this->_name; }
 };
 
+// Indicates a nonlocal exit. This is used by the compiler to ensure consistency
+// when compiling the unreachable code following an exit.
+// The idea is that this unreachable code can be compiled as if the exit only
+// acted as a nonexiting form.
+// For example take (foo (return (bar)) ...); computation of the remaining
+// arguments and the call to FOO are unreachable, but if the argument was just
+// (bar), this unreachable code would just need to have one value added to the
+// stack and to be in whatever dynamic environment is in place before.
+FORWARD(BytecodeDebugExit);
+class BytecodeDebugExit_O : public BytecodeDebugInfo_O {
+  LISP_CLASS(core, CorePkg, BytecodeDebugExit_O, "BytecodeDebugExit", BytecodeDebugInfo_O);
+public:
+  BytecodeDebugExit_O(T_sp start, T_sp end, int receiving)
+    : BytecodeDebugInfo_O(start, end), _receiving(receiving) {}
+  CL_LISPIFY_NAME(BytecodeDebugExit/make)
+    CL_DEF_CLASS_METHOD
+    static BytecodeDebugExit_sp make(T_sp start, T_sp end, int receiving) {
+    return gctools::GC<BytecodeDebugExit_O>::allocate<gctools::RuntimeStage>(start, end, receiving);
+  }
+public:
+  int _receiving; // meaning is as for compiler contexts
+public:
+  CL_LISPIFY_NAME(BytecodeDebugExit/receiving)
+    CL_DEFMETHOD Fixnum receiving() const { return this->_receiving; }
+};
+
+
 // Dynenv used for VM call frames to ensure the unwinder properly
 // cleans up stack frames.
 class VMFrameDynEnv_O : public DynEnv_O {

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -11,8 +11,8 @@
                           "core::OptionalArgument" "core::HashTable_O"
                           "core::SimpleVector_size_t_O" "llvmo::DIScope_O" "core::FileStatus_O"
                           "core::CodeSimpleFun_O" "llvmo::IndirectBrInst_O"
-                          "llvmo::ConstantArray_O" "llvmo::PHINode_O" "core::Package_O"
-                          "core::SimpleMDArrayBaseChar_O" "llvmo::DILocation_O"
+                          "core::BytecodeDebugExit_O" "llvmo::ConstantArray_O" "llvmo::PHINode_O"
+                          "core::Package_O" "core::SimpleMDArrayBaseChar_O" "llvmo::DILocation_O"
                           "llvmo::DWARFUnit_O" "core::SimpleMDArray_O" "core::Stream_O"
                           "core::VMFrameDynEnv_O" "core::SymbolClassHolderPair"
                           "comp::EncageFixup_O" "llvmo::MDString_O" "core::ShortFloat_O"
@@ -3596,6 +3596,19 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
              :offset-base-ctype "core::BytecodeDebugDecls_O" :layout-offset-field-names ("_decls")}
+{class-kind :stamp-name "STAMPWTAG_core__BytecodeDebugExit_O"
+            :stamp-key "core::BytecodeDebugExit_O" :parent-class "core::BytecodeDebugInfo_O"
+            :lisp-class-base "core::BytecodeDebugInfo_O" :root-class "core::T_O" :stamp-wtag 3
+            :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::BytecodeDebugExit_O" :layout-offset-field-names ("_start")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::BytecodeDebugExit_O" :layout-offset-field-names ("_end")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::BytecodeDebugExit_O"
+             :layout-offset-field-names ("_receiving")}
 {class-kind :stamp-name "STAMPWTAG_clasp_ffi__ForeignTypeSpec_O"
             :stamp-key "clasp_ffi::ForeignTypeSpec_O" :parent-class "core::General_O"
             :lisp-class-base "core::General_O" :root-class "core::T_O" :stamp-wtag 3

--- a/src/analysis/clasp_gc_cando.sif
+++ b/src/analysis/clasp_gc_cando.sif
@@ -20,16 +20,17 @@
                           "chem::Dimacs_O" "llvmo::DIScope_O" "chem::FullLargeSquareMatrix_O"
                           "core::FileStatus_O" "chem::EnergySketchStretch_O"
                           "chem::EnergyChiralRestraint_O" "llvmo::IndirectBrInst_O"
-                          "core::CodeSimpleFun_O" "geom::MDArrayCoordinate_O"
-                          "llvmo::ConstantArray_O" "chem::ElementsInfo_O" "llvmo::PHINode_O"
-                          "chem::EnergySketchNonbond" "chem::EnergyFixedNonbondRestraint_O"
-                          "core::Package_O" "chem::Structure_Old_List_O"
-                          "core::SimpleMDArrayBaseChar_O" "chem::OctNode_O" "chem::AGEdge_O"
-                          "llvmo::DWARFUnit_O" "chem::ReadAmberParameters_O" "chem::AtomTest_O"
-                          "core::Stream_O" "llvmo::DILocation_O" "core::SimpleMDArray_O"
-                          "core::VMFrameDynEnv_O" "core::SymbolClassHolderPair"
-                          "comp::EncageFixup_O" "chem::EnergyAnchorRestraint_O" "chem::FFAngle_O"
-                          "chem::Smirks_O" "core::ShortFloat_O" "llvmo::MDString_O"
+                          "core::BytecodeDebugExit_O" "core::CodeSimpleFun_O"
+                          "geom::MDArrayCoordinate_O" "llvmo::ConstantArray_O"
+                          "chem::ElementsInfo_O" "llvmo::PHINode_O" "chem::EnergySketchNonbond"
+                          "chem::EnergyFixedNonbondRestraint_O" "core::Package_O"
+                          "chem::Structure_Old_List_O" "core::SimpleMDArrayBaseChar_O"
+                          "chem::OctNode_O" "chem::AGEdge_O" "llvmo::DWARFUnit_O"
+                          "chem::ReadAmberParameters_O" "chem::AtomTest_O" "core::Stream_O"
+                          "llvmo::DILocation_O" "core::SimpleMDArray_O" "core::VMFrameDynEnv_O"
+                          "core::SymbolClassHolderPair" "comp::EncageFixup_O"
+                          "chem::EnergyAnchorRestraint_O" "chem::FFAngle_O" "chem::Smirks_O"
+                          "core::ShortFloat_O" "llvmo::MDString_O"
                           "chem::EnergyDihedralRestraint_O" "core::T_O" "core::Number_O"
                           "llvmo::DICompileUnit_O" "core::BindingDynEnv_O"
                           "chem::EnergyFunctionEnergy_O" "core::AbstractSimpleVector_O"
@@ -5643,6 +5644,19 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
              :offset-base-ctype "core::BytecodeDebugDecls_O" :layout-offset-field-names ("_decls")}
+{class-kind :stamp-name "STAMPWTAG_core__BytecodeDebugExit_O"
+            :stamp-key "core::BytecodeDebugExit_O" :parent-class "core::BytecodeDebugInfo_O"
+            :lisp-class-base "core::BytecodeDebugInfo_O" :root-class "core::T_O" :stamp-wtag 3
+            :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::BytecodeDebugExit_O" :layout-offset-field-names ("_start")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::BytecodeDebugExit_O" :layout-offset-field-names ("_end")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::BytecodeDebugExit_O"
+             :layout-offset-field-names ("_receiving")}
 {class-kind :stamp-name "STAMPWTAG_clasp_ffi__ForeignTypeSpec_O"
             :stamp-key "clasp_ffi::ForeignTypeSpec_O" :parent-class "core::General_O"
             :lisp-class-base "core::General_O" :root-class "core::T_O" :stamp-wtag 3

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -584,7 +584,6 @@ void Context::emit_mv_call() const {
     this->assemble0(vm_mv_call_receive_one);
     break;
   case -1:
-  case 0: // should be receive_fixed 0?
     this->assemble0(vm_mv_call);
     break;
   default:

--- a/src/core/loadltv.cc
+++ b/src/core/loadltv.cc
@@ -56,6 +56,7 @@
 #define LTV_DI_OP_DECLS 3
 #define LTV_DI_OP_THE 4
 #define LTV_DI_OP_BLOCK 5
+#define LTV_DI_OP_EXIT 6
 
 namespace core {
 
@@ -696,6 +697,13 @@ struct loadltv {
     return BytecodeDebugBlock_O::make(start, end, name, receiving);
   }
 
+  T_sp di_op_exit() {
+    Integer_sp start = Integer_O::create(read_u32()),
+      end = Integer_O::create(read_u32());
+    int32_t receiving = read_s32();
+    return BytecodeDebugExit_O::make(start, end, receiving);
+  }
+
   void attr_clasp_module_debug_info(uint32_t bytes) {
     BytecodeModule_sp mod = gc::As<BytecodeModule_sp>(get_ltv(read_index()));
     gctools::Vec0<T_sp> vargs;
@@ -720,6 +728,9 @@ struct loadltv {
           break;
       case LTV_DI_OP_BLOCK:
           vargs.push_back(di_op_block());
+          break;
+      case LTV_DI_OP_EXIT:
+          vargs.push_back(di_op_exit());
           break;
       default:
           SIMPLE_ERROR("Unknown debug info opcode {:02x}", op);

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -1027,7 +1027,10 @@
                                     :inputs () :outputs ()
                                     :come-from cf
                                     :destination dest)))
-      (push dest (rest (bir:next cf)))
+      ;; Don't add duplicate NEXT entries
+      ;; (obscure NLX uses can hit this, like CORE::PACKAGES-ITERATOR)
+      (unless (eql dest (first (bir:next cf)))
+        (pushnew dest (rest (bir:next cf))))
       (set:nadjoinf (bir:predecessors dest) (bir:iblock cf))
       (set:nadjoinf (bir:unwinds cf) uw)
       (set:nadjoinf (bir:entrances dest)

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -1173,13 +1173,6 @@
     (stack-push (%read-variable var inserter) context)
     (stack-push (%read-variable var inserter) context)))
 
-(defmethod compile-instruction ((mnemonic (eql :drop-mv))
-                                inserter annots context &rest args)
-  (declare (ignore inserter annots))
-  (assert (null args))
-  (check-type (context-mv context) bir:linear-datum)
-  (setf (context-mv context) nil))
-
 (defun compile-type-decl (inserter which ctype datum)
   (let ((sys clasp-cleavir:*clasp-system*)
         (sv-ctype-p (member which '(:variable :argument :setq))))

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -630,9 +630,15 @@
            (setf (aref locals base) (cons var cellp))
            (bind-variable var rvalue inserter annots)))
         (t
-         (let ((var (car varcons)))
+         (let* ((var (car varcons))
+                (value (stack-pop context))
+                (cellp (consp value))
+                (rvalue (if cellp (car value) value)))
            (check-type var bir:variable)
-           (write-variable var (stack-pop context) inserter)))))))
+           ;; This is necessary because the attributes are sometimes attached
+           ;; after a later SET. E.g. if a LET binds two cells.
+           (setf (cdr varcons) cellp)
+           (write-variable var rvalue inserter)))))))
 
 (defmethod compile-instruction ((mnemonic (eql :make-cell))
                                 inserter annot context &rest args)

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -749,7 +749,9 @@
             for i from start
             for (arg -p) in args
             for (var . cellp) = (aref locals i)
-            do (bind-variable var arg inserter annots)))))
+            ;; We use %bind rather than bind because we don't want
+            ;; to assert the type of a possibly unprovided argument.
+            do (%bind-variable var arg inserter)))))
 
 ;;; FIXME: Why does this instruction not put it immediately into a var
 (defmethod compile-instruction ((mnemonic (eql :listify-rest-args))
@@ -790,7 +792,8 @@
             while (consp spec)
             do (destructuring-bind (key arg -p) spec
                  (declare (ignore key -p))
-                 (bind-variable var arg inserter annots))))))
+                 ;; %bind to avoid asserting type of unprovided arg
+                 (%bind-variable var arg inserter))))))
 
 (defun compile-jump (inserter context destination)
   (declare (ignore context))

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -616,6 +616,7 @@
                 (value (stack-pop context))
                 (cellp (consp value))
                 (rvalue (if cellp (car value) value)))
+           (check-type rvalue bir:linear-datum)
            (setf (aref locals base) (cons var cellp))
            (bind-variable var rvalue inserter annots)))
         (t
@@ -1352,7 +1353,7 @@
                             (loop repeat r
                                   for o = (make-instance 'bir:output
                                             :name '#:unreachable)
-                                  do (stack-push r c)))
+                                  do (stack-push o c)))
                         (push (cons aend c) exit-contexts))))))))
     ;; Recompute optimize and policy if necessary.
     (when recompute-optimize

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -455,10 +455,12 @@
                     inserter)))
 
 (defun %write-variable (variable value inserter)
-  (bir:record-variable-set variable)
-  (assert (slot-boundp variable 'bir::%binder))
-  (ast-to-bir:insert inserter 'bir:writevar
-                     :inputs (list value) :outputs (list variable)))
+  (cond ((slot-boundp variable 'bir::%binder)
+         (bir:record-variable-set variable)
+         (ast-to-bir:insert inserter 'bir:writevar
+                            :inputs (list value) :outputs (list variable)))
+        (t ; KLUDGE: arises from &optional/&key -p variables.
+         (%bind-variable variable value inserter))))
 
 (defun write-variable (variable value inserter)
   (let ((declared-ctype (declared-var-ctype (bir:name variable))))

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -655,9 +655,13 @@
     (write-variable (car cell) val inserter)))
 
 (defun variable-from-output (output)
-  (let ((readvar (bir:definition output)))
-    (check-type readvar bir:readvar)
-    (bir:input readvar)))
+  (let ((def (bir:definition output)))
+    (etypecase def
+      (bir:readvar (bir:input def))
+      (bir:thei
+       (let ((tdef (bir:definition (bir:input def))))
+         (check-type tdef bir:readvar)
+         (bir:input tdef))))))
 
 (defun resolve-closed (v)
   ;; Each thing on the stack is either a come-from, a list

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -799,7 +799,7 @@
     (let* ((iblock (ast-to-bir::iblock inserter))
            (ifun (bir:function iblock))
            (ll (bir:lambda-list ifun))
-           (args (cdr (member '&key ll))))
+           (args (ldiff (cdr (member '&key ll)) (member '&allow-other-keys ll))))
       (loop with locals = (context-locals context)
             for i from frame-start
             for spec in args

--- a/src/lisp/kernel/cmp/bytecode-machines.lisp
+++ b/src/lisp/kernel/cmp/bytecode-machines.lisp
@@ -92,7 +92,6 @@
     ("push" 56)
     ("pop" 57)
     ("dup" 58)
-    ("drop-mv" 59)
     ("long" 255)))
 
 (defun pythonify-arguments (args)

--- a/src/lisp/kernel/cmp/compile-file.lisp
+++ b/src/lisp/kernel/cmp/compile-file.lisp
@@ -271,7 +271,7 @@ Compile a Lisp source stream and return a corresponding LLVM module."
                                       :serial))
                        environment ; compilation environment
                        ;; output-type can be (or :fasl :bitcode :object)
-                       (output-type (default-library-type) output-type-p)
+                       (output-type (default-library-type))
                        ;; type can be either :kernel or :user
                        ;; FIXME: What does this do.
                        (type :user)

--- a/src/lisp/kernel/lsp/queue.lisp
+++ b/src/lisp/kernel/lsp/queue.lisp
@@ -98,7 +98,7 @@ RETURN:     MESSAGE
     (mp:condition-variable-signal (queue-not-empty queue)))
   message)
 
-(defun dequeue (queue &key (timeout nil timeoutp) (timeout-val nil timeout-val-p))
+(defun dequeue (queue &key (timeout nil) (timeout-val nil))
   "
 DO:         Atomically, dequeue the first message from the QUEUE.  If
             the queue is empty,  then wait on the not-empty condition


### PR DESCRIPTION
Gets the bytecode-to-BIR compiler working on all CL and CORE functions. There are a few more problems remaining:

- Spurious unused variable warnings from `(progn (let ((y x)) y) ...)` kind of code due to bytecode not preserving the variable read
- Lambda lists are handled by checking the `core:function-lambda-list`, which is invalid for e.g. macro functions
- Inlining does not occur (though compiler macroexpansion and deftransform do)