### PR TITLE
Function cells

### DIFF
--- a/include/clasp/core/designators.h
+++ b/include/clasp/core/designators.h
@@ -46,6 +46,9 @@ namespace coerce {
 	*/
 extern Function_sp functionDesignator(T_sp obj);
 extern Function_sp closureDesignator(T_sp obj);
+// Coerce a designator that's about to be called.
+// This lets us save an fboundp check.
+extern Function_sp calledFunctionDesignator(T_sp obj);
 
 #if 0
 /*! Return a Path by interpreting a pathname designator */

--- a/include/clasp/core/evaluator.h
+++ b/include/clasp/core/evaluator.h
@@ -72,41 +72,41 @@ List_sp core__aclasp_list_of_all_special_operators();
 */
 
 inline LCC_RETURN funcall(T_sp fn) {
-  Function_sp func = coerce::functionDesignator(fn);
+  Function_sp func = coerce::calledFunctionDesignator(fn);
   return func->entry_0()( func.raw_() );
 }
 
 
 inline LCC_RETURN funcall(T_sp fn, T_sp arg0 ) {
-  Function_sp func = coerce::functionDesignator(fn);
+  Function_sp func = coerce::calledFunctionDesignator(fn);
   return func->entry_1()( func.raw_(), arg0.raw_() );
 }
 
 
 inline LCC_RETURN funcall(T_sp fn, T_sp arg0, T_sp arg1 ) {
-  Function_sp func = coerce::functionDesignator(fn);
+  Function_sp func = coerce::calledFunctionDesignator(fn);
   return func->entry_2()( func.raw_(), arg0.raw_(), arg1.raw_() );
 }
 
 inline LCC_RETURN funcall(T_sp fn, T_sp arg0, T_sp arg1, T_sp arg2 ) {
-  Function_sp func = coerce::functionDesignator(fn);
+  Function_sp func = coerce::calledFunctionDesignator(fn);
   return func->entry_3()( func.raw_(), arg0.raw_(), arg1.raw_(), arg2.raw_() );
 }
 
 inline LCC_RETURN funcall(T_sp fn, T_sp arg0, T_sp arg1, T_sp arg2, T_sp arg3 ) {
-  Function_sp func = coerce::functionDesignator(fn);
+  Function_sp func = coerce::calledFunctionDesignator(fn);
   return func->entry_4()( func.raw_(), arg0.raw_(), arg1.raw_(), arg2.raw_(), arg3.raw_() );
 }
 
 inline LCC_RETURN funcall(T_sp fn, T_sp arg0, T_sp arg1, T_sp arg2, T_sp arg3, T_sp arg4 ) {
-  Function_sp func = coerce::functionDesignator(fn);
+  Function_sp func = coerce::calledFunctionDesignator(fn);
   return func->entry_5()( func.raw_(), arg0.raw_(), arg1.raw_(), arg2.raw_(), arg3.raw_(), arg4.raw_() );
 }
 
 
  template <class... ARGS>
   inline LCC_RETURN funcall(T_sp fn, ARGS &&... args) {
-   Function_sp func = coerce::functionDesignator(fn);
+   Function_sp func = coerce::calledFunctionDesignator(fn);
   size_t nargs = sizeof...(ARGS);
   T_O* aargs[sizeof...(ARGS)] = {args.raw_()...};
   return func->entry()(func.raw_(), nargs, &aargs[0] );

--- a/include/clasp/core/function.h
+++ b/include/clasp/core/function.h
@@ -525,6 +525,9 @@ public:
 public:
   std::atomic<Function_sp> _Function;
 public:
+  static FunctionCell_sp make(T_sp name, Function_sp initial);
+  static FunctionCell_sp make(T_sp name); // unbound
+public:
   Function_sp real_function() const {
     // relaxed because nobody should be synchronizing on this,
     // but in practice it's probably irrelevant what we do?
@@ -533,7 +536,8 @@ public:
   void real_function_set(Function_sp fun) {
     this->_Function.store(fun, std::memory_order_relaxed);
   }
-
+  void fmakunbound(T_sp name);
+  bool fboundp();
 public:
   // probably unnecessary
   virtual bool compiledP() const {
@@ -608,11 +612,6 @@ public:
     return xep.invoke_5(funcallable_closure.raw_(), lcc_farg0, lcc_farg1, lcc_farg2, lcc_farg3, lcc_farg4);
   }
 };
-
-FunctionCell_sp make_function_cell(T_sp name, Function_sp fun);
-FunctionCell_sp make_unbound_function_cell(T_sp name);
-void function_cell_fmakunbound(FunctionCell_sp fcell, T_sp name);
-bool function_cell_boundp(FunctionCell_sp fcell);
 
 }; // namespace core
 

--- a/include/clasp/core/function.h
+++ b/include/clasp/core/function.h
@@ -609,6 +609,11 @@ public:
   }
 };
 
+FunctionCell_sp make_function_cell(T_sp name, Function_sp fun);
+FunctionCell_sp make_unbound_function_cell(T_sp name);
+void function_cell_fmakunbound(FunctionCell_sp fcell, T_sp name);
+bool function_cell_boundp(FunctionCell_sp fcell);
+
 }; // namespace core
 
 namespace core {

--- a/include/clasp/core/function.h
+++ b/include/clasp/core/function.h
@@ -515,6 +515,103 @@ namespace core {
 };
 
 namespace core {
+
+FORWARD(FunctionCell)
+class FunctionCell_O : public Function_O {
+  LISP_CLASS(core, CorePkg, FunctionCell_O, "FunctionCell", Function_O);
+public:
+  FunctionCell_O(GlobalSimpleFun_sp ep, Function_sp function)
+    : Base(ep), _Function(function) {}
+public:
+  std::atomic<Function_sp> _Function;
+public:
+  Function_sp real_function() const {
+    // relaxed because nobody should be synchronizing on this,
+    // but in practice it's probably irrelevant what we do?
+    return this->_Function.load(std::memory_order_relaxed);
+  }
+  void real_function_set(Function_sp fun) {
+    this->_Function.store(fun, std::memory_order_relaxed);
+  }
+
+public:
+  // probably unnecessary
+  virtual bool compiledP() const {
+    return this->real_function()->compiledP();
+  }
+
+public:
+  static inline LCC_RETURN entry_point_n(core::T_O *lcc_closure, size_t lcc_nargs, core::T_O **lcc_args) {
+    SETUP_CLOSURE(FunctionCell_O, closure);
+    INCREMENT_FUNCTION_CALL_COUNTER(closure);
+    DO_DRAG_CXX_CALLS();
+    // We need to be sure to load the real function only once to avoid race conditions.
+    Function_sp funcallable_closure = closure->real_function();
+    GlobalSimpleFunBase_sp simpleFun = gc::As_assert<GlobalSimpleFunBase_sp>(funcallable_closure->_TheSimpleFun.load());
+    ClaspXepGeneralFunction entry_point = (ClaspXepGeneralFunction)simpleFun->_EntryPoints[0];
+    return (entry_point)(funcallable_closure.raw_(), lcc_nargs, lcc_args);
+  }
+
+  static inline LCC_RETURN entry_point_0(core::T_O *lcc_closure) {
+    SETUP_CLOSURE(FunctionCell_O, closure);
+    INCREMENT_FUNCTION_CALL_COUNTER(closure);
+    DO_DRAG_CXX_CALLS();
+    Function_sp funcallable_closure = closure->real_function();
+    const ClaspXepFunction &xep = gc::As_assert<GlobalSimpleFunBase_sp>(funcallable_closure->_TheSimpleFun.load())->_EntryPoints;
+    return xep.invoke_0(funcallable_closure.raw_());
+  }
+
+  static inline LCC_RETURN entry_point_1(core::T_O *lcc_closure, core::T_O *lcc_farg0) {
+    SETUP_CLOSURE(FunctionCell_O, closure);
+    INCREMENT_FUNCTION_CALL_COUNTER(closure);
+    DO_DRAG_CXX_CALLS();
+    Function_sp funcallable_closure = closure->real_function();
+    const ClaspXepFunction &xep = gc::As_assert<GlobalSimpleFunBase_sp>(funcallable_closure->_TheSimpleFun.load())->_EntryPoints;
+    return xep.invoke_1(funcallable_closure.raw_(), lcc_farg0);
+  }
+
+  static inline LCC_RETURN entry_point_2(core::T_O *lcc_closure, core::T_O *lcc_farg0, core::T_O *lcc_farg1) {
+    SETUP_CLOSURE(FunctionCell_O, closure);
+    INCREMENT_FUNCTION_CALL_COUNTER(closure);
+    DO_DRAG_CXX_CALLS();
+    Function_sp funcallable_closure = closure->real_function();
+    const ClaspXepFunction &xep = gc::As_assert<GlobalSimpleFunBase_sp>(funcallable_closure->_TheSimpleFun.load())->_EntryPoints;
+    return xep.invoke_2(funcallable_closure.raw_(), lcc_farg0, lcc_farg1);
+  }
+
+  static inline LCC_RETURN entry_point_3(core::T_O *lcc_closure, core::T_O *lcc_farg0, core::T_O *lcc_farg1, core::T_O *lcc_farg2) {
+    SETUP_CLOSURE(FunctionCell_O, closure);
+    INCREMENT_FUNCTION_CALL_COUNTER(closure);
+    DO_DRAG_CXX_CALLS();
+    Function_sp funcallable_closure = closure->real_function();
+    const ClaspXepFunction &xep = gc::As_assert<GlobalSimpleFunBase_sp>(funcallable_closure->_TheSimpleFun.load())->_EntryPoints;
+    return xep.invoke_3(funcallable_closure.raw_(), lcc_farg0, lcc_farg1, lcc_farg2);
+  }
+
+  static inline LCC_RETURN entry_point_4(core::T_O *lcc_closure, core::T_O *lcc_farg0, core::T_O *lcc_farg1, core::T_O *lcc_farg2,
+                                         core::T_O *lcc_farg3) {
+    SETUP_CLOSURE(FunctionCell_O, closure);
+    INCREMENT_FUNCTION_CALL_COUNTER(closure);
+    DO_DRAG_CXX_CALLS();
+    Function_sp funcallable_closure = closure->real_function();
+    const ClaspXepFunction &xep = gc::As_assert<GlobalSimpleFunBase_sp>(funcallable_closure->_TheSimpleFun.load())->_EntryPoints;
+    return xep.invoke_4(funcallable_closure.raw_(), lcc_farg0, lcc_farg1, lcc_farg2, lcc_farg3);
+  }
+
+  static inline LCC_RETURN entry_point_5(core::T_O *lcc_closure, core::T_O *lcc_farg0, core::T_O *lcc_farg1, core::T_O *lcc_farg2,
+                                         core::T_O *lcc_farg3, core::T_O *lcc_farg4) {
+    SETUP_CLOSURE(FunctionCell_O, closure);
+    INCREMENT_FUNCTION_CALL_COUNTER(closure);
+    DO_DRAG_CXX_CALLS();
+    Function_sp funcallable_closure = closure->real_function();
+    const ClaspXepFunction &xep = gc::As_assert<GlobalSimpleFunBase_sp>(funcallable_closure->_TheSimpleFun.load())->_EntryPoints;
+    return xep.invoke_5(funcallable_closure.raw_(), lcc_farg0, lcc_farg1, lcc_farg2, lcc_farg3, lcc_farg4);
+  }
+};
+
+}; // namespace core
+
+namespace core {
   void core__closure_slots_dump(Function_sp func);
 
 };

--- a/include/clasp/core/function.h
+++ b/include/clasp/core/function.h
@@ -538,6 +538,8 @@ public:
   }
   void fmakunbound(T_sp name);
   bool fboundp();
