### PR TITLE
bytecode autocompile

### DIFF
--- a/include/clasp/core/bytecode_compiler.h
+++ b/include/clasp/core/bytecode_compiler.h
@@ -1022,13 +1022,15 @@ public:
 public:
   // Convenience method to link the module and return the new bytecode function
   // corresponding to this cfunction. Good for cl:compile.
-  CL_DEFMETHOD GlobalBytecodeSimpleFun_sp link_function(T_sp compile_info);
+  CL_DEFMETHOD Function_sp link_function(T_sp compile_info);
 };
 
 // Main entry point
-GlobalBytecodeSimpleFun_sp bytecompile(T_sp, Lexenv_sp);
+Function_sp bytecompile(T_sp, Lexenv_sp);
 // main entry point for using the evaluator
 T_mv cmp__bytecode_implicit_compile_form(T_sp, T_sp);
 T_mv bytecode_toplevel_eval(T_sp, T_sp);
+// Used in loader
+bool btb_bcfun_p(GlobalBytecodeSimpleFun_sp, SimpleVector_sp);
 
 }; // namespace comp

--- a/include/clasp/core/function.h
+++ b/include/clasp/core/function.h
@@ -360,8 +360,7 @@ public:
   CL_DEFMETHOD Fixnum callCount() const {
     return this->_CallCount.load(std::memory_order_relaxed);
   }
