### PR TITLE
bytecode FASLs: open file later

### DIFF
--- a/src/lisp/kernel/cmp/cmpltv.lisp
+++ b/src/lisp/kernel/cmp/cmpltv.lisp
@@ -1604,27 +1604,28 @@
                                 &key (environment
                                       (cmp:make-null-lexical-environment))
                                 &allow-other-keys)
-  (cmp:with-atomic-file-rename (temp-output-path output-path)
-    (with-open-file (output temp-output-path
-                            :direction :output
-                            :if-does-not-exist :create
-                            :element-type '(unsigned-byte 8))
-      (with-constants ()
-        ;; Read and compile the forms.
-        (loop with eof = (gensym "EOF")
-              with *compile-time-too* = nil
-              with eclector.reader:*client* = (make-instance 'eclector.readtable::clasp-tracking-elector-client)
-              with cfsdp = (core:file-scope cmp::*compile-file-source-debug-pathname*)
-              with cfsdl = cmp::*compile-file-source-debug-lineno*
-              with cfsdo = cmp::*compile-file-source-debug-offset*
-              for core:*current-source-pos-info*
-                = (core:input-stream-source-pos-info input cfsdp cfsdl cfsdo)
-              for cmp:*source-locations* = (make-hash-table :test #'eq)
-              for form = (eclector.parse-result:read eclector.reader:*client* input nil eof)
-              until (eq form eof)
-              do (when *compile-print*
-                   (cmp::describe-form form))
-                 (bytecode-compile-toplevel form environment))
-        ;; Write out the FASL bytecode.
+  (with-constants ()
+    ;; Read and compile the forms.
+    (loop with eof = (gensym "EOF")
+          with *compile-time-too* = nil
+          with eclector.reader:*client* = (make-instance 'eclector.readtable::clasp-tracking-elector-client)
+          with cfsdp = (core:file-scope cmp::*compile-file-source-debug-pathname*)
+          with cfsdl = cmp::*compile-file-source-debug-lineno*
+          with cfsdo = cmp::*compile-file-source-debug-offset*
+          for core:*current-source-pos-info*
+            = (core:input-stream-source-pos-info input cfsdp cfsdl cfsdo)
+          for cmp:*source-locations* = (make-hash-table :test #'eq)
+          for form = (eclector.parse-result:read eclector.reader:*client* input nil eof)
+          until (eq form eof)
+          do (when *compile-print*
+               (cmp::describe-form form))
+             (bytecode-compile-toplevel form environment))
+    ;; Write out the FASL bytecode.
+    (cmp:with-atomic-file-rename (temp-output-path output-path)
+      (with-open-file (output temp-output-path
+                              :direction :output
+                              :if-does-not-exist :create
+                              :element-type '(unsigned-byte 8))
+
         (%write-bytecode output))))
   (truename output-path))


### PR DESCRIPTION
our with-open-file/close do not totally abort new files, so if there's an error in the with-open-file body, you end up with an empty file. This is kind of unfortunate for FASLs. We should fix close, but in the meantime, we can just have the file compiler delay opening the file. This should avoid an empty FASL being produced in most cases, but it could still happen if there's some error during %write-bytecode - which I think would have to be an internal error/bug.