+  // like real_function() but signals an error if we are un-fbound.
+  Function_sp fdefinition() const;
 public:
   // probably unnecessary
   virtual bool compiledP() const {

--- a/include/clasp/core/lisp.h
+++ b/include/clasp/core/lisp.h
@@ -317,8 +317,7 @@ public:
     std::atomic<T_sp>          _AllObjectFiles;
     std::atomic<T_sp>          _AllCodeBlocks;
     std::atomic<T_sp>          _AllBytecodeModules;
-    GlobalSimpleFun_sp        _UnboundSymbolFunctionEntryPoint;
-    GlobalSimpleFun_sp        _UnboundSetfSymbolFunctionEntryPoint;
+    GlobalSimpleFun_sp         _UnboundCellFunctionEntryPoint;
     T_sp                       _TerminalIO;
     List_sp                    _ActiveThreads;
     List_sp                    _DefaultSpecialBindings;

--- a/include/clasp/core/primitives.h
+++ b/include/clasp/core/primitives.h
@@ -100,6 +100,7 @@ T_sp core__valid_function_name_p(T_sp arg);
   T_sp core__get_global_inline_status(core::T_sp name, core::T_sp env);
   void core__setf_global_inline_statis(core::T_sp name, bool status, core::T_sp env);
   T_sp cl__fdefinition(T_sp functionName);
+FunctionCell_sp core__ensure_function_cell(T_sp functionName);
   T_sp cl__special_operator_p(Symbol_sp sym);
   T_sp cl__sleep(Real_sp oseconds);
   List_sp core__list_from_vaslist(Vaslist_sp valist);

--- a/include/clasp/core/symbol.h
+++ b/include/clasp/core/symbol.h
@@ -308,21 +308,36 @@ public:
 
  public: // function value slots access
 
+  inline Function_sp functionCell() const { return _Function.load(std::memory_order_relaxed); }
+  inline Function_sp setfFunctionCell() const { return _SetfFunction.load(std::memory_order_relaxed); }
+  inline void functionCellSet(Function_sp f) {
+    _Function.store(f, std::memory_order_relaxed);
+  }
+  inline void setfFunctionCellSet(Function_sp f) {
+    _SetfFunction.store(f, std::memory_order_relaxed);
+  }
+
   void fmakunbound();
   
-  void setSetfFdefinition(Function_sp fn) { _SetfFunction.store(fn, std::memory_order_relaxed); }
-  inline Function_sp getSetfFdefinition() const { return _SetfFunction.load(std::memory_order_relaxed); }
+  inline void setSetfFdefinition(Function_sp fn) { setfFunctionCellSet(fn); }
+  Function_sp getSetfFdefinition() const;
   bool fboundp_setf() const;
   void fmakunbound_setf();
   
   /*! Set the global function value of this symbol */
-  void setf_symbolFunction(Function_sp exec);
+  inline void setf_symbolFunction(Function_sp exec) { functionCellSet(exec); }
 
   /*! Return the global bound function */
-  inline Function_sp symbolFunction() const { return _Function.load(std::memory_order_relaxed); }
+  Function_sp symbolFunction() const;
 
   /*! Return true if the symbol has a function bound*/
   bool fboundp() const;
+
+  // These can be used when the result is going to be called immediately.
+  // They don't check for fboundedness, because if un-fbound the cell
+  // will just signal an error when it is called.
+  inline Function_sp symbolFunctionCalled() const { return functionCell(); }
+  inline Function_sp getSetfFdefinitionCalled() const { return setfFunctionCell(); }
 
  public: // packages, the name, misc
 

--- a/include/clasp/llvmo/intrinsics.h
+++ b/include/clasp/llvmo/intrinsics.h
@@ -79,6 +79,7 @@ LtvcReturn ltvc_make_local_entry_point(gctools::GCRootsInModule* holder, char ta
 
 LtvcReturn ltvc_make_global_entry_point(gctools::GCRootsInModule* holder, char tag, size_t index, size_t functionIndex, core::T_O* functionDescription_t, size_t localEntryPointIndex );
 
+LtvcReturn ltvc_ensure_fcell(gctools::GCRootsInModule* holder, char tag, size_t index, core::T_O* fname);
 
 
 LtvcReturn ltvc_make_package(gctools::GCRootsInModule* holder, char tag, size_t index, core::T_O* package_name_t );

--- a/repos.sexp
+++ b/repos.sexp
@@ -108,7 +108,7 @@
  (:name :cleavir
   :repository "https://github.com/s-expressionists/Cleavir.git"
   :directory "src/lisp/kernel/contrib/Cleavir/"
-  :commit "cacdf4cca14647a258321effb3500ec4563fc570")
+  :commit "833d66dc9b9a8a6fe5a27d4bb852067c579ce226")
  (:name :closer-mop
   :repository "https://github.com/pcostanza/closer-mop.git"
   :directory "src/lisp/kernel/contrib/closer-mop/"

--- a/repos.sexp
+++ b/repos.sexp
@@ -108,7 +108,7 @@
  (:name :cleavir
   :repository "https://github.com/s-expressionists/Cleavir.git"
   :directory "src/lisp/kernel/contrib/Cleavir/"
-  :commit "833d66dc9b9a8a6fe5a27d4bb852067c579ce226")
+  :commit "18ffb79684e1160a034e95b1f27a248873b9ed1b")
  (:name :closer-mop
   :repository "https://github.com/pcostanza/closer-mop.git"
   :directory "src/lisp/kernel/contrib/closer-mop/"

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -3359,10 +3359,10 @@
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::Symbol_O"
              :layout-offset-field-names ("_GlobalValue")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::Function_O>"
+             :offset-ctype "gctools::smart_ptr<core::FunctionCell_O>"
              :offset-base-ctype "core::Symbol_O" :layout-offset-field-names ("_Function")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::Function_O>"
+             :offset-ctype "gctools::smart_ptr<core::FunctionCell_O>"
              :offset-base-ctype "core::Symbol_O" :layout-offset-field-names ("_SetfFunction")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_POD_OFFSET_unsigned_int"
              :offset-ctype "unsigned int" :offset-base-ctype "core::Symbol_O"
@@ -3386,11 +3386,11 @@
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::Null_O"
              :layout-offset-field-names ("_GlobalValue")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::Function_O>" :offset-base-ctype "core::Null_O"
-             :layout-offset-field-names ("_Function")}
+             :offset-ctype "gctools::smart_ptr<core::FunctionCell_O>"
+             :offset-base-ctype "core::Null_O" :layout-offset-field-names ("_Function")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::Function_O>" :offset-base-ctype "core::Null_O"
-             :layout-offset-field-names ("_SetfFunction")}
+             :offset-ctype "gctools::smart_ptr<core::FunctionCell_O>"
+             :offset-base-ctype "core::Null_O" :layout-offset-field-names ("_SetfFunction")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_POD_OFFSET_unsigned_int"
              :offset-ctype "unsigned int" :offset-base-ctype "core::Null_O"
              :layout-offset-field-names ("_BindingIdx")}
@@ -6801,11 +6801,7 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::GlobalSimpleFun_O>"
              :offset-base-ctype "core::Lisp"
-             :layout-offset-field-names ("_Roots" "._UnboundSymbolFunctionEntryPoint")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::GlobalSimpleFun_O>"
-             :offset-base-ctype "core::Lisp"
-             :layout-offset-field-names ("_Roots" "._UnboundSetfSymbolFunctionEntryPoint")}
+             :layout-offset-field-names ("_Roots" "._UnboundCellFunctionEntryPoint")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::Lisp"
              :layout-offset-field-names ("_Roots" "._TerminalIO")}

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -2,13 +2,14 @@
                           "core::SimpleMDArray_fixnum_O" "core::ComplexVector_O"
                           "core::SimpleMDArray_int32_t_O" "core::Integer_O"
                           "clbind::ClassRegistry_O" "mp::Process_O" "core::Record_O"
-                          "core::LightUserData_O" "core::MDArrayT_O" "core::DirectoryEntry_O"
-                          "llvmo::Linker_O" "comp::FunInfo_O" "core::MDArray_float_O"
-                          "core::SimpleFun_O" "core::SourcePosInfo_O" "llvmo::BranchInst_O"
-                          "llvmo::AllocaInst_O" "core::StandardClassCreator_O"
-                          "core::ComplexVector_float_O" "core::HashTableCustom_O"
-                          "comp::LexicalVarInfo_O" "core::ComplexVector_byte8_t_O"
-                          "core::OptionalArgument" "comp::FunctionCellInfo_O" "core::HashTable_O"
+                          "core::LightUserData_O" "core::MDArrayT_O" "core::FunctionCell_O"
+                          "core::DirectoryEntry_O" "llvmo::Linker_O" "comp::FunInfo_O"
+                          "core::MDArray_float_O" "core::SimpleFun_O" "core::SourcePosInfo_O"
+                          "llvmo::BranchInst_O" "llvmo::AllocaInst_O"
+                          "core::StandardClassCreator_O" "core::ComplexVector_float_O"
+                          "core::HashTableCustom_O" "comp::LexicalVarInfo_O"
+                          "core::ComplexVector_byte8_t_O" "core::OptionalArgument"
+                          "comp::FunctionCellInfo_O" "core::HashTable_O"
                           "core::SimpleVector_size_t_O" "llvmo::DIScope_O" "core::FileStatus_O"
                           "core::CodeSimpleFun_O" "llvmo::IndirectBrInst_O"
                           "core::BytecodeDebugExit_O" "llvmo::ConstantArray_O" "llvmo::PHINode_O"
@@ -580,6 +581,15 @@
              :offset-base-ctype "core::LocalSimpleFun_O" :layout-offset-field-names ("_Code")}
 {fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
              :offset-base-ctype "core::LocalSimpleFun_O" :layout-offset-field-names ("_Entry")}