-private:
-  inline void count_call() {
+  inline void countCall() {
     // We use this instead of ++ to get a weak memory ordering.
     this->_CallCount.fetch_add(1, std::memory_order_relaxed);
   }

--- a/include/clasp/core/function.h
+++ b/include/clasp/core/function.h
@@ -156,14 +156,14 @@ public:
   //  virtual void set_fdesc(FunctionDescription_sp address) { this->_FunctionDescription.store(address); };
 
   CL_DEFMETHOD SimpleFun_sp entryPoint() const {
-    SimpleFun_sp ep = this->_TheSimpleFun.load();
+    SimpleFun_sp ep = this->_TheSimpleFun.load(std::memory_order_relaxed);
     ASSERT(ep.generalp());
     return ep;
   }
 
   CL_DEFMETHOD void setSimpleFun(SimpleFun_sp ep) {
     ASSERT(ep.generalp());
-    return this->_TheSimpleFun.store(ep);
+    return this->_TheSimpleFun.store(ep, std::memory_order_relaxed);
   }
 
   CL_LISPIFY_NAME("core:functionName");

--- a/include/clasp/gctools/gc_boot.h
+++ b/include/clasp/gctools/gc_boot.h
@@ -59,6 +59,7 @@ enum Data_types {
     ctype_size_t,
     ctype_opaque_ptr,
     CXX_FIXUP_OFFSET,
+    ATOMIC_POD_OFFSET_unsigned_short,
     ATOMIC_POD_OFFSET_unsigned_long,
     ATOMIC_POD_OFFSET_mp__ProcessPhase,
     ATOMIC_POD_OFFSET_unsigned_int,

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -562,6 +562,9 @@
 {fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
              :offset-base-ctype "core::GlobalBytecodeSimpleFun_O"
              :layout-offset-field-names ("_Trampoline")}
+{fixed-field :offset-type-cxx-identifier "ATOMIC_POD_OFFSET_unsigned_short"
+             :offset-ctype "unsigned short" :offset-base-ctype "core::GlobalBytecodeSimpleFun_O"
+             :layout-offset-field-names ("_CallCount")}
 {class-kind :stamp-name "STAMPWTAG_core__LocalSimpleFun_O" :stamp-key "core::LocalSimpleFun_O"
             :parent-class "core::CodeSimpleFun_O" :lisp-class-base "core::CodeSimpleFun_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -1346,7 +1346,8 @@ gctools::return_type bytecode_call(unsigned char *pc, core::T_O *lcc_closure, si
   closure->setSimpleFun(entry->entryPoint());
   // Proceed with the bytecode call.
   core::GlobalBytecodeSimpleFun_sp entryPoint = gctools::As_assert<core::GlobalBytecodeSimpleFun_sp>(entry);
-  DBG_printf("%s:%d:%s This is where we evaluate bytecode functions pc: %p\n", __FILE__, __LINE__, __FUNCTION__, pc);
+  entryPoint->countCall();
+  DBG_printf("%s:%d:%s This is where we evaluate bytecode functions pc: %p\n", __FILE__, __LINE__, __FUNCTION__, pc );
   size_t nlocals = entryPoint->_LocalsFrameSize;
   core::BytecodeModule_sp module = gc::As_assert<core::BytecodeModule_sp>(entryPoint->_Code);
   core::T_O **literals = (core::T_O **)&gc::As_assert<core::SimpleVector_sp>(module->_Literals)->_Data[0];

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -1339,6 +1339,12 @@ gctools::return_type bytecode_call(unsigned char *pc, core::T_O *lcc_closure, si
   core::Closure_O *closure = gctools::untag_general<core::Closure_O *>((core::Closure_O *)lcc_closure);
   ASSERT(gc::IsA<core::GlobalBytecodeSimpleFun_sp>(closure->entryPoint()));
   auto entry = closure->entryPoint();
+  // Set the closure's simple fun to be its simple fun's simple fun.
+  // This is so that if a bytecode's simple fun has been replaced with
+  // a native compiled version, that native simple fun will be used
+  // for subsequent calls.
+  closure->setSimpleFun(entry->entryPoint());
+  // Proceed with the bytecode call.
   core::GlobalBytecodeSimpleFun_sp entryPoint = gctools::As_assert<core::GlobalBytecodeSimpleFun_sp>(entry);
   DBG_printf("%s:%d:%s This is where we evaluate bytecode functions pc: %p\n", __FILE__, __LINE__, __FUNCTION__, pc);
   size_t nlocals = entryPoint->_LocalsFrameSize;

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -1335,18 +1335,28 @@ void VMFrameDynEnv_O::proceed() {
 }; // namespace core
 
 extern "C" {
+
+#define BYTECODE_COMPILE_THRESHOLD 65535
+
 gctools::return_type bytecode_call(unsigned char *pc, core::T_O *lcc_closure, size_t lcc_nargs, core::T_O **lcc_args) {
   core::Closure_O *closure = gctools::untag_general<core::Closure_O *>((core::Closure_O *)lcc_closure);
   ASSERT(gc::IsA<core::GlobalBytecodeSimpleFun_sp>(closure->entryPoint()));
   auto entry = closure->entryPoint();
+  core::GlobalBytecodeSimpleFun_sp entryPoint = gctools::As_assert<core::GlobalBytecodeSimpleFun_sp>(entry);
+  // Maybe compile this function, if it's been called a lot.
+  entryPoint->countCall();
+  if (entryPoint->callCount() >= BYTECODE_COMPILE_THRESHOLD
+      && comp::_sym_STARautocompile_hookSTAR->boundP()
+      && comp::_sym_STARautocompile_hookSTAR->symbolValue().notnilp()) {
+    core::T_sp nat = core::eval::funcall(comp::_sym_STARautocompile_hookSTAR->symbolValue(), entry, nil<core::T_O>());
+    entryPoint->setSimpleFun(gc::As_assert<core::SimpleFun_sp>(nat));
+  }
   // Set the closure's simple fun to be its simple fun's simple fun.
   // This is so that if a bytecode's simple fun has been replaced with
   // a native compiled version, that native simple fun will be used
   // for subsequent calls.
   closure->setSimpleFun(entry->entryPoint());
   // Proceed with the bytecode call.
-  core::GlobalBytecodeSimpleFun_sp entryPoint = gctools::As_assert<core::GlobalBytecodeSimpleFun_sp>(entry);
-  entryPoint->countCall();
   DBG_printf("%s:%d:%s This is where we evaluate bytecode functions pc: %p\n", __FILE__, __LINE__, __FUNCTION__, pc );
   size_t nlocals = entryPoint->_LocalsFrameSize;
   core::BytecodeModule_sp module = gc::As_assert<core::BytecodeModule_sp>(entryPoint->_Code);

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -1078,10 +1078,44 @@ SimpleVector_byte8_t_sp Module_O::create_bytecode() {
 
 CL_DEFUN T_sp lambda_list_for_name(T_sp raw_lambda_list) { return core::lambda_list_for_name(raw_lambda_list); }
 
-GlobalBytecodeSimpleFun_sp Cfunction_O::link_function(T_sp compile_info) {
+Function_sp Cfunction_O::link_function(T_sp compile_info) {
   this->module()->link_load(compile_info);
   // Linking installed the GBEP in this cfunction's info. Return that.
   return this->info();
+}
+
+// Should we BTB compile this new bytecode function?
+// We say yes if there's a (speed 3) declaration anywhere in it.
+bool btb_bcfun_p(GlobalBytecodeSimpleFun_sp fun,
+                 SimpleVector_sp debug_info) {
+  size_t start = fun->entryPcN();
+  size_t end = start + fun->bytecodeSize();
+  for (size_t i = 0; i < debug_info->length(); ++i) {
+    T_sp tinfo = (*debug_info)[i];
+    if (gc::IsA<BytecodeDebugDecls_sp>(tinfo)) {
+      BytecodeDebugDecls_sp info = gc::As_unsafe<BytecodeDebugDecls_sp>(tinfo);
+      size_t infostart = info->start().unsafe_fixnum();
+      size_t infoend = info->start().unsafe_fixnum();
+      if (infostart > end) return false; // overshot.
+      if (infostart < start || infoend > end) continue;
+      // Look for an optimize speed 3.
+      for (auto cur : info->decls()) {
+        T_sp decl = oCar(cur);
+        if (gc::IsA<Cons_sp>(decl) && oCar(decl) == cl::_sym_optimize)
+          for (auto copt : gc::As<List_sp>(oCdr(decl))) {
+            T_sp opt = oCar(copt);
+            if (opt == cl::_sym_speed
+                || (gc::IsA<Cons_sp>(opt)
+                    && oCar(opt) == cl::_sym_speed
+                    && gc::IsA<Cons_sp>(oCdr(opt))
+                    && gc::IsA<Fixnum_sp>(oCadr(opt))
+                    && oCadr(opt).unsafe_fixnum() == 3))
+              return true;
+          }
+      }
+    }
+  }
+  return false;
 }
 
 void Module_O::link() {
@@ -1157,6 +1191,21 @@ void Module_O::link_load(T_sp compile_info) {
   bytecode_module->setf_bytecode(bytecode);
   bytecode_module->setf_debugInfo(debug_info);
   bytecode_module->setf_compileInfo(compile_info);
+  // Native-compile anything that really seems like it should be,
+  // and install the resulting simple funs.
+  // We can only do native compilations after the module is
+  // fully realized above.
+  if (core::_sym_STARbytecode_autocompileSTAR->symbolValue().notnilp()
+      && cl::_sym_compile->fboundp()) {
+    for (T_sp tfun : *cfunctions) {
+      Cfunction_sp cfun = gc::As_assert<Cfunction_sp>(tfun);
+      GlobalBytecodeSimpleFun_sp fun = cfun->info();
+      if (btb_bcfun_p(fun, debug_info)) {
+        T_sp nat = eval::funcall(cl::_sym_compile, nil<T_O>(), fun);
+        fun->setSimpleFun(gc::As_assert<SimpleFun_sp>(nat));
+      }
+    }
+  }
 }
 
 void compile_literal(T_sp literal, Lexenv_sp env, const Context context) {
@@ -2348,7 +2397,7 @@ static T_sp symbol_macrolet_bindings(Lexenv_sp menv, List_sp bindings, T_sp vars
     T_sp lexpr = Cons_O::createList(cl::_sym_lambda, Cons_O::createList(formv, envv),
                                     Cons_O::createList(cl::_sym_declare, Cons_O::createList(cl::_sym_ignore, formv, envv)),
                                     Cons_O::createList(cl::_sym_quote, expansion));
-    GlobalBytecodeSimpleFun_sp expander = bytecompile(lexpr, menv);
+    Function_sp expander = bytecompile(lexpr, menv);
     SymbolMacroVarInfo_sp info = SymbolMacroVarInfo_O::make(expander);
     vars = Cons_O::create(Cons_O::create(name, info), vars);
   }
@@ -2369,7 +2418,7 @@ static List_sp macrolet_bindings(Lexenv_sp menv, List_sp bindings, List_sp funs)
     T_sp lambda_list = oCadr(binding);
     T_sp body = oCddr(binding);
     T_sp eform = eval::funcall(ext::_sym_parse_macro, name, lambda_list, body, menv);
-    GlobalBytecodeSimpleFun_sp expander = bytecompile(eform, menv);
+    Function_sp expander = bytecompile(eform, menv);
     LocalMacroInfo_sp info = LocalMacroInfo_O::make(expander);
     funs = Cons_O::create(Cons_O::create(name, info), funs);
   }
@@ -2568,7 +2617,7 @@ CL_DEFUN Cfunction_sp bytecompile_into(Module_sp module, T_sp lambda_expression,
 }
 
 CL_LAMBDA(lambda-expression &optional (env (cmp::make-null-lexical-environment)));
-CL_DEFUN GlobalBytecodeSimpleFun_sp bytecompile(T_sp lambda_expression, Lexenv_sp env) {
+CL_DEFUN Function_sp bytecompile(T_sp lambda_expression, Lexenv_sp env) {
   Module_sp module = Module_O::make();
   Cfunction_sp cf = bytecompile_into(module, lambda_expression, env);
   return cf->link_function(Cons_O::create(lambda_expression, env));

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -1195,13 +1195,13 @@ void Module_O::link_load(T_sp compile_info) {
   // and install the resulting simple funs.
   // We can only do native compilations after the module is
   // fully realized above.
-  if (core::_sym_STARbytecode_autocompileSTAR->symbolValue().notnilp()
-      && cl::_sym_compile->fboundp()) {
+  if (_sym_STARautocompile_hookSTAR->boundP()
+      && _sym_STARautocompile_hookSTAR->symbolValue().notnilp()) {
     for (T_sp tfun : *cfunctions) {
       Cfunction_sp cfun = gc::As_assert<Cfunction_sp>(tfun);
       GlobalBytecodeSimpleFun_sp fun = cfun->info();
       if (btb_bcfun_p(fun, debug_info)) {
-        T_sp nat = eval::funcall(cl::_sym_compile, nil<T_O>(), fun);
+        T_sp nat = eval::funcall(_sym_STARautocompile_hookSTAR->symbolValue(), fun, nil<T_O>());
         fun->setSimpleFun(gc::As_assert<SimpleFun_sp>(nat));
       }
     }

--- a/src/core/compPackage.cc
+++ b/src/core/compPackage.cc
@@ -45,6 +45,8 @@ SYMBOL_EXPORT_SC_(CompPkg, STARsaved_module_from_clasp_jitSTAR);
 SYMBOL_EXPORT_SC_(CompPkg, STARcodeWalkerSTAR);
 SYMBOL_EXPORT_SC_(CompPkg, STARsourceLocationsSTAR);
 SYMBOL_EXPORT_SC_(CompPkg, STARoptimizeSTAR);
+SYMBOL_EXPORT_SC_(CompPkg, STARbtb_compile_hookSTAR);
+SYMBOL_EXPORT_SC_(CompPkg, STARautocompile_hookSTAR);
 SYMBOL_EXPORT_SC_(CompPkg, optimize_module_for_compile);
 SYMBOL_EXPORT_SC_(CompPkg, compile_quick_module_dump);
 void initialize_compPackage() {

--- a/src/core/compiler.cc
+++ b/src/core/compiler.cc
@@ -1663,6 +1663,8 @@ void initialize_compiler_primitives(LispPtr lisp) {
   cleavirPrimop::_sym_callWithVariableBound->setf_symbolFunction(_sym_callWithVariableBound->symbolFunction());
   comp::_sym_STARcodeWalkerSTAR->defparameter(nil<T_O>());
   comp::_sym_STARsourceLocationsSTAR->makeSpecial();
+  comp::_sym_STARbtb_compile_hookSTAR->defparameter(nil<T_O>());
+  comp::_sym_STARautocompile_hookSTAR->defparameter(nil<T_O>());
   {
     Fixnum_sp one = clasp_make_fixnum(1);
     comp::_sym_STARoptimizeSTAR->defparameter(

--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -139,7 +139,6 @@ SYMBOL_EXPORT_SC_(CorePkg, STARuseParallelBuildSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARuseBuildForkRedirectSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARreader_generate_cstSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARreader_cst_resultSTAR);
-SYMBOL_EXPORT_SC_(CorePkg, STARbytecode_autocompileSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, arguments);
 SYMBOL_EXPORT_SC_(CorePkg, STARdebug_valuesSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARdebug_accessorsSTAR);
@@ -1081,7 +1080,6 @@ void CoreExposer_O::define_essential_globals(LispPtr lisp) {
   cl::_sym_arrayDimensionLimit->defconstant(make_fixnum(MOST_POSITIVE_FIXNUM));
   cl::_sym_arrayTotalSizeLimit->defconstant(make_fixnum(MOST_POSITIVE_FIXNUM));
   core::_sym_STARpollTicksPerGcSTAR->defparameter(make_fixnum(POLL_TICKS_PER_GC));
-  core::_sym_STARbytecode_autocompileSTAR->defparameter(nil<T_O>());
   comp::_sym_STARlowLevelTraceSTAR->defparameter(nil<T_O>());
   comp::_sym_STARlowLevelTracePrintSTAR->defparameter(nil<T_O>());
   comp::_sym_STARsave_module_for_disassembleSTAR->defparameter(nil<core::T_O>());

--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -139,6 +139,7 @@ SYMBOL_EXPORT_SC_(CorePkg, STARuseParallelBuildSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARuseBuildForkRedirectSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARreader_generate_cstSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARreader_cst_resultSTAR);
+SYMBOL_EXPORT_SC_(CorePkg, STARbytecode_autocompileSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, arguments);
 SYMBOL_EXPORT_SC_(CorePkg, STARdebug_valuesSTAR);
 SYMBOL_EXPORT_SC_(CorePkg, STARdebug_accessorsSTAR);
@@ -1080,6 +1081,7 @@ void CoreExposer_O::define_essential_globals(LispPtr lisp) {
   cl::_sym_arrayDimensionLimit->defconstant(make_fixnum(MOST_POSITIVE_FIXNUM));
   cl::_sym_arrayTotalSizeLimit->defconstant(make_fixnum(MOST_POSITIVE_FIXNUM));
   core::_sym_STARpollTicksPerGcSTAR->defparameter(make_fixnum(POLL_TICKS_PER_GC));
+  core::_sym_STARbytecode_autocompileSTAR->defparameter(nil<T_O>());
   comp::_sym_STARlowLevelTraceSTAR->defparameter(nil<T_O>());
   comp::_sym_STARlowLevelTracePrintSTAR->defparameter(nil<T_O>());
   comp::_sym_STARsave_module_for_disassembleSTAR->defparameter(nil<core::T_O>());

--- a/src/core/loadltv.cc
+++ b/src/core/loadltv.cc
@@ -18,6 +18,8 @@
 #include <clasp/core/pathname.h>      // making pathnames
 #include <clasp/core/unixfsys.h>      // cl__truename
 #include <clasp/llvmo/llvmoPackage.h> // cmp__compile_trampoline
+#include <clasp/core/bytecode_compiler.h> // btb_bcfun_p
+#include <clasp/core/evaluator.h>     // eval::funcall
 
 // FIXME: Move these to the generated file thingie
 #define LTV_OP_NIL 65
@@ -583,6 +585,12 @@ struct loadltv {
     FunctionDescription_sp fdesc = makeFunctionDescription(name, lambda_list, docstring, nil<T_O>(), nil<T_O>(), -1, -1, -1);
     GlobalBytecodeSimpleFun_sp fun = core__makeGlobalBytecodeSimpleFun(fdesc, module, nlocals, nclosed, entry_point, final_size,
                                                                        llvmo::cmp__compile_trampoline(name));
+    if (core::_sym_STARbytecode_autocompileSTAR->symbolValue().notnilp()
+        && cl::_sym_compile->fboundp()
+        && comp::btb_bcfun_p(fun, gc::As<SimpleVector_sp>(module->debugInfo()))) {
+      T_sp nfun = eval::funcall(cl::_sym_compile, nil<T_O>(), fun);
+      fun->setSimpleFun(gc::As<SimpleFun_sp>(nfun));
+    }
     set_ltv(fun, index);
   }
 

--- a/src/core/loadltv.cc
+++ b/src/core/loadltv.cc
@@ -585,10 +585,14 @@ struct loadltv {
     FunctionDescription_sp fdesc = makeFunctionDescription(name, lambda_list, docstring, nil<T_O>(), nil<T_O>(), -1, -1, -1);
     GlobalBytecodeSimpleFun_sp fun = core__makeGlobalBytecodeSimpleFun(fdesc, module, nlocals, nclosed, entry_point, final_size,
                                                                        llvmo::cmp__compile_trampoline(name));
-    if (core::_sym_STARbytecode_autocompileSTAR->symbolValue().notnilp()
-        && cl::_sym_compile->fboundp()
-        && comp::btb_bcfun_p(fun, gc::As<SimpleVector_sp>(module->debugInfo()))) {
-      T_sp nfun = eval::funcall(cl::_sym_compile, nil<T_O>(), fun);
+    if (comp::_sym_STARautocompile_hookSTAR->boundP()
+        && comp::_sym_STARautocompile_hookSTAR->symbolValue().notnilp()
+        // Not sure exactly how it happens that we get here with
+        // an unfinished module. From the bcfuns in the debug info,
+        // maybe? Maybe.
+        && gc::IsA<SimpleVector_sp>(module->debugInfo())
+        && comp::btb_bcfun_p(fun, gc::As_unsafe<SimpleVector_sp>(module->debugInfo()))) {
+      T_sp nfun = eval::funcall(comp::_sym_STARautocompile_hookSTAR->symbolValue(), fun, nil<T_O>());
       fun->setSimpleFun(gc::As<SimpleFun_sp>(nfun));
     }
     set_ltv(fun, index);

--- a/src/core/symbol.cc
+++ b/src/core/symbol.cc
@@ -346,7 +346,7 @@ FunctionCell_sp Symbol_O::ensureFunctionCell(Function_sp init) {
 FunctionCell_sp Symbol_O::ensureSetfFunctionCell() {
   FunctionCell_sp existing = setfFunctionCell();
   if (existing.unboundp()) {
-    FunctionCell_sp n = FunctionCell_O::make(this->asSmartPtr());
+    FunctionCell_sp n = FunctionCell_O::make(Cons_O::createList(cl::_sym_setf, this->asSmartPtr()));
     if (this->_SetfFunction.compare_exchange_strong(existing, n, std::memory_order_relaxed))
       return n;
     else
@@ -358,7 +358,7 @@ FunctionCell_sp Symbol_O::ensureSetfFunctionCell() {
 FunctionCell_sp Symbol_O::ensureSetfFunctionCell(Function_sp init) {
   FunctionCell_sp existing = setfFunctionCell();
   if (existing.unboundp()) {
-    FunctionCell_sp n = FunctionCell_O::make(this->asSmartPtr(), init);
+    FunctionCell_sp n = FunctionCell_O::make(Cons_O::createList(cl::_sym_setf, this->asSmartPtr()), init);
     if (this->_SetfFunction.compare_exchange_strong(existing, n, std::memory_order_relaxed))
       return n;
     else

--- a/src/gctools/gc_boot.cc
+++ b/src/gctools/gc_boot.cc
@@ -80,6 +80,7 @@ void dump_data_types(std::ostream& fout, const std::string& indent)
   DTNAME(ctype_opaque_ptr,"opaque_ptr",sizeof(void*));
 
   DTNAME(CXX_FIXUP_OFFSET,"CXX_FIXUP_OFFSET",sizeof(unsigned long));
+  DTNAME(ATOMIC_POD_OFFSET_unsigned_short,"ATOMIC_POD_OFFSET_unsigned_short",sizeof(unsigned short));
   DTNAME(ATOMIC_POD_OFFSET_unsigned_long,"ATOMIC_POD_OFFSET_unsigned_long",sizeof(unsigned long));
   DTNAME(ATOMIC_POD_OFFSET_mp__ProcessPhase,"ATOMIC_POD_OFFSET_mp__ProcessPhase",sizeof(mp::ProcessPhase));
   DTNAME(ATOMIC_POD_OFFSET_unsigned_int,"ATOMIC_POD_OFFSET_unsigned_int",sizeof(unsigned int));

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -22,26 +22,6 @@
         (replace name string :start1 index)
         (incf index (length string))))))
 
-(defun bind-lambda-list-arguments (lambda-list function)
-  (flet ((argument (symbol)
-           (make-instance 'bir:argument
-             :name symbol :function function)))
-    (multiple-value-bind (required optional rest keyp keys aokp aux varestp)
-        (core:process-lambda-list lambda-list 'cl:function)
-      (declare (ignore aux))
-      (nconc (mapcar #'argument (cdr required))
-             (unless (zerop (car optional)) (list '&optional))
-             (loop for (var default -p) on (cdr optional)
-                   by #'cdddr
-                   collect (list (argument var) (argument -p)))
-             (when rest
-               (list (if varestp 'core:&va-rest '&rest) (argument rest)))
-             (when keyp (list '&key))
-             (loop for (key var default -p) on (cdr keys)
-                   by #'cddddr
-                   collect (list key (argument var) (argument -p)))
-             (when aokp (list '&allow-other-keys))))))
-
 (defun function-spi (function)
   (multiple-value-bind (path filepos lineno column)
       (core:function-source-pos function)
@@ -56,6 +36,7 @@
          (function (make-instance 'bir:function
                      :returni nil ; set by :return compilation
                      :name (core:function-name bytecode-function)
+                     :lambda-list nil
                      :docstring (core:function-docstring bytecode-function)
                      :original-lambda-list lambda-list
                      :origin (function-spi bytecode-function)
@@ -63,8 +44,6 @@
                      :attributes nil
                      :module module)))
     (set:nadjoinf (bir:functions module) function)
-    (setf (bir:lambda-list function)
-          (bind-lambda-list-arguments lambda-list function))
     function))
 
 (defun next-arg (argspec bytecode opip ip nbytes)
@@ -171,43 +150,12 @@
     :successors (bt:block-entry-successors block)
     :dynamic-environment (context-dynamic-environment context)))
 
-(defun install-ll-vars (locals lambda-list annots)
-  (multiple-value-bind (required optional rest keyp keys)
-      (core:process-lambda-list lambda-list 'cl:function)
-    (declare (ignore keyp))
-    (let ((index 0))
-      ;; The bytecode compiler sets out the indices as follows:
-      ;; 1) required variables
-      ;; 2) optional
-      ;; 3) key
-      ;; 4) optional -p
-      ;; 5) rest
-      ;; 6) key -p
-      (flet ((newvar (name)
-               (setf (aref locals index)
-                     (cons (make-instance 'bir:variable
-                             :name name
-                             :ignore (variable-ignore name annots))
-                           nil))
-               (incf index)))
-        (mapc #'newvar (rest required))
-        (loop for (opt) on (rest optional) by #'cdddr
-              do (newvar opt))
-        (loop for (key kvar) on (rest keys) by #'cddddr
-              do (newvar kvar))
-        (loop for (_ _1 -p) on (rest optional) by #'cdddr
-              when -p do (incf index)) ; -p variables are bound by SET.
-        (when rest (incf index)) ; since we bind &rest vars with SET, no var needed here.
-        (loop for (_ _1 _2 -p) on (rest keys) by #'cddddr
-              when -p do (incf index))))))
-
 (defun make-context (function block annots)
   (let* ((bcfun (bt:function-entry-bcfun function))
          (irfun (bt:function-entry-extra function))
          (nlocals (bcfun/locals-size bcfun))
          (locals (make-array nlocals))
          (successors (bt:block-entry-successors block)))
-    (install-ll-vars locals (core:function-lambda-list bcfun) annots)
     (%make-context locals successors irfun)))
 
 ;;; Alist of IR functions to sequences of variables they close over,
@@ -370,7 +318,8 @@
                                (setf ctype (ctype:conjoin sys ctype ct))))))
                         ;; FIXME: Hardcoded. Bad
                         ((dynamic-extent ftype ignorable ignore inline
-                                         notinline optimize special))
+                                         notinline optimize special
+                                         core:lambda-name core:lambda-list))
                         (otherwise ; assume a type
                          (when (member varname rest)
                            (let ((ct (cleavir-env:parse-type-specifier
@@ -717,72 +666,93 @@
 (defmethod compile-instruction ((mnemonic (eql :bind-required-args))
                                 inserter annots context &rest args)
   (destructuring-bind (nreq) args
-    (let* ((iblock (ast-to-bir::iblock inserter))
-           (ifun (bir:function iblock))
-           (ll (bir:lambda-list ifun))
-           (args (subseq ll 0 nreq)))
+    (let* ((varannot
+             (find-if (lambda (a) (typep a 'core:bytecode-debug-vars))
+                      annots))
+           (bindings
+             (and varannot (core:bytecode-debug-vars/bindings varannot)))
+           (iblock (ast-to-bir::iblock inserter))
+           (ifun (bir:function iblock)))
+      (assert (= (length bindings) nreq))
       (loop with locals = (context-locals context)
             for i from 0
-            for arg in args
-            for (var . cellp) = (aref locals i)
-            do (bind-variable var arg inserter annots)))))
+            for (name . index) in bindings
+            for cellp = (consp index)
+            for rindex = (if cellp (car index) index)
+            for arg = (make-instance 'bir:argument
+                        :name name :function ifun)
+            for var = (make-instance 'bir:variable
+                        :name name :ignore nil)
+            do (assert (= i rindex))
+               (setf (aref locals i) (cons var cellp))
+               (bind-variable var arg inserter annots)
+            collect arg into args
+            finally (setf (bir:lambda-list ifun) args)))))
 
 (defmethod compile-instruction ((mnemonic (eql :bind-optional-args))
                                 inserter annots context &rest args)
   (destructuring-bind (start nopt) args
     (let* ((iblock (ast-to-bir::iblock inserter))
            (ifun (bir:function iblock))
-           (ll (bir:lambda-list ifun))
-           (args (subseq (cdr (member '&optional ll)) 0 nopt)))
+           (ll (bir:lambda-list ifun)))
       (loop with locals = (context-locals context)
+            repeat nopt
             for i from start
-            for (arg -p) in args
-            for (var . cellp) = (aref locals i)
+            for arg = (make-instance 'bir:argument :function ifun)
+            for -p = (make-instance 'bir:argument :function ifun)
+            for var = (make-instance 'bir:variable :ignore nil)
             ;; We use %bind rather than bind because we don't want
             ;; to assert the type of a possibly unprovided argument.
-            do (%bind-variable var arg inserter)))))
+            do (setf (aref locals i) (cons var nil))
+               (%bind-variable var arg inserter)
+            collect (list arg -p) into ll-app
+            finally (setf (bir:lambda-list ifun)
+                          (append ll '(&optional) ll-app))))))
 
 ;;; FIXME: Why does this instruction not put it immediately into a var
 (defmethod compile-instruction ((mnemonic (eql :listify-rest-args))
                                 inserter annot context &rest args)
   (declare (ignore annot))
   (destructuring-bind (start) args
-    (declare (ignore start))
     (let* ((iblock (ast-to-bir::iblock inserter))
            (ifun (bir:function iblock))
            (ll (bir:lambda-list ifun))
-           (rarg (second (member '&rest ll))))
-      (check-type rarg bir:argument)
+           (rarg (make-instance 'bir:argument :function ifun)))
+      (setf (bir:lambda-list ifun) (append ll `(&rest ,rarg)))
       (stack-push rarg context))))
 (defmethod compile-instruction ((mnemonic (eql :vaslistify-rest-args))
                                 inserter annot context &rest args)
   (declare (ignore annot))
   (destructuring-bind (start) args
-    (declare (ignore start))
     (let* ((iblock (ast-to-bir::iblock inserter))
            (ifun (bir:function iblock))
            (ll (bir:lambda-list ifun))
-           (rarg (second (member 'core:&va-rest ll))))
-      (check-type rarg bir:argument)
+           (rarg (make-instance 'bir:argument :function ifun)))
+      (setf (bir:lambda-list ifun) (append ll `(core:&va-rest ,rarg)))
       (stack-push rarg context))))
 
 (defmethod compile-instruction ((mnemonic (eql :parse-key-args))
                                 inserter annots context &rest args)
-  (destructuring-bind (start key-count-info key-start frame-start) args
-    (declare (ignore start key-count-info key-start))
+  (destructuring-bind (start (key-count . aokp) keys frame-start) args
+    (declare (ignore key-count))
     (let* ((iblock (ast-to-bir::iblock inserter))
            (ifun (bir:function iblock))
-           (ll (bir:lambda-list ifun))
-           (args (ldiff (cdr (member '&key ll)) (member '&allow-other-keys ll))))
+           (ll (bir:lambda-list ifun)))
       (loop with locals = (context-locals context)
             for i from frame-start
-            for spec in args
-            for (var . cellp) = (aref locals i)
-            while (consp spec)
-            do (destructuring-bind (key arg -p) spec
-                 (declare (ignore key -p))
-                 ;; %bind to avoid asserting type of unprovided arg
-                 (%bind-variable var arg inserter))))))
+            for key in keys
+            for arg = (make-instance 'bir:argument :function ifun)
+            for -p = (make-instance 'bir:argument :function ifun)
+            for var = (make-instance 'bir:variable :name key :ignore nil)
+            do (setf (aref locals i) (cons var nil))
+               ;; %bind to avoid asserting type of unprovided arg
+               (%bind-variable var arg inserter)
+            collect (list key arg -p) into ll-app
+            finally (setf (bir:lambda-list ifun)
+                          (append ll `(&key ,@ll-app)
+                                  (if aokp
+                                      '(&allow-other-keys)
+                                      ())))))))
 
 (defun compile-jump (inserter context destination)
   (declare (ignore context))
@@ -1375,6 +1345,17 @@
                    value)
                   ((:operand) value))))
 
+(defun compute-pka-args (args literals)
+  (let ((more-args (cdr (first args)))
+        (key-count-info (cdr (second args)))
+        (key-literals-start (cdr (third args)))
+        (key-frame-start (cdr (fourth args))))
+    (list more-args key-count-info
+          (loop for i from key-literals-start
+                repeat (car key-count-info)
+                collect (aref literals i))
+          key-frame-start)))
+
 (defun compile-bytecode (bytecode literals function-entries
                          block-entries annotations)
   (let* ((all-function-entries function-entries)
@@ -1414,9 +1395,11 @@
             (bir:*policy*
               (cleavir-policy:compute-policy
                (compute-optimize *active-annotations*)
-               clasp-cleavir:*clasp-env*)))
-        (apply #'compile-instruction mnemonic inserter annots context
-               (compute-args args literals all-block-entries))
+               clasp-cleavir:*clasp-env*))
+            (args (if (eq mnemonic :parse-key-args)
+                      (compute-pka-args args literals)
+                      (compute-args args literals all-block-entries))))
+        (apply #'compile-instruction mnemonic inserter annots context args)
         (maybe-compile-the annots inserter context)
         ;; Update current block and function if required.
         (when (and block-entries

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -679,10 +679,11 @@
             for (name . index) in bindings
             for cellp = (consp index)
             for rindex = (if cellp (car index) index)
+            for ignore = (variable-ignore name annots)
             for arg = (make-instance 'bir:argument
                         :name name :function ifun)
             for var = (make-instance 'bir:variable
-                        :name name :ignore nil)
+                        :name name :ignore ignore)
             do (assert (= i rindex))
                (setf (aref locals i) (cons var cellp))
                (bind-variable var arg inserter annots)

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -1473,11 +1473,7 @@
          (bytecode (core:bytecode-module/bytecode bytecode-module))
          (literals (core:bytecode-module/literals bytecode-module))
          (functions (bytecode-module/functions bytecode-module))
-         ;; bit circuitous to work around a bug in compile-file that
-         ;; doesn't maintain identities of module bcfuns in the
-         ;; debug info. FIXME
-         (fpos (position (bcfun/entry function) functions
-                         :key #'bcfun/entry))
+         (fpos (position function functions))
          (annotations
            (core:bytecode-module/debug-info bytecode-module))
          (*closures* nil))

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -1345,8 +1345,11 @@
                      in (core:bytecode-debug-decls/decls annot)
                    when (eq spec 'cl:optimize)
                      do (loop for optim in rest
-                              unless (assoc (car optim) optimize)
-                                do (push optim optimize)))
+                              for roptim = (if (consp optim)
+                                               optim
+                                               `(,optim 3))
+                              unless (assoc (car roptim) optimize)
+                                do (push roptim optimize)))
         finally (return
                   ;; If the declarations don't have enough OPTIMIZE qualities
                   ;; to cover the gamut (arguably they always should), fill

--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -1584,4 +1584,7 @@
 ;;; To be bound to cmp:*btb-compile-hook*.
 (defun compile-hook (definition environment)
   (declare (ignore environment))
-  (compile-function definition))
+  (handler-case (compile-function definition)
+    (error (e)
+      (warn "BUG: Error during BTB compilation: ~a" e)
+      definition)))

--- a/src/lisp/kernel/clos/hierarchy.lisp
+++ b/src/lisp/kernel/clos/hierarchy.lisp
@@ -283,7 +283,7 @@
     '((fast-method-function :initarg :fmf :initform nil
                             :accessor %mf-fast-method-function)
       (contf :initarg :contf :initform nil
-             :reader %mf-contf))))
+             :accessor %mf-contf))))
 
 
 ;;; ----------------------------------------------------------------------

--- a/src/lisp/kernel/cmp/compile.lisp
+++ b/src/lisp/kernel/cmp/compile.lisp
@@ -48,18 +48,17 @@ We could do more fancy things here - like if cleavir-clasp fails, use the clasp 
 
 (export 'builtin-wrapper-form :cmp)
 
-;;; Hook called to compile bytecode functions to native.
-(defvar *btb-compile-hook*)
-
 (defun %compile (definition environment)
   (cond
     ((and (typep definition 'core:global-bytecode-simple-fun)
-          (boundp '*btb-compile-hook*))
+          (boundp '*btb-compile-hook*)
+          *btb-compile-hook*)
      (compile-in-env definition environment *btb-compile-hook*))
     ((and (typep definition 'core:closure)
           (typep (core:function/entry-point definition)
                  'core:global-bytecode-simple-fun)
-          (boundp '*btb-compile-hook*))
+          (boundp '*btb-compile-hook*)
+          *btb-compile-hook*)
      (multiple-value-bind (csfun warn fail)
          (compile-in-env (core:function/entry-point definition)
                          environment *btb-compile-hook*)


### PR DESCRIPTION
experimental and in fact does not seem to work in general. with this PR it becomes available but disabled by default.

Sets it up so that after a bytecode function is called some threshold number of times (hardcoded as 65535 right now) it is native compiled using bytecode-to-bir. This is controlled by the `cmp:*autocompile-hook*` flag, which is `nil` by default. Auto compilation can be enabled by binding this to `clasp-bytecode-to-bir:compile-hook`.