### PR TITLE
Fix error return on gray read-byte

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -24,6 +24,8 @@
 
 ## Fixed
 * `cl:read-line` so it correctly returns lines that end with EOF.
+* `cl:read-byte` so it respects the `eof-error-p` and `eof-value`
+  arguments for Gray streams.
 
 # Version 2.4.0 (LLVM15-17) 2023-10-01
 

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -5661,29 +5661,20 @@ CL_DEFUN T_sp cl__read_byte(T_sp strm, T_sp eof_error_p, T_sp eof_value) {
   // Should signal an error of type error if stream is not a binary input stream.
   if (strm.nilp())
     TYPE_ERROR(strm, cl::_sym_Stream_O);
-  if (!AnsiStreamP(strm)) {
-    // if the return value is :eof, return nil
-    T_sp byte_or_eof = eval::funcall(gray::_sym_stream_read_byte, strm);
-    if (byte_or_eof == kw::_sym_eof)
-      return nil<T_O>();
-    else
-      return byte_or_eof;
-  }
   // as a side effect verifies that strm is really a stream.
   T_sp elt_type = clasp_stream_element_type(strm);
   if (elt_type == cl::_sym_character || elt_type == cl::_sym_base_char)
     SIMPLE_ERROR("Not a binary stream");
+
   T_sp c = clasp_read_byte(strm);
-  if (c.nilp()) {
-    LOG("Hit eof");
-    if (!eof_error_p.isTrue()) {
-      LOG("Returning eof_value[{}]", _rep_(eof_value));
-      return eof_value;
-    }
-    ERROR_END_OF_FILE(strm);
-  }
-  LOG("Read and returning char[{}]", c);
-  return c;
+
+  if (!c.nilp())
+    return c;
+
+  if (eof_error_p.nilp())
+    return eof_value;
+
+  ERROR_END_OF_FILE(strm);
 }
 
 CL_LAMBDA(&optional peek-type strm (eof-errorp t) eof-value recursivep);

--- a/src/lisp/regression-tests/streams01.lisp
+++ b/src/lisp/regression-tests/streams01.lisp
@@ -273,3 +273,37 @@
     (delete-file name)
     buffer)
   ("foo"))
+
+(defclass binary-input-stream (gray:fundamental-binary-input-stream)
+  ((value :reader value
+          :initarg :value)
+   (index :accessor index
+          :initform 0)))
+
+(defmethod gray:stream-element-type ((stream binary-input-stream))
+  '(unsigned-byte 8))
+
+(defmethod gray:stream-read-byte ((stream binary-input-stream))
+  (with-accessors ((value value)
+                   (index index))
+      stream
+    (if (< index (length value))
+        (prog1 (elt value index)
+          (incf index))
+        :eof)))
+
+(test read-byte.01
+  (let ((stream (make-instance 'binary-input-stream :value #())))
+    (read-byte stream nil :wibble))
+  (:wibble))
+
+(test-expect-error read-byte.02
+  (let ((stream (make-instance 'binary-input-stream :value #())))
+    (read-byte stream))
+  :type end-of-file)
+
+(test read-byte.03
+  (let ((stream (make-instance 'binary-input-stream :value #(73))))
+    (values (read-byte stream nil :wibble)
+            (read-byte stream nil :wibble)))
+  (73 :wibble))


### PR DESCRIPTION
Currently `cl:read-byte` ignores `eof-error-p` and `eof-value` arguments for Gray streams. `clasp_read_byte` already handles EOF correctly via the dispatch tables so I just removed the unneeded special code for Gray streams.