+{class-kind :stamp-name "STAMPWTAG_core__FunctionCell_O" :stamp-key "core::FunctionCell_O"
+            :parent-class "core::Function_O" :lisp-class-base "core::Function_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::SimpleFun_O>"
+             :offset-base-ctype "core::FunctionCell_O" :layout-offset-field-names ("_TheSimpleFun")}
+{fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::Function_O>"
+             :offset-base-ctype "core::FunctionCell_O" :layout-offset-field-names ("_Function")}
 {class-kind :stamp-name "STAMPWTAG_core__ImmobileObject_O" :stamp-key "core::ImmobileObject_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -8,7 +8,7 @@
                           "llvmo::AllocaInst_O" "core::StandardClassCreator_O"
                           "core::ComplexVector_float_O" "core::HashTableCustom_O"
                           "comp::LexicalVarInfo_O" "core::ComplexVector_byte8_t_O"
-                          "core::OptionalArgument" "core::HashTable_O"
+                          "core::OptionalArgument" "comp::FunctionCellInfo_O" "core::HashTable_O"
                           "core::SimpleVector_size_t_O" "llvmo::DIScope_O" "core::FileStatus_O"
                           "core::CodeSimpleFun_O" "llvmo::IndirectBrInst_O"
                           "core::BytecodeDebugExit_O" "llvmo::ConstantArray_O" "llvmo::PHINode_O"
@@ -60,10 +60,10 @@
                           "asttooling::AsttoolingExposer_O" "core::GlobalSimpleFunGenerator_O"
                           "llvmo::IntegerType_O" "comp::GlobalMacroInfo_O"
                           "core::MDArray_int64_t_O" "core::SimpleMDArray_size_t_O"
-                          "core::SmallMultimap_O" "llvmo::PassManagerBuilder_O"
-                          "core::Fixnum_dummy_O" "core::AuxArgument" "core::MDArray_int8_t_O"
-                          "llvmo::ConstantFP_O" "core::BlockDynEnv_O" "core::Cons_O"
-                          "core::WRAPPER_Translator_O" "clbind::detail::vertex"
+                          "comp::VariableCellInfo_O" "core::SmallMultimap_O"
+                          "llvmo::PassManagerBuilder_O" "core::Fixnum_dummy_O" "core::AuxArgument"
+                          "core::MDArray_int8_t_O" "llvmo::ConstantFP_O" "core::BlockDynEnv_O"
+                          "core::Cons_O" "core::WRAPPER_Translator_O" "clbind::detail::vertex"
                           "llvmo::LLVMContext_O" "core::MDArray_int4_t_O"
                           "core::WeakKeyHashTable_O" "core::Rack_O" "core::MDArrayBaseChar_O"
                           "core::UserData_O" "core::ExternalObject_O" "llvmo::DINode_O"
@@ -126,12 +126,12 @@
                           "core::Rational_O" "core::CatchDynEnv_O" "core::MDArrayCharacter_O"
                           "llvmo::LandingPadInst_O" "core::ImmobileObject_O" "core::Function_O"
                           "core::SimpleMDArray_int2_t_O" "core::HashTableEql_O"
-                          "mp::ConditionVariable_O" "core::Real_O" "core::Lisp"
-                          "core::MDArray_byte8_t_O" "core::FuncallableInstanceCreator_O"
-                          "core::StringOutputStream_O" "llvmo::AttributeSet_O"
-                          "llvmo::AtomicRMWInst_O" "comp::Module_O" "llvmo::MDBuilder_O"
-                          "llvmo::PassManager_O" "core::SimpleVector_O" "llvmo::DISubprogram_O"
-                          "core::SymbolStorage" "llvmo::ArrayType_O"
+                          "comp::ConstantInfo_O" "mp::ConditionVariable_O" "core::Real_O"
+                          "core::Lisp" "core::MDArray_byte8_t_O"
+                          "core::FuncallableInstanceCreator_O" "core::StringOutputStream_O"
+                          "llvmo::AttributeSet_O" "llvmo::AtomicRMWInst_O" "comp::Module_O"
+                          "llvmo::MDBuilder_O" "llvmo::PassManager_O" "core::SimpleVector_O"
+                          "llvmo::DISubprogram_O" "core::SymbolStorage" "llvmo::ArrayType_O"
                           "core::SimpleMDArray_int64_t_O" "core::SimpleString_O"
                           "llvmo::DIVariable_O" "core::SimpleMDArray_byte2_t_O"
                           "llvmo::BlockAddress_O" "llvmo::DICompositeType_O"
@@ -218,6 +218,12 @@
 {class-kind :stamp-name "STAMPWTAG_llvmo__AttributeSet_O" :stamp-key "llvmo::AttributeSet_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{class-kind :stamp-name "STAMPWTAG_comp__ConstantInfo_O" :stamp-key "comp::ConstantInfo_O"
+            :parent-class "core::General_O" :lisp-class-base "core::General_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "comp::ConstantInfo_O" :layout-offset-field-names ("_value")}
 {class-kind :stamp-name "STAMPWTAG_core__Function_O" :stamp-key "core::Function_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -4626,6 +4632,12 @@
              :offset-ctype "gctools::tagged_pointer<gctools::GCVector_moveable<std::pair<gctools::smart_ptr<core::Symbol_O>,gctools::smart_ptr<core::T_O>>>>"
              :offset-base-ctype "core::SmallMultimap_O"
              :layout-offset-field-names ("map" "._Contents")}
+{class-kind :stamp-name "STAMPWTAG_comp__VariableCellInfo_O" :stamp-key "comp::VariableCellInfo_O"
+            :parent-class "core::General_O" :lisp-class-base "core::General_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::Symbol_O>"
+             :offset-base-ctype "comp::VariableCellInfo_O" :layout-offset-field-names ("_vname")}
 {class-kind :stamp-name "STAMPWTAG_core__Sigset_O" :stamp-key "core::Sigset_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -6654,6 +6666,12 @@
 {class-kind :stamp-name "STAMPWTAG_core__FileStatus_O" :stamp-key "core::FileStatus_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{class-kind :stamp-name "STAMPWTAG_comp__FunctionCellInfo_O" :stamp-key "comp::FunctionCellInfo_O"
+            :parent-class "core::General_O" :lisp-class-base "core::General_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "comp::FunctionCellInfo_O" :layout-offset-field-names ("_fname")}
 {class-kind :stamp-name "STAMPWTAG_core__SourcePosInfo_O" :stamp-key "core::SourcePosInfo_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}

--- a/src/analysis/clasp_gc_cando.sif
+++ b/src/analysis/clasp_gc_cando.sif
@@ -5,32 +5,32 @@
                           "core::SimpleMDArray_int32_t_O" "core::Integer_O"
                           "chem::SparseLargeSquareMatrix_O" "clbind::ClassRegistry_O"
                           "mp::Process_O" "core::Record_O" "core::LightUserData_O"
-                          "core::MDArrayT_O" "core::DirectoryEntry_O" "chem::Atom_O"
-                          "chem::Kmeans_O" "llvmo::Linker_O" "comp::FunInfo_O" "chem::ZMatrix_O"
-                          "core::MDArray_float_O" "chem::KmeansPlusPlus_O" "core::SimpleFun_O"
-                          "core::SourcePosInfo_O" "llvmo::BranchInst_O" "chem::IterateMatter_O"
-                          "llvmo::AllocaInst_O" "chem::AtomicInfo" "chem::FFTypesDb_O"
-                          "core::ComplexVector_float_O" "core::StandardClassCreator_O"
-                          "chem::Alias_O" "comp::LexicalVarInfo_O"
+                          "core::MDArrayT_O" "core::FunctionCell_O" "core::DirectoryEntry_O"
+                          "chem::Atom_O" "llvmo::Linker_O" "chem::Kmeans_O" "comp::FunInfo_O"
+                          "chem::ZMatrix_O" "core::MDArray_float_O" "chem::KmeansPlusPlus_O"
+                          "core::SimpleFun_O" "core::SourcePosInfo_O" "llvmo::BranchInst_O"
+                          "chem::IterateMatter_O" "llvmo::AllocaInst_O" "chem::AtomicInfo"
+                          "chem::FFTypesDb_O" "core::ComplexVector_float_O"
+                          "core::StandardClassCreator_O" "chem::Alias_O" "comp::LexicalVarInfo_O"
                           "chem::MapOfMonomerNamesToAtomIndexers_O" "chem::ZMatrixInternal_O"
                           "core::HashTableCustom_O" "adapt::SymbolSet_O" "chem::Minimizer_O"
                           "core::ComplexVector_byte8_t_O" "core::OptionalArgument"
-                          "core::HashTable_O" "chem::ChemDraw_O" "chem::Molecule_O"
-                          "chem::ReportBase_O" "core::SimpleVector_size_t_O" "chem::RotamerAtom"
-                          "chem::Dimacs_O" "llvmo::DIScope_O" "chem::FullLargeSquareMatrix_O"
-                          "core::FileStatus_O" "chem::EnergySketchStretch_O"
-                          "chem::EnergyChiralRestraint_O" "llvmo::IndirectBrInst_O"
-                          "core::BytecodeDebugExit_O" "core::CodeSimpleFun_O"
-                          "geom::MDArrayCoordinate_O" "llvmo::ConstantArray_O"
-                          "chem::ElementsInfo_O" "llvmo::PHINode_O" "chem::EnergySketchNonbond"
-                          "chem::EnergyFixedNonbondRestraint_O" "core::Package_O"
-                          "chem::Structure_Old_List_O" "core::SimpleMDArrayBaseChar_O"
-                          "chem::OctNode_O" "chem::AGEdge_O" "llvmo::DWARFUnit_O"
-                          "chem::ReadAmberParameters_O" "chem::AtomTest_O" "core::Stream_O"
-                          "llvmo::DILocation_O" "core::SimpleMDArray_O" "core::VMFrameDynEnv_O"
-                          "core::SymbolClassHolderPair" "comp::EncageFixup_O"
-                          "chem::EnergyAnchorRestraint_O" "chem::FFAngle_O" "chem::Smirks_O"
-                          "core::ShortFloat_O" "llvmo::MDString_O"
+                          "comp::FunctionCellInfo_O" "core::HashTable_O" "chem::ChemDraw_O"
+                          "chem::Molecule_O" "chem::ReportBase_O" "core::SimpleVector_size_t_O"
+                          "chem::RotamerAtom" "chem::Dimacs_O" "llvmo::DIScope_O"
+                          "chem::FullLargeSquareMatrix_O" "core::FileStatus_O"
+                          "chem::EnergySketchStretch_O" "chem::EnergyChiralRestraint_O"
+                          "llvmo::IndirectBrInst_O" "core::BytecodeDebugExit_O"
+                          "core::CodeSimpleFun_O" "geom::MDArrayCoordinate_O"
+                          "llvmo::ConstantArray_O" "chem::ElementsInfo_O" "llvmo::PHINode_O"
+                          "chem::EnergySketchNonbond" "chem::EnergyFixedNonbondRestraint_O"
+                          "core::Package_O" "chem::Structure_Old_List_O"
+                          "core::SimpleMDArrayBaseChar_O" "chem::OctNode_O" "chem::AGEdge_O"
+                          "llvmo::DWARFUnit_O" "chem::ReadAmberParameters_O" "chem::AtomTest_O"
+                          "core::Stream_O" "llvmo::DILocation_O" "core::SimpleMDArray_O"
+                          "core::VMFrameDynEnv_O" "core::SymbolClassHolderPair"
+                          "comp::EncageFixup_O" "chem::EnergyAnchorRestraint_O" "chem::FFAngle_O"
+                          "chem::Smirks_O" "core::ShortFloat_O" "llvmo::MDString_O"
                           "chem::EnergyDihedralRestraint_O" "core::T_O" "core::Number_O"
                           "llvmo::DICompileUnit_O" "core::BindingDynEnv_O"
                           "chem::EnergyFunctionEnergy_O" "core::AbstractSimpleVector_O"
@@ -104,10 +104,10 @@
                           "comp::GlobalMacroInfo_O" "core::SimpleMDArray_size_t_O"
                           "llvmo::IntegerType_O" "core::SmallMultimap_O"
                           "core::GlobalSimpleFunGenerator_O" "core::MDArray_int64_t_O"
-                          "core::Fixnum_dummy_O" "core::AuxArgument" "llvmo::PassManagerBuilder_O"
-                          "core::MDArray_int8_t_O" "chem::ZMatrixBondInternal_O"
-                          "llvmo::ConstantFP_O" "core::BlockDynEnv_O" "core::Cons_O"
-                          "core::WRAPPER_Translator_O" "clbind::detail::vertex"
+                          "core::Fixnum_dummy_O" "core::AuxArgument" "comp::VariableCellInfo_O"
+                          "llvmo::PassManagerBuilder_O" "core::MDArray_int8_t_O"
+                          "chem::ZMatrixBondInternal_O" "llvmo::ConstantFP_O" "core::BlockDynEnv_O"
+                          "core::WRAPPER_Translator_O" "clbind::detail::vertex" "core::Cons_O"
                           "chem::ImproperTorsion_O" "chem::ZMatrixAngleInternal_O"
                           "chem::Rotamer_O" "llvmo::LLVMContext_O" "chem::EnergyAnchorRestraint"
                           "core::MDArray_int4_t_O" "core::WeakKeyHashTable_O"
@@ -212,20 +212,20 @@
                           "kinematics::BondedJoint_O" "core::SimpleMDArray_int2_t_O"
                           "core::ImmobileObject_O" "adapt::IndexedObjectBag_O"
                           "chem::CipPrioritizer_O" "core::HashTableEql_O" "chem::AtomTable_O"
-                          "chem::SpanningLoop_O" "chem::PdbReader_O" "mp::ConditionVariable_O"
-                          "chem::ConformationExplorerEntry_O" "core::Real_O" "core::Lisp"
-                          "core::MDArray_byte8_t_O" "core::FuncallableInstanceCreator_O"
-                          "chem::BondListMatchNode_O" "core::StringOutputStream_O"
-                          "units::Dimension_O" "chem::BondMatcher_O" "llvmo::AttributeSet_O"
-                          "llvmo::AtomicRMWInst_O" "chem::PdbMonomerConnectivity_O"
-                          "chem::RigidBodyNonbondCrossTerm" "comp::Module_O" "llvmo::PassManager_O"
-                          "llvmo::MDBuilder_O" "core::SimpleVector_O" "llvmo::DISubprogram_O"
-                          "core::SymbolStorage" "chem::TrajectoryFrame_O"
-                          "chem::SketchFunctionEnergy_O" "adapt::ObjectSet_O" "llvmo::ArrayType_O"
-                          "core::SimpleMDArray_int64_t_O" "core::SimpleString_O"
-                          "chem::PdbWriter_O" "llvmo::DIVariable_O" "llvmo::MCSubtargetInfo_O"
-                          "core::SimpleMDArray_byte2_t_O" "llvmo::BlockAddress_O"
-                          "llvmo::DICompositeType_O" "chem::Matter_O"
+                          "comp::ConstantInfo_O" "chem::SpanningLoop_O" "chem::PdbReader_O"
+                          "mp::ConditionVariable_O" "chem::ConformationExplorerEntry_O"
+                          "core::Real_O" "core::Lisp" "core::MDArray_byte8_t_O"
+                          "core::FuncallableInstanceCreator_O" "chem::BondListMatchNode_O"
+                          "core::StringOutputStream_O" "units::Dimension_O" "chem::BondMatcher_O"
+                          "llvmo::AttributeSet_O" "llvmo::AtomicRMWInst_O"
+                          "chem::PdbMonomerConnectivity_O" "chem::RigidBodyNonbondCrossTerm"
+                          "comp::Module_O" "llvmo::PassManager_O" "llvmo::MDBuilder_O"
+                          "core::SimpleVector_O" "llvmo::DISubprogram_O" "core::SymbolStorage"
+                          "chem::TrajectoryFrame_O" "chem::SketchFunctionEnergy_O"
+                          "adapt::ObjectSet_O" "llvmo::ArrayType_O" "core::SimpleMDArray_int64_t_O"
+                          "core::SimpleString_O" "chem::PdbWriter_O" "llvmo::DIVariable_O"
+                          "llvmo::MCSubtargetInfo_O" "core::SimpleMDArray_byte2_t_O"
+                          "llvmo::BlockAddress_O" "llvmo::DICompositeType_O" "chem::Matter_O"
                           "core::DerivableCxxClassCreator_O" "core::HashTableEq_O"
                           "chem::RestraintChiral_O" "chem::EnergyComponent_O"
                           "geom::ComplexVectorCoordinate_O" "core::HashTableEqualp_O"
@@ -262,6 +262,12 @@
 {class-kind :stamp-name "STAMPWTAG_llvmo__AttributeSet_O" :stamp-key "llvmo::AttributeSet_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{class-kind :stamp-name "STAMPWTAG_comp__ConstantInfo_O" :stamp-key "comp::ConstantInfo_O"
+            :parent-class "core::General_O" :lisp-class-base "core::General_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "comp::ConstantInfo_O" :layout-offset-field-names ("_value")}
 {class-kind :stamp-name "STAMPWTAG_core__DynEnv_O" :stamp-key "core::DynEnv_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -5449,10 +5455,10 @@
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::Symbol_O"
              :layout-offset-field-names ("_GlobalValue")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::Function_O>"
+             :offset-ctype "gctools::smart_ptr<core::FunctionCell_O>"
              :offset-base-ctype "core::Symbol_O" :layout-offset-field-names ("_Function")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::Function_O>"
+             :offset-ctype "gctools::smart_ptr<core::FunctionCell_O>"
              :offset-base-ctype "core::Symbol_O" :layout-offset-field-names ("_SetfFunction")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_POD_OFFSET_unsigned_int"
              :offset-ctype "unsigned int" :offset-base-ctype "core::Symbol_O"
@@ -5476,11 +5482,11 @@
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::Null_O"
              :layout-offset-field-names ("_GlobalValue")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::Function_O>" :offset-base-ctype "core::Null_O"
-             :layout-offset-field-names ("_Function")}
+             :offset-ctype "gctools::smart_ptr<core::FunctionCell_O>"
+             :offset-base-ctype "core::Null_O" :layout-offset-field-names ("_Function")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::Function_O>" :offset-base-ctype "core::Null_O"
-             :layout-offset-field-names ("_SetfFunction")}
+             :offset-ctype "gctools::smart_ptr<core::FunctionCell_O>"
+             :offset-base-ctype "core::Null_O" :layout-offset-field-names ("_SetfFunction")}
 {fixed-field :offset-type-cxx-identifier "ATOMIC_POD_OFFSET_unsigned_int"
              :offset-ctype "unsigned int" :offset-base-ctype "core::Null_O"
              :layout-offset-field-names ("_BindingIdx")}
@@ -5753,6 +5759,12 @@
              :offset-base-ctype "mpip::Mpi_O" :layout-offset-field-names ("_Source")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "mpip::Mpi_O" :layout-offset-field-names ("_Tag")}
+{class-kind :stamp-name "STAMPWTAG_comp__VariableCellInfo_O" :stamp-key "comp::VariableCellInfo_O"
+            :parent-class "core::General_O" :lisp-class-base "core::General_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::Symbol_O>"
+             :offset-base-ctype "comp::VariableCellInfo_O" :layout-offset-field-names ("_vname")}
 {class-kind :stamp-name "STAMPWTAG_core__Sigset_O" :stamp-key "core::Sigset_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -6022,6 +6034,12 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::Real_O>" :offset-base-ctype "core::Complex_O"
              :layout-offset-field-names ("_imaginary")}
+{class-kind :stamp-name "STAMPWTAG_comp__FunctionCellInfo_O" :stamp-key "comp::FunctionCellInfo_O"
+            :parent-class "core::General_O" :lisp-class-base "core::General_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "comp::FunctionCellInfo_O" :layout-offset-field-names ("_fname")}
 {class-kind :stamp-name "STAMPWTAG_core__SourcePosInfo_O" :stamp-key "core::SourcePosInfo_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -6501,6 +6519,15 @@
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::LocalSimpleFunGenerator_O"
              :layout-offset-field-names ("_entry_point_indices")}
+{class-kind :stamp-name "STAMPWTAG_core__FunctionCell_O" :stamp-key "core::FunctionCell_O"
+            :parent-class "core::Function_O" :lisp-class-base "core::Function_O"
+            :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
+{fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::SimpleFun_O>"
+             :offset-base-ctype "core::FunctionCell_O" :layout-offset-field-names ("_TheSimpleFun")}
+{fixed-field :offset-type-cxx-identifier "ATOMIC_SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::Function_O>"
+             :offset-base-ctype "core::FunctionCell_O" :layout-offset-field-names ("_Function")}
 {class-kind :stamp-name "STAMPWTAG_comp__LexicalInfo_O" :stamp-key "comp::LexicalInfo_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -13261,11 +13288,7 @@
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::GlobalSimpleFun_O>"
              :offset-base-ctype "core::Lisp"
-             :layout-offset-field-names ("_Roots" "._UnboundSymbolFunctionEntryPoint")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::GlobalSimpleFun_O>"
-             :offset-base-ctype "core::Lisp"
-             :layout-offset-field-names ("_Roots" "._UnboundSetfSymbolFunctionEntryPoint")}
+             :layout-offset-field-names ("_Roots" "._UnboundCellFunctionEntryPoint")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::Lisp"
              :layout-offset-field-names ("_Roots" "._TerminalIO")}

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -12,7 +12,7 @@
 #include <clasp/core/array.h>
 #include <clasp/core/unwind.h>
 #include <clasp/core/ql.h>
-
+#include <clasp/core/designators.h> // calledFunctionDesignator
 
 
 #define VM_CODES
@@ -842,14 +842,12 @@ gctools::return_type bytecode_vm(VirtualMachine& vm,
     }
     case vm_fdefinition: {
       // We have function cells in the literals vector. While these are
-      // themselves callable, we have to resolve the cell because we also
+      // themselves callable, we have to resolve the cell because we
       // use vm_fdefinition for lookup of #'foo.
-      // (This doesn't increase indirections in the call case, since when
-      //  called the cell would have to read its function anyway.)
       uint8_t c = *(++pc);
       DBG_VM1("fdefinition %" PRIu8 "\n", c);
       T_sp cell((gctools::Tagged)literals[c]);
-      Function_sp fun = gc::As_assert<FunctionCell_sp>(cell)->real_function();
+      Function_sp fun = gc::As_assert<FunctionCell_sp>(cell)->fdefinition();
       vm.push(sp, fun.raw_());
       VM_RECORD_PLAYBACK(fun.raw_(), "fdefinition");
       pc++;
@@ -878,6 +876,29 @@ gctools::return_type bytecode_vm(VirtualMachine& vm,
       T_O* obj = vm.pop(sp);
       vm.push(sp, obj);
       vm.push(sp, obj);
+      pc++;
+      break;
+    }
+    case vm_fdesignator: {
+      DBG_VM1("fdesignator");
+      T_sp desig((gctools::Tagged)vm.pop(sp));
+      Function_sp fun = coerce::calledFunctionDesignator(desig);
+      vm.push(sp, fun.raw_());
+      VM_RECORD_PLAYBACK(run.raw_(), "fdesignator");
+      pc++;
+      break;
+    }
+    case vm_called_fdefinition: {
+      // This is like FDEFINITION except that we know the result will
+      // just be called. So, we can just use the cell directly
+      // without checking fboundedness, and this is just like const.
+      // (const would be different on an implementation that doesn't
+      //  have funcallable function cells.)
+      uint8_t c = *(++pc);
+      DBG_VM1("called-fdefinition %" PRIu8 "\n", c);
+      T_O* fun = literals[c];
+      vm.push(sp, fun);
+      VM_RECORD_PLAYBACK(fun, "called-fdefinition");
       pc++;
       break;
     }
@@ -1024,7 +1045,7 @@ static unsigned char *long_dispatch(VirtualMachine& vm,
     uint16_t n = low + (*(++pc) << 8);
     DBG_VM1("long fdefinition %" PRIu16 "\n", n);
     T_sp cell((gctools::Tagged)literals[n]);
-    Function_sp fun = gc::As_assert<FunctionCell_sp>(cell)->real_function();
+    Function_sp fun = gc::As_assert<FunctionCell_sp>(cell)->fdefinition();
     vm.push(sp, fun.raw_());
     VM_RECORD_PLAYBACK(fun.raw_(),"long fdefinition");
     pc++;
@@ -1307,6 +1328,16 @@ static unsigned char *long_dispatch(VirtualMachine& vm,
     Symbol_sp sym = gc::As_assert<Symbol_sp>(sym_sp);
     T_sp value((gctools::Tagged)(vm.pop(sp)));
     sym->setf_symbolValue(value);
+    pc++;
+    break;
+  }
+  case vm_called_fdefinition: {
+    uint8_t low = *(++pc);
+    uint16_t n = low + (*(++pc) << 8);
+    DBG_VM1("long called-fdefinition %" PRIu16 "\n", n);
+    T_O* fun = literals[n];
+    vm.push(sp, fun);
+    VM_RECORD_PLAYBACK(fun, "long called-fdefinition");
     pc++;
     break;
   }

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -1134,7 +1134,7 @@ void Module_O::link_load(T_sp compile_info) {
     else if (gc::IsA<ConstantInfo_sp>(lit))
       (*literals)[i] = gc::As_unsafe<ConstantInfo_sp>(lit)->value();
     else if (gc::IsA<FunctionCellInfo_sp>(lit))
-      (*literals)[i] = gc::As_unsafe<FunctionCellInfo_sp>(lit)->fname();
+      (*literals)[i] = core__ensure_function_cell(gc::As_unsafe<FunctionCellInfo_sp>(lit)->fname());
     else if (gc::IsA<VariableCellInfo_sp>(lit))
       (*literals)[i] = gc::As_unsafe<VariableCellInfo_sp>(lit)->vname();
     else SIMPLE_ERROR("BUG: Weird thing in compiler literals vector: {}",

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -2,7 +2,7 @@
 #include <clasp/core/evaluator.h>         // extract_decl...
 #include <clasp/core/sysprop.h>           // core__get_sysprop
 #include <clasp/core/lambdaListHandler.h> // lambda list parsing
-#include <clasp/core/designators.h>       // functionDesignator
+#include <clasp/core/designators.h>       // calledFunctionDesignator
 #include <clasp/core/primitives.h>        // gensym, function_block_name
 #include <clasp/core/sourceFileInfo.h>    // source info stuff
 #include <clasp/llvmo/llvmoPackage.h>
@@ -1185,7 +1185,7 @@ static T_sp expand_macro(Function_sp expander, T_sp form, Lexenv_sp env) {
   // This is copied from cl__macroexpand. I guess eval::funcall doesn't do the
   // coercion itself?
   T_sp macroexpandHook = cl::_sym_STARmacroexpand_hookSTAR->symbolValue();
-  Function_sp hook = coerce::functionDesignator(macroexpandHook);
+  Function_sp hook = coerce::calledFunctionDesignator(macroexpandHook);
   return eval::funcall(hook, expander, form, env);
 }
 

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -2470,7 +2470,9 @@ void compile_combination(T_sp head, T_sp rest, Lexenv_sp env, const Context cont
   else if (head == cl::_sym_the)
     compile_the(oCar(rest), oCadr(rest), env, context);
   // basic optimization
-  else if (head == cl::_sym_funcall)
+  else if (head == cl::_sym_funcall
+           // Do a basic syntax check so that (funcall) fails properly.
+           && rest.consp())
     compile_funcall(oCar(rest), oCdr(rest), env, context);
   // extension
   else if (head == cleavirPrimop::_sym_funcall)

--- a/src/core/compiler.cc
+++ b/src/core/compiler.cc
@@ -1580,7 +1580,7 @@ void ltvc_mlf_create_basic_call_varargs(gctools::GCRootsInModule *holder, char t
                                         Cons_O *varargs) {
   T_sp tfname((gctools::Tagged)fname);
   T_sp tvarargs((gctools::Tagged)varargs);
-  T_sp val = core__apply0(coerce::functionDesignator(tfname), tvarargs);
+  T_sp val = core__apply0(coerce::calledFunctionDesignator(tfname), tvarargs);
   holder->setTaggedIndex(tag, index, val.tagged_());
 }
 
@@ -1588,7 +1588,7 @@ void ltvc_mlf_init_basic_call_varargs(gctools::GCRootsInModule *holder, T_O *fna
   (void)len; // don't need it.
   T_sp tfname((gctools::Tagged)fname);
   T_sp tvarargs((gctools::Tagged)varargs);
-  core__apply0(coerce::functionDesignator(tfname), tvarargs);
+  core__apply0(coerce::calledFunctionDesignator(tfname), tvarargs);
 }
 
 void dump_start_code(T_sp fin, size_t length, bool useFrom = false, size_t from = 0) {

--- a/src/core/designators.cc
+++ b/src/core/designators.cc
@@ -55,6 +55,21 @@ Function_sp functionDesignator(T_sp obj) {
   TYPE_ERROR(obj,Cons_O::createList(cl::_sym_or, cl::_sym_function, cl::_sym_Symbol_O));
 }
 
+// Like the above, but doesn't bother checking fboundp, on the premise
+// that the cell will end up signaling unboundedness anyway.
+Function_sp calledFunctionDesignator(T_sp obj) {
+  if (Function_sp fnobj = obj.asOrNull<Function_O>()) {
+    return fnobj;
+  } else if (obj.nilp()) {
+    ERROR_UNDEFINED_FUNCTION(obj);
+  } else if (obj.unboundp()) {
+    ERROR_UNDEFINED_FUNCTION(obj);
+  } else if (Symbol_sp sym = obj.asOrNull<Symbol_O>()) {
+    return sym->symbolFunctionCalled();
+  }
+  TYPE_ERROR(obj,Cons_O::createList(cl::_sym_or, cl::_sym_function, cl::_sym_Symbol_O));
+}
+
 // this very similar to functionDesignator, can we merge?
 // only use is core__function_source_pos_info
 // perhaps expected type == core::_sym_closure or cl::_sym_symbol

--- a/src/core/designators.cc
+++ b/src/core/designators.cc
@@ -95,6 +95,11 @@ DOCGROUP(clasp);
 CL_DEFUN Function_sp coerce_fdesignator(T_sp obj) {
   return coerce::functionDesignator(obj);
 }
+
+DOCGROUP(clasp);
+CL_DEFUN Function_sp core__coerce_called_fdesignator(T_sp obj) {
+  return coerce::calledFunctionDesignator(obj);
+}
 };
 
 namespace core {

--- a/src/core/designators.cc
+++ b/src/core/designators.cc
@@ -50,8 +50,6 @@ Function_sp functionDesignator(T_sp obj) {
   } else if (obj.unboundp()) {
     ERROR_UNDEFINED_FUNCTION(obj);
   } else if (Symbol_sp sym = obj.asOrNull<Symbol_O>()) {
-    if (!sym->fboundp())
-      SIMPLE_ERROR("Function value for {} is unbound", _rep_(sym));
     return sym->symbolFunction();
   }
   TYPE_ERROR(obj,Cons_O::createList(cl::_sym_or, cl::_sym_function, cl::_sym_Symbol_O));

--- a/src/core/evaluator.cc
+++ b/src/core/evaluator.cc
@@ -521,7 +521,7 @@ CL_UNWIND_COOP(true);
 CL_DOCSTRING(R"dx(apply)dx");
 DOCGROUP(clasp);
 CL_DEFUN T_mv cl__apply(T_sp head, Vaslist_sp args) {
-  Function_sp func = coerce::functionDesignator( head );
+  Function_sp func = coerce::calledFunctionDesignator( head );
   if (args->nargs_zero()) eval::errorApplyZeroArguments();
   size_t lenArgs = args->nargs();
   T_O* lastArgRaw = (*args)[lenArgs - 1];
@@ -658,7 +658,7 @@ CL_DEFUN T_mv core__interpret(T_sp form, T_sp env) {
 }
 
 
-// fast funcall
+// fast funcall. FIXME: use va-rest
 CL_LAMBDA(function-desig &rest args);
 CL_DECLARE((declare (dynamic-extent args)));
 CL_UNWIND_COOP(true);
@@ -666,7 +666,7 @@ CL_DOCSTRING(R"dx(See CLHS: funcall)dx");
 DOCGROUP(clasp);
 CL_DEFUN T_mv cl__funcall(T_sp function_desig, List_sp args) {
   //    printf("%s:%d cl__funcall should be inlined after the compiler starts up\n", __FILE__, __LINE__ );
-  Function_sp func = coerce::functionDesignator(function_desig);
+  Function_sp func = coerce::calledFunctionDesignator(function_desig);
   if (func.nilp()) {
     ERROR_UNDEFINED_FUNCTION(function_desig);
   }

--- a/src/core/evaluator.cc
+++ b/src/core/evaluator.cc
@@ -658,28 +658,19 @@ CL_DEFUN T_mv core__interpret(T_sp form, T_sp env) {
 }
 
 
-// fast funcall. FIXME: use va-rest
-CL_LAMBDA(function-desig &rest args);
-CL_DECLARE((declare (dynamic-extent args)));
+// fast funcall
+CL_LAMBDA(function-desig core:&va-rest args);
+CL_DECLARE();
 CL_UNWIND_COOP(true);
 CL_DOCSTRING(R"dx(See CLHS: funcall)dx");
 DOCGROUP(clasp);
-CL_DEFUN T_mv cl__funcall(T_sp function_desig, List_sp args) {
-  //    printf("%s:%d cl__funcall should be inlined after the compiler starts up\n", __FILE__, __LINE__ );
+CL_DEFUN T_mv cl__funcall(T_sp function_desig, Vaslist_sp args) {
   Function_sp func = coerce::calledFunctionDesignator(function_desig);
-  if (func.nilp()) {
-    ERROR_UNDEFINED_FUNCTION(function_desig);
-  }
-  if (func.unboundp()) {
-    if (function_desig.nilp()) SIMPLE_ERROR("The function designator was NIL");
-    if (function_desig.unboundp()) SIMPLE_ERROR("The function designator was UNBOUND");
-    SIMPLE_ERROR("The function {} was unbound", _rep_(function_desig));
-  }
-  size_t nargs = cl__length(args);
+  size_t nargs = args->nargs();
   MAKE_STACK_FRAME( fargs, nargs );
   size_t ia(0);
-  gctools::fill_frame_list( fargs, ia, args );
-  T_mv res = funcall_general<core::Function_O>(func.tagged_(), nargs, fargs->arguments(0));
+  gctools::fill_frame_vaslist( fargs, ia, args );
+  T_mv res = funcall_general<core::Function_O>(func.tagged_(), nargs, fargs->arguments());
   return res;
 }
 

--- a/src/core/evaluator.cc
+++ b/src/core/evaluator.cc
@@ -692,16 +692,11 @@ CL_DEFUN Function_sp core__coerce_to_function(T_sp arg) {
   if (Function_sp fnobj = arg.asOrNull<Function_O>()) {
     return fnobj;
   } else if (Symbol_sp sym = arg.asOrNull<Symbol_O>()) {
-    if (!sym->fboundp())
-      SIMPLE_ERROR("Function value for {} is unbound", _rep_(sym));
     return sym->symbolFunction();
   } else if (Cons_sp carg = arg.asOrNull<Cons_O>()) {
     T_sp head = oCar(carg);
     if (head == cl::_sym_setf) {
       Symbol_sp sym = oCadr(carg).as<Symbol_O>();
-      if (!sym->fboundp_setf()) {
-        SIMPLE_ERROR("SETF function value for {} is unbound", _rep_(sym));
-      }
       return sym->getSetfFdefinition();
     } else if (head == cl::_sym_lambda) {
       // Really, this will always return a function, but we'll sanity check.

--- a/src/core/exceptions.cc
+++ b/src/core/exceptions.cc
@@ -868,7 +868,7 @@ void FEpackage_error(const char *fmt,
 }
 
 void Warn(T_sp datum, List_sp arguments) {
-  core__apply1( core::coerce::functionDesignator(cl::_sym_warn), arguments, datum);
+  core__apply1( core::coerce::calledFunctionDesignator(cl::_sym_warn), arguments, datum);
 }
 
 void clasp_internal_error(const char *msg) {

--- a/src/core/foundation.cc
+++ b/src/core/foundation.cc
@@ -1375,7 +1375,7 @@ NOINLINE void lisp_error_simple(const char *functionName, const char *fileName, 
     printf("%s:%d lisp_error ->\n %s\n", __FILE__, __LINE__, ss.str().c_str());
     early_debug(nil<T_O>(), false);
   }
-  core__apply1(coerce::functionDesignator(cl::_sym_error), arguments, datum);
+  core__apply1(coerce::calledFunctionDesignator(cl::_sym_error), arguments, datum);
   UNREACHABLE();
 }
 

--- a/src/core/function.cc
+++ b/src/core/function.cc
@@ -1002,5 +1002,19 @@ bool FunctionCell_O::fboundp() {
   return real_function()->entry() != UnboundCellFunctionEntryPoint::entry_point_n;
 }
 
+Function_sp FunctionCell_O::fdefinition() const {
+  // We don't use fboundp since we want to only load the real function
+  // once, in order to avoid strange race condition nonsense.
+  Function_sp rf = real_function();
+  if (real_function()->entry() != UnboundCellFunctionEntryPoint::entry_point_n)
+    return rf;
+  else {
+    // It's an unbound cell closure, so this will signal an
+    // appropriate error.
+    Closure_O* closure = gctools::untag_general<Closure_O*>((Closure_O*)(rf.raw_()));
+    ERROR_UNDEFINED_FUNCTION((*closure)[0]);
+  }
+}
+
 }; // namespace core
 

--- a/src/core/function.cc
+++ b/src/core/function.cc
@@ -974,90 +974,33 @@ struct UnboundCellFunctionEntryPoint {
 
 };
 
-CL_LISPIFY_NAME(FunctionCell/make);
-CL_DEFUN FunctionCell_sp make_function_cell(T_sp name, Function_sp fun)
+FunctionCell_sp FunctionCell_O::make(T_sp name, Function_sp fun)
 {
   GlobalSimpleFun_sp entryPoint =
     makeGlobalSimpleFunAndFunctionDescription<FunctionCell_O>(name, nil<T_O>());
   return gctools::GC<FunctionCell_O>::allocate(entryPoint, fun);
 }
 
-CL_LISPIFY_NAME(FunctionCell/make-unbound);
-CL_DEFUN FunctionCell_sp make_unbound_function_cell(T_sp name) {
+FunctionCell_sp FunctionCell_O::make(T_sp name) {
   if (_lisp->_Roots._UnboundCellFunctionEntryPoint.unboundp())
     _lisp->_Roots._UnboundCellFunctionEntryPoint = makeGlobalSimpleFunAndFunctionDescription<UnboundCellFunctionEntryPoint>(name, nil<T_O>());
   Closure_sp cf = gctools::GC<core::Closure_O>::allocate_container<gctools::RuntimeStage>(false, 1, _lisp->_Roots._UnboundCellFunctionEntryPoint);
   (*cf)[0] = name;
-  return make_function_cell(name, cf);
+  return FunctionCell_O::make(name, cf);
 }
 
-CL_LISPIFY_NAME(FunctionCell/fmakunbound);
-CL_DEFUN void function_cell_fmakunbound(FunctionCell_sp fcell, T_sp name)
+void FunctionCell_O::fmakunbound(T_sp name)
 {
   GlobalSimpleFun_sp f =
     makeGlobalSimpleFunAndFunctionDescription<UnboundCellFunctionEntryPoint>(name, nil<T_O>());
   Closure_sp cf = gctools::GC<core::Closure_O>::allocate_container<gctools::RuntimeStage>(false, 1, f);
   (*cf)[0] = name;
-  fcell->real_function_set(cf);
+  real_function_set(cf);
 }
 
-CL_LISPIFY_NAME(FunctionCell/function);
-DOCGROUP(clasp);
-CL_DEFUN Function_sp function_cell_function(FunctionCell_sp fcell) {
-  return fcell->real_function();
+bool FunctionCell_O::fboundp() {
+  return real_function()->entry() != UnboundCellFunctionEntryPoint::entry_point_n;
 }
 
-CL_LISPIFY_NAME(function-cell/function);
-DOCGROUP(clasp);
-CL_DEFUN_SETF Function_sp function_cell_function_set(Function_sp nv, FunctionCell_sp fcell) {
-  fcell->real_function_set(nv);
-  return nv;
-}
-
-CL_LISPIFY_NAME(function-cell/fboundp);
-CL_DEFUN bool function_cell_boundp(FunctionCell_sp fcell) {
-  return fcell->real_function()->entry() != UnboundCellFunctionEntryPoint::entry_point_n;
-}
-
-
-/*
-FunctionCell_sp ensure_function_cell(T_sp name) {
-  T_sp cell = find_function_cell(name);
-  if (cell.nilp()) {
-    FunctionCell_sp n = make_unbound_function_cell(name);
-    set_function_cell(name, n);
-    return n;
-  } else return gc::As_assert<FunctionCell_sp>(cell);
-}
-
-void set_fdefinition(T_sp name, Function_sp fun) {
-  // could be done with ensure_function_cell, but like this we can
-  // skip putting in an unbound marker
-  T_sp cell = find_function_cell(name);
-  if (cell.nilp()) {
-    FunctionCell_sp n = make_function_cell(name, fun);
-    set_function_cell(name, n);
-    return n;
-  } else {
-    gc::As_assert<FunctionCell_sp>(cell)->real_function_set(fun);
-  }
-}
-
-Function_sp unsafe_fdefinition(T_sp name) {
-  // used for e.g. calls
-  return ensure_function_cell(name)->real_function();
-}
-
-Function_sp safe_fdefinition(T_sp name) {
-  // We go through some extra effort to not ensure a function cell
-  // to reduce garbage a bit.
-  T_sp cell = find_function_cell(name);
-  if (!cell.nilp()) {
-    Function_sp fun = gc::As_assert<FunctionCell_sp>(cell)->real_function();
-    if (function_boundp(fun)) return fun;
-  }
-  ERROR_UNDEFINED_FUNCTION(name);
-}
-*/
 }; // namespace core
 

--- a/src/core/hashTable.cc
+++ b/src/core/hashTable.cc
@@ -254,7 +254,10 @@ CL_DEFUN T_sp cl__make_hash_table(T_sp test, Fixnum_sp size,
   SYMBOL_EXPORT_SC_(KeywordPkg, key);
   if (weakness.notnilp()) {
     if (weakness == INTERN_(kw, key)) {
-      if (test == cl::_sym_eq || test == cl::_sym_eq->symbolFunction()) {
+      // We use symbolFunctionCalled because we actually make hash
+      // tables before eq etc. are bound, so symbolFunction would
+      // signal an error.
+      if (test == cl::_sym_eq || test == cl::_sym_eq->symbolFunctionCalled()) {
         return core__make_weak_key_hash_table(size);
       } else {
         SIMPLE_ERROR("Weak hash tables non-EQ tests are not yet supported");
@@ -270,13 +273,13 @@ CL_DEFUN T_sp cl__make_hash_table(T_sp test, Fixnum_sp size,
   this->_InitialSize = isize;
 #endif
   //	clasp_write_string(fmt::format("{}:{} - make_hash_table - fix me so that I grow by powers of 2\n" , __FILE__ , __LINE__ ));
-  if (test == cl::_sym_eq || test == cl::_sym_eq->symbolFunction()) {
+  if (test == cl::_sym_eq || test == cl::_sym_eq->symbolFunctionCalled()) {
     table = HashTableEq_O::create(isize, rehash_size, rehash_threshold);
-  } else if (test == cl::_sym_eql || test == cl::_sym_eql->symbolFunction()) {
+  } else if (test == cl::_sym_eql || test == cl::_sym_eql->symbolFunctionCalled()) {
     table = HashTableEql_O::create(isize, rehash_size, rehash_threshold);
-  } else if (test == cl::_sym_equal || test == cl::_sym_equal->symbolFunction()) {
+  } else if (test == cl::_sym_equal || test == cl::_sym_equal->symbolFunctionCalled()) {
     table = HashTableEqual_O::create(isize, rehash_size, rehash_threshold);
-  } else if (test == cl::_sym_equalp || test == cl::_sym_equalp->symbolFunction()) {
+  } else if (test == cl::_sym_equalp || test == cl::_sym_equalp->symbolFunctionCalled()) {
     table = HashTableEqualp_O::create(isize, rehash_size, rehash_threshold);
   } else {
     Function_sp comparator = coerce::functionDesignator(test);

--- a/src/core/hashTable.cc
+++ b/src/core/hashTable.cc
@@ -254,10 +254,10 @@ CL_DEFUN T_sp cl__make_hash_table(T_sp test, Fixnum_sp size,
   SYMBOL_EXPORT_SC_(KeywordPkg, key);
   if (weakness.notnilp()) {
     if (weakness == INTERN_(kw, key)) {
-      // We use symbolFunctionCalled because we actually make hash
+      // We use fboundp because we actually make hash
       // tables before eq etc. are bound, so symbolFunction would
       // signal an error.
-      if (test == cl::_sym_eq || test == cl::_sym_eq->symbolFunctionCalled()) {
+      if (test == cl::_sym_eq || (cl::_sym_eq->fboundp() && test == cl::_sym_eq->symbolFunction())) {
         return core__make_weak_key_hash_table(size);
       } else {
         SIMPLE_ERROR("Weak hash tables non-EQ tests are not yet supported");
@@ -273,13 +273,13 @@ CL_DEFUN T_sp cl__make_hash_table(T_sp test, Fixnum_sp size,
   this->_InitialSize = isize;
 #endif
   //	clasp_write_string(fmt::format("{}:{} - make_hash_table - fix me so that I grow by powers of 2\n" , __FILE__ , __LINE__ ));
-  if (test == cl::_sym_eq || test == cl::_sym_eq->symbolFunctionCalled()) {
+  if (test == cl::_sym_eq || (cl::_sym_eq->fboundp() && test == cl::_sym_eq->symbolFunction())) {
     table = HashTableEq_O::create(isize, rehash_size, rehash_threshold);
-  } else if (test == cl::_sym_eql || test == cl::_sym_eql->symbolFunctionCalled()) {
+  } else if (test == cl::_sym_eql || (cl::_sym_eql->fboundp() && test == cl::_sym_eql->symbolFunction())) {
     table = HashTableEql_O::create(isize, rehash_size, rehash_threshold);
-  } else if (test == cl::_sym_equal || test == cl::_sym_equal->symbolFunctionCalled()) {
+  } else if (test == cl::_sym_equal || (cl::_sym_equal->fboundp() && test == cl::_sym_equal->symbolFunction())) {
     table = HashTableEqual_O::create(isize, rehash_size, rehash_threshold);
-  } else if (test == cl::_sym_equalp || test == cl::_sym_equalp->symbolFunctionCalled()) {
+  } else if (test == cl::_sym_equalp || (cl::_sym_equalp->fboundp() && test == cl::_sym_equalp->symbolFunction())) {
     table = HashTableEqualp_O::create(isize, rehash_size, rehash_threshold);
   } else {
     Function_sp comparator = coerce::functionDesignator(test);

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -201,8 +201,7 @@ Lisp::GCRoots::GCRoots() :
   _AllLibraries(nil<T_O>()),
   _AllBytecodeModules(nil<T_O>()),
 #ifdef CLASP_THREADS
-    _UnboundSymbolFunctionEntryPoint(unbound<GlobalSimpleFun_O>()),
-    _UnboundSetfSymbolFunctionEntryPoint(unbound<GlobalSimpleFun_O>()),
+  _UnboundCellFunctionEntryPoint(unbound<GlobalSimpleFun_O>()),
   _ActiveThreads(nil<T_O>()),
   _DefaultSpecialBindings(nil<T_O>()),
 #endif

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -1811,7 +1811,7 @@ CL_DEFUN T_mv cl__macroexpand_1(T_sp form, T_sp env) {
   }
   if (expansionFunction.notnilp()) {
     T_sp macroexpandHook = cl::_sym_STARmacroexpand_hookSTAR->symbolValue();
-    Function_sp hookFunc = coerce::functionDesignator(macroexpandHook);
+    Function_sp hookFunc = coerce::calledFunctionDesignator(macroexpandHook);
     T_sp expanded = eval::funcall(hookFunc, expansionFunction, form, env);
     return (Values(expanded, _lisp->_true()));
   } else

--- a/src/core/loadltv.cc
+++ b/src/core/loadltv.cc
@@ -65,7 +65,7 @@ namespace core {
 #define BC_HEADER_SIZE 16
 
 #define BC_VERSION_MAJOR 0
-#define BC_VERSION_MINOR 11
+#define BC_VERSION_MINOR 12
 
 // versions are std::arrays so that we can compare them.
 typedef std::array<uint16_t, 2> BCVersion;

--- a/src/core/loadltv.cc
+++ b/src/core/loadltv.cc
@@ -221,22 +221,22 @@ struct loadltv {
     // may not work. so we do something stupid.
     for (size_t i = 0; i < _literals.size(); ++i)
       if (_literals[i].unboundp()) // not initialized
-        SIMPLE_ERROR("Invalid FASL: did not initialize object #%zu", i);
+        SIMPLE_ERROR("Invalid FASL: did not initialize object #{:02d}", i);
   }
 
   T_sp get_ltv(size_t index) {
     if (index >= _literals.size())
-      SIMPLE_ERROR("Invalid FASL: requested object #%zu, which is out of range", index);
+      SIMPLE_ERROR("Invalid FASL: requested object #{:02d}, which is out of range", index);
     if (_literals[index].unboundp())
-      SIMPLE_ERROR("Invalid FASL: requested object #%zu, which has not yet been initialized", index);
+      SIMPLE_ERROR("Invalid FASL: requested object #{:02d}, which has not yet been initialized", index);
     return _literals[index];
   }
 
   void set_ltv(T_sp value, size_t index) {
     if (index >= _literals.size())
-      SIMPLE_ERROR("Invalid FASL: Tried to set object #%zu, which is out of range", index);
+      SIMPLE_ERROR("Invalid FASL: Tried to set object #{:02d}, which is out of range", index);
     if (!_literals[index].unboundp())
-      SIMPLE_ERROR("Invalid FASL: Tried to set object #%zu, which has already been initialized", index);
+      SIMPLE_ERROR("Invalid FASL: Tried to set object #{:02d}, which has already been initialized", index);
     _literals[index] = value;
   }
 

--- a/src/core/loadltv.cc
+++ b/src/core/loadltv.cc
@@ -9,7 +9,7 @@
 #include <clasp/core/core.h>
 #include <clasp/core/bformat.h>
 #include <clasp/core/ql.h>            // ql::list
-#include <clasp/core/primitives.h>    // cl__fdefinition
+#include <clasp/core/primitives.h>    // core__ensure_function_cell
 #include <clasp/core/bytecode.h>      // modules, functions
 #include <clasp/core/lispStream.h>    // I/O
 #include <clasp/core/hashTable.h>     // making hash tables
@@ -65,13 +65,13 @@ namespace core {
 #define BC_HEADER_SIZE 16
 
 #define BC_VERSION_MAJOR 0
-#define BC_VERSION_MINOR 10
+#define BC_VERSION_MINOR 11
 
 // versions are std::arrays so that we can compare them.
 typedef std::array<uint16_t, 2> BCVersion;
 
 const BCVersion min_version = {BC_VERSION_MAJOR, BC_VERSION_MINOR};
-const BCVersion max_version = {BC_VERSION_MAJOR, BC_VERSION_MINOR + 1};
+const BCVersion max_version = {BC_VERSION_MAJOR, BC_VERSION_MINOR};
 
 static uint64_t ltv_header_decode(uint8_t *header) {
   if (header[0] != FASL_MAGIC_NUMBER_0 || header[1] != FASL_MAGIC_NUMBER_1 || header[2] != FASL_MAGIC_NUMBER_2 || header[3] != FASL_MAGIC_NUMBER_3)
@@ -611,10 +611,9 @@ struct loadltv {
   }
 
   void op_fcell() {
-    // Currently Clasp does not have FDEFNs, so this is just an identity.
     size_t index = read_index();
     T_sp name = get_ltv(read_index());
-    set_ltv(name, index);
+    set_ltv(core__ensure_function_cell(name), index);
   }
 
   void op_vcell() {

--- a/src/core/mpPackage.cc
+++ b/src/core/mpPackage.cc
@@ -165,7 +165,7 @@ void do_start_thread_inner(Process_sp process, core::List_sp bindings) {
     core::T_mv result_mv;
     {
       try {
-        result_mv = core::core__apply0(core::coerce::functionDesignator(process->_Function),args);
+        result_mv = core::core__apply0(core::coerce::calledFunctionDesignator(process->_Function),args);
       } catch (ExitProcess& e) {
         // Exiting specially. Don't touch _ReturnValuesList - it's initialized to NIL just fine,
         // and may have been set by mp:exit-process.

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -1068,6 +1068,26 @@ CL_DEFUN_SETF T_sp setf_fdefinition(Function_sp function, T_sp name) {
   TYPE_ERROR(name, Cons_O::createList(cl::_sym_satisfies, core::_sym_validFunctionNameP));
 }
 
+// Used by the FASL loaders.
+DOCGROUP(clasp);
+CL_DEFUN FunctionCell_sp core__ensure_function_cell(T_sp functionName) {
+  if (functionName.consp()) {
+    List_sp cname = functionName;
+    if (oCar(cname) == cl::_sym_setf) {
+      T_sp dname = oCdr(cname);
+      if (dname.consp()) {
+        Symbol_sp name = gc::As<Symbol_sp>(oCar(dname));
+        if (name.notnilp() && oCdr(dname).nilp()) {
+          return name->ensureSetfFunctionCell();
+        }
+      }
+    }
+  } else if (gc::IsA<Symbol_sp>(functionName)) {
+    return gc::As_unsafe<Symbol_sp>(functionName)->ensureFunctionCell();
+  }
+  TYPE_ERROR(functionName, Cons_O::createList(cl::_sym_satisfies, core::_sym_validFunctionNameP));
+}
+
 // reader in symbol.cc; this additionally involves function properties, so it's here
 CL_LISPIFY_NAME("cl:symbol-function");
 CL_LAMBDA(function symbol);

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -1030,17 +1030,11 @@ CL_DEFUN T_sp cl__fdefinition(T_sp functionName) {
       if (dname.consp()) {
         Symbol_sp name = gc::As<Symbol_sp>(oCar(dname));
         if (name.notnilp() && oCdr(dname).nilp()) {
-          if (!name->fboundp_setf()) {
-            ERROR_UNDEFINED_FUNCTION(functionName);
-          }
           return name->getSetfFdefinition();
         }
       }
     }
   } else if (Symbol_sp sym = functionName.asOrNull<Symbol_O>() ) {
-    if (!sym->fboundp()) {
-      ERROR_UNDEFINED_FUNCTION(functionName);
-    }
     return sym->symbolFunction();
   }
   TYPE_ERROR(functionName, Cons_O::createList(cl::_sym_satisfies, core::_sym_validFunctionNameP));

--- a/src/core/readtable.cc
+++ b/src/core/readtable.cc
@@ -875,7 +875,7 @@ Readtable_sp Readtable_O::create_standard_readtable() {
                           _sym_reader_backquoted_expression,
                           nil<T_O>());
   rt->set_macro_character_(clasp_make_standard_character(','),
-                          _sym_reader_comma_form->symbolFunction(),
+                           _sym_reader_comma_form,
                           nil<T_O>());
   SYMBOL_SC_(CorePkg, read_list_allow_consing_dot);
   rt->set_macro_character_(clasp_make_standard_character('('),

--- a/src/lisp/kernel/cleavir/bmir.lisp
+++ b/src/lisp/kernel/cleavir/bmir.lisp
@@ -66,3 +66,10 @@
 (cleavir-stealth-mixins:define-stealth-mixin
     constant (datum) bir:constant
   ((%rtype :initform '(:object))))
+
+(cleavir-stealth-mixins:define-stealth-mixin
+    function-cell (datum) bir:function-cell
+  ((%rtype :initform '(:object))))
+(cleavir-stealth-mixins:define-stealth-mixin
+    variable-cell (datum) bir:variable-cell
+  ((%rtype :initform '(:object))))

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -483,11 +483,16 @@
          (bir:come-from var))
        context))))
 
+(defun inserter-module (inserter)
+  ;; FIXME: Export a-t-b:iblock or something.
+  (bir:module (bir:function (ast-to-bir::iblock inserter))))
+
 (defun inserter-constant (value inserter)
-  (let* ((iblock (ast-to-bir::iblock inserter)) ; FIXME
-         (ifun (bir:function iblock))
-         (module (bir:module ifun)))
-    (bir:constant-in-module value module)))
+  (bir:constant-in-module value (inserter-module inserter)))
+(defun inserter-vcell (symbol inserter)
+  (bir:variable-cell-in-module symbol (inserter-module inserter)))
+(defun inserter-fcell (fname inserter)
+  (bir:function-cell-in-module fname (inserter-module inserter)))
 
 (defun compile-constant (value inserter)
   (let* ((const (inserter-constant value inserter))
@@ -1088,7 +1093,7 @@
   (destructuring-bind (symbol) args
     (let* ((next (mapcar #'bt:block-entry-extra
                          (context-successors context)))
-           (const (inserter-constant symbol inserter))
+           (const (inserter-vcell symbol inserter))
            (value (stack-pop context))
            (bind (ast-to-bir:terminate inserter 'bir:constant-bind
                                        :inputs (list const value)
@@ -1099,7 +1104,7 @@
                                 inserter annot context &rest args)
   (declare (ignore annot))
   (destructuring-bind (symbol) args
-    (let ((const (inserter-constant symbol inserter))
+    (let ((const (inserter-vcell symbol inserter))
           (out (make-instance 'bir:output :name symbol)))
       (ast-to-bir:insert inserter 'bir:constant-symbol-value
                          :inputs (list const) :outputs (list out))
@@ -1109,7 +1114,7 @@
                                 inserter annot context &rest args)
   (declare (ignore annot))
   (destructuring-bind (symbol) args
-    (let ((const (inserter-constant symbol inserter))
+    (let ((const (inserter-vcell symbol inserter))
           (in (stack-pop context)))
       (ast-to-bir:insert inserter 'bir:set-constant-symbol-value
                          :inputs (list const in)))))
@@ -1130,13 +1135,10 @@
                                 inserter annot context &rest args)
   (declare (ignore annot))
   (destructuring-bind (fcell) args
-    (let* ((iblock (ast-to-bir::iblock inserter))
-           (ifun (bir:function iblock))
-           (module (bir:module ifun))
-           ;; FIXME: May not be a sufficiently reliable way to get
+    (let* (;; FIXME: May not be a sufficiently reliable way to get
            ;; the name from the cell in all cases? Probably ok though
            (fname (core:function-name fcell))
-           (const (bir:constant-in-module fname module))
+           (const (inserter-fcell fname inserter))
            (attributes (clasp-cleavir::function-attributes fname))
            (fdef-out (make-instance 'bir:output
                        :name fname :attributes attributes)))
@@ -1150,11 +1152,8 @@
                                 inserter annot context &rest args)
   (declare (ignore annot))
   (destructuring-bind (fcell) args
-    (let* ((iblock (ast-to-bir::iblock inserter))
-           (ifun (bir:function iblock))
-           (module (bir:module ifun))
-           (fname (core:function-name fcell))
-           (const (bir:constant-in-module fname module))
+    (let* ((fname (core:function-name fcell))
+           (const (inserter-fcell fname inserter))
            (attributes (clasp-cleavir::function-attributes fname))
            (fdef-out (make-instance 'bir:output
                        :name fname :attributes attributes)))
@@ -1167,11 +1166,8 @@
   ;; Just call CORE:COERCE-CALLED-FDESIGNATOR.
   (declare (ignore annot))
   (let* ((desig (stack-pop context))
-         (iblock (ast-to-bir::iblock inserter))
-         (ifun (bir:function iblock))
-         (module (bir:module ifun))
          (fname 'core:coerce-called-fdesignator)
-         (const (bir:constant-in-module fname module))
+         (const (inserter-fcell fname inserter))
          (attributes (clasp-cleavir::function-attributes fname))
          (fdef-out (make-instance 'bir:output
                      :name fname :attributes attributes))

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -1129,10 +1129,13 @@
 (defmethod compile-instruction ((mnemonic (eql :fdefinition))
                                 inserter annot context &rest args)
   (declare (ignore annot))
-  (destructuring-bind (fname) args
+  (destructuring-bind (fcell) args
     (let* ((iblock (ast-to-bir::iblock inserter))
            (ifun (bir:function iblock))
            (module (bir:module ifun))
+           ;; FIXME: May not be a sufficiently reliable way to get
+           ;; the name from the cell in all cases? Probably ok though
+           (fname (core:function-name fcell))
            (const (bir:constant-in-module fname module))
            (attributes (clasp-cleavir::function-attributes fname))
            (fdef-out (make-instance 'bir:output

--- a/src/lisp/kernel/cleavir/convert-special.lisp
+++ b/src/lisp/kernel/cleavir/convert-special.lisp
@@ -47,7 +47,7 @@
 ;;;
 
 (def-convert-macro multiple-value-call (function-form &rest forms)
-  (let ((cf `(core:coerce-fdesignator ,function-form)))
+  (let ((cf `(core:coerce-called-fdesignator ,function-form)))
     (case (length forms)
       (0
        `(cleavir-primop:funcall ,cf))

--- a/src/lisp/kernel/cleavir/inline.lisp
+++ b/src/lisp/kernel/cleavir/inline.lisp
@@ -72,7 +72,7 @@
               (funcall *macroexpand-hook* cmf form env)
               `(cleavir-primop:funcall ,function ,@arguments))))))
   `(cleavir-primop:funcall
-    (core:coerce-fdesignator ,function)
+    (core:coerce-called-fdesignator ,function)
     ,@arguments))
 
 ;;; We do this so that the compiler only has one form of variadic call to

--- a/src/lisp/kernel/cmp/bytecode-machines.lisp
+++ b/src/lisp/kernel/cmp/bytecode-machines.lisp
@@ -92,6 +92,8 @@
     ("push" 56)
     ("pop" 57)
     ("dup" 58)
+    ("fdesignator" 59)
+    ("called-fdefinition" 60 ((constant-arg 1)) ((constant-arg 2)))
     ("long" 255)))
 
 (defun pythonify-arguments (args)

--- a/src/lisp/kernel/cmp/cmpexports.lisp
+++ b/src/lisp/kernel/cmp/cmpexports.lisp
@@ -443,6 +443,7 @@
           new-table-index
           constants-table-reference
           constants-table-value
+          reference-function-cell
           load-time-value-from-thunk
           with-rtv
           arrange-thunk-as-top-level

--- a/src/lisp/kernel/cmp/cmpintrinsics.lisp
+++ b/src/lisp/kernel/cmp/cmpintrinsics.lisp
@@ -411,6 +411,12 @@ Boehm and MPS use a single pointer"
 (defconstant +funcallable-instance.rack-index+ (c++-field-index :rack info.%funcallable-instance%))
 (define-symbol-macro %funcallable-instance*% (llvm-sys:type-get-pointer-to %funcallable-instance%))
 
+;;; Ditto for FunctionCell_O
+(define-c++-struct %function-cell% +general-tag+
+  ((%i8*% :vtable)
+   (%t*% :entry-point)
+   (%atomic<tsp>% :real-function)))
+
 ;;;
 ;;; The %symbol% type MUST match the layout and size of Symbol_O in symbol.h
 ;;;

--- a/src/lisp/kernel/cmp/cmpir.lisp
+++ b/src/lisp/kernel/cmp/cmpir.lisp
@@ -407,12 +407,10 @@ local-function - the lcl function that all of the xep functions call."
 (defun irc-ptr-to-int (val int-type &optional (label "ptrtoint"))
   (llvm-sys:create-ptr-to-int *irbuilder* val int-type label))
 
-(defun irc-fdefinition (symbol &optional (label ""))
-  (irc-t*-load-atomic (c++-field-ptr info.%symbol% symbol :function) :label label))
-
-(defun irc-setf-fdefinition (symbol &optional (label ""))
-  (irc-t*-load-atomic (c++-field-ptr info.%symbol% symbol :setf-function)
-                   :label label))
+(defun irc-fdefinition (fcell &optional (label ""))
+  (irc-t*-load-atomic
+   (c++-field-ptr info.%function-cell% fcell :real-function)
+   :label label))
 
 (defun irc-maybe-check-tag (tagged-ptr tag)
   (if (member :check-tags *features*)

--- a/src/lisp/kernel/cmp/cmpltv.lisp
+++ b/src/lisp/kernel/cmp/cmpltv.lisp
@@ -754,7 +754,7 @@
 (defun write-magic (stream) (write-b32 +magic+ stream))
 
 (defparameter *major-version* 0)
-(defparameter *minor-version* 10)
+(defparameter *minor-version* 11)
 
 (defun write-version (stream)
   (write-b16 *major-version* stream)

--- a/src/lisp/kernel/cmp/cmpltv.lisp
+++ b/src/lisp/kernel/cmp/cmpltv.lisp
@@ -627,8 +627,11 @@
            (let ((*initializer-map* (or *initializer-map* (make-hash-table))))
              (prog1
                  (add-creator value (creation-form-creator value create))
+               ;; WARNING: If object initializations ever need instructions
+               ;; moved besides GENERAL-INITIALIZER, they have to be part of
+               ;; these TYPEPs.
                (setf *instructions* (nconc (remove-if (lambda (x)
-                                                        (not (typep x 'creator)))
+                                                        (typep x 'general-initializer))
                                                       (gethash value *initializer-map*))
                                            *instructions*))
                (let* ((*initializer-destination* value)
@@ -641,7 +644,7 @@
                            (nconc (gethash *initializer-destination* *initializer-map*)
                                   instructions))))
                (setf *instructions* (nconc (remove-if (lambda (x)
-                                                        (typep x 'creator))
+                                                        (not (typep x 'general-initializer)))
                                                       (gethash value *initializer-map*))
                                            *instructions*))))))
         (*initializer-destination*

--- a/src/lisp/kernel/cmp/cmpltv.lisp
+++ b/src/lisp/kernel/cmp/cmpltv.lisp
@@ -754,7 +754,7 @@
 (defun write-magic (stream) (write-b32 +magic+ stream))
 
 (defparameter *major-version* 0)
-(defparameter *minor-version* 11)
+(defparameter *minor-version* 12)
 
 (defun write-version (stream)
   (write-b16 *major-version* stream)

--- a/src/lisp/kernel/cmp/startup-primitives.lisp
+++ b/src/lisp/kernel/cmp/startup-primitives.lisp
@@ -17,13 +17,15 @@
 ;;;   The gcroots, tag, targetIndex are used to get a reference to a cell in the gcroots
 ;;;   and the ...args... are used to construct the object.
 ;;; If you add a new ltvc_xxxx function then do the following to rebuild the virtual machine
-;;; To build the machine in the src/core/byte-code-interpreter.cc file use:
+;;; To build the machine in the src/core/byte-code-interpreter.cc file manually use:
 ;;; (0) Erase the code in byte-code-interpreter.cc
 ;;; (1) ./waf build_rboehm
 ;;; (2) (literal::build-c++-machine)
 ;;; (3) copy the result into byte-code-interpreter.cc
+;;; But the build system will rebuild the interpreter automatically.
 ;;;
 (defvar *startup-primitives-as-list*
+  ;; (unwindsp name argtypes &key varargs)
   '((nil "ltvc_make_nil"                  (:i8 :size_t))
     (nil "ltvc_make_t"                    (:i8 :size_t))
     (nil "ltvc_make_ratio"                (:i8 :size_t :t* :t*))
@@ -49,6 +51,7 @@
                                            :size_t :size_t))
     (nil "ltvc_make_global_entry_point"   (:i8 :size_t :size_t :t* :size_t))
     (nil "ltvc_make_local_entry_point"    (:i8 :size_t :size_t :t*))
+    (nil "ltvc_ensure_fcell"              (:i8 :size_t :t*))
     (nil "ltvc_make_random_state"         (:i8 :size_t :t*))
     (nil "ltvc_make_float"                (:i8 :size_t :single-float))
     (nil "ltvc_make_double"               (:i8 :size_t :double-float))

--- a/src/llvmo/link_intrinsics.cc
+++ b/src/llvmo/link_intrinsics.cc
@@ -439,6 +439,14 @@ LtvcReturnVoid ltvc_make_global_entry_point(gctools::GCRootsInModule* holder, ch
   NO_UNWIND_END();
 }
 
+LtvcReturnVoid ltvc_ensure_fcell(gctools::GCRootsInModule* holder, char tag, size_t index, core::T_O* fname)
+{
+  NO_UNWIND_BEGIN();
+  T_sp tfname((gctools::Tagged)fname);
+  FunctionCell_sp fcell = core__ensure_function_cell(tfname);
+  LTVCRETURN holder->setTaggedIndex(tag,index,fcell.tagged_());
+  NO_UNWIND_END();
+}
 
 LtvcReturnVoid ltvc_make_package(gctools::GCRootsInModule* holder, char tag, size_t index, core::T_O* package_name_t )
 {


### PR DESCRIPTION
Moves global function definitions into function cells. Also applies some new optimizations for bytecode.

The function cells are still just stored in symbols, so a bit more work would be required for any kind of first class environment structure.