### PR TITLE
Abstract out GC_MALLOC in threadlocal

### DIFF
--- a/src/gctools/threadlocal.cc
+++ b/src/gctools/threadlocal.cc
@@ -160,7 +160,7 @@ VirtualMachine::VirtualMachine() :
 
 void VirtualMachine::startup() {
   size_t stackSpace = VirtualMachine::MaxStackWords*sizeof(T_O*);
-  this->_stackBottom = (T_O**)GC_MALLOC_UNCOLLECTABLE(stackSpace);
+  this->_stackBottom = (T_O**)gctools::RootClassAllocator<T_O>::allocateRootsAndZero(VirtualMachine::MaxStackWords);
   this->_stackTop = this->_stackBottom+VirtualMachine::MaxStackWords-1;
 //  printf("%s:%d:%s vm._stackTop = %p\n", __FILE__, __LINE__, __FUNCTION__, this->_stackTop );
   size_t pageSize = getpagesize();
@@ -203,7 +203,7 @@ VirtualMachine::~VirtualMachine() {
 #if 1
   this->disable_guards();
 #endif
-  GC_FREE(this->_stackBottom);
+  gctools::RootClassAllocator<T_O>::freeRoots(this->_stackBottom);
 }
 
 


### PR DESCRIPTION
Now it can (hypothetically) be used with GCs other than precise Boehm, most notably to let the scraper run. However, I'm not certain how this works (the template type should be irrelevant, but using void crashes the scraper even though that's how it's used in snapshotSaveLoad) sooooo here's hoping everything's fine.