### PR TITLE
Fix read-line

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,9 @@
 ## Removed
 * Obsolete `:object`, `:ll`, `:bc`, and `:fasl` build modes.
 
+## Fixed
+* `cl:read-line` so it correctly returns lines that end with EOF.
+
 # Version 2.4.0 (LLVM15-17) 2023-10-01
 
 ## Added

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -5797,7 +5797,8 @@ CL_DEFUN T_mv cl__read_line(T_sp sin, T_sp eof_error_p, T_sp eof_value, T_sp rec
   if (!AnsiStreamP(sin)) {
     T_mv results = eval::funcall(gray::_sym_stream_read_line, sin);
     MultipleValues &mvn = core::lisp_multipleValues();
-    if (mvn.second(results.number_of_values()).isTrue()) {
+    if (mvn.second(results.number_of_values()).isTrue() &&
+        (gc::As<core::String_sp>(results)->length() == 0)) {
       if (eof_error_p.notnilp()) {
         ERROR_END_OF_FILE(sin);
       } else {

--- a/src/lisp/kernel/clos/streams.lisp
+++ b/src/lisp/kernel/clos/streams.lisp
@@ -539,9 +539,7 @@
     (loop
      (let ((ch (stream-read-char stream)))
        (cond ((eq ch :eof)
-              (return (values (if (zerop index)
-                                  nil
-                                  (si::shrink-vector res index))
+              (return (values (si::shrink-vector res index)
                               t)))
              (t
               (when (char= ch #\newline)


### PR DESCRIPTION
Our read-line implementation for Gray streams isn't compliant with the spec. Currently it returns the error-value or signals an error whenever EOF is reached. The [spec](https://novaspec.org/cl/f_read-line) says EOF should only be signaled when no characters are read as follows:

1. At eof `(read-line stream)` signals end-of-file.
2. At eof `(read-line stream nil :wibble)` returns `(values :wibble t)`
3. When stream contains #\a followed by #\newline `(read-line stream)` return `(values "a" nil)`
4. When stream contains #\a followed by eof `(read-line stream)` return `(values "a" t)`
