### PR TITLE
Misc fixes for Gray streams

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -8,6 +8,8 @@
   code (FASO) while the bytecode compiler is active.
 * Generic `gray:stream-file-length` which implements `cl:file-length`
   for Gray streams.
+* Generic versions of `cl:pathname` and `cl:truename`, both of which
+  are available after the Gray stream modules is required.
 
 ## Changed
 * `cl:format` and `pprint` now respect the value returned bye

--- a/src/core/grayPackage.cc
+++ b/src/core/grayPackage.cc
@@ -62,6 +62,8 @@ SYMBOL_SHADOW_EXPORT_SC_(GrayPkg, streamp);
 SYMBOL_SHADOW_EXPORT_SC_(GrayPkg, input_stream_p);
 SYMBOL_SHADOW_EXPORT_SC_(GrayPkg, output_stream_p);
 SYMBOL_EXPORT_SC_(GrayPkg, stream_interactive_p);
+SYMBOL_SHADOW_EXPORT_SC_(GrayPkg, pathname);
+SYMBOL_SHADOW_EXPORT_SC_(GrayPkg, truename);
 SYMBOL_SHADOW_EXPORT_SC_(GrayPkg, stream_element_type);
 SYMBOL_EXPORT_SC_(GrayPkg, stream_file_length);
 SYMBOL_EXPORT_SC_(GrayPkg, stream_file_position);

--- a/src/core/pathname.cc
+++ b/src/core/pathname.cc
@@ -888,7 +888,7 @@ struct PathnameRecursionGuard {
 };
 
 DOCGROUP(clasp);
-CL_DEFUN Pathname_sp cl__pathname(T_sp x) {
+CL_DEFUN Pathname_sp core__pathnameSTAR(T_sp x) {
   PathnameRecursionGuard guard;
   if (x.nilp()) {
     ERROR_WRONG_TYPE_ONLY_ARG(cl::_sym_pathname, x,
@@ -909,6 +909,13 @@ L:
         Cons_O::createList(cl::_sym_or, cl::_sym_fileStream, cl::_sym_string, cl::_sym_pathname, cl::_sym_SynonymStream_O));
   }
   return gc::As<Pathname_sp>(x);
+}
+
+CL_DOCSTRING(R"dx(Returns the pathname denoted by pathspec. If the gray-streams module has been loaded
+then this function will be made generic.)dx")
+DOCGROUP(clasp);
+CL_DEFUN Pathname_sp cl__pathname(T_sp pathspec) {
+  return core__pathnameSTAR(pathspec);
 }
 
 CL_LAMBDA(x);

--- a/src/core/unixfsys.cc
+++ b/src/core/unixfsys.cc
@@ -879,12 +879,11 @@ CL_DEFUN Pathname_mv core__file_truename(T_sp pathname, T_sp filename, bool foll
  * current directory
  */
 
-CL_LAMBDA(orig-pathname);
+CL_LAMBDA(filespec);
 CL_DECLARE();
-CL_DOCSTRING(R"dx(truename)dx");
 DOCGROUP(clasp);
-CL_DEFUN Pathname_sp cl__truename(T_sp orig_pathname) {
-  Pathname_sp pathname = make_absolute_pathname(orig_pathname);
+CL_DEFUN Pathname_sp core__truenameSTAR(T_sp filespec) {
+  Pathname_sp pathname = make_absolute_pathname(filespec);
   Pathname_sp base_dir = make_base_pathname(pathname);
   Cons_sp dir;
   /* We process the directory part of the filename, removing all
@@ -904,6 +903,15 @@ CL_DEFUN Pathname_sp cl__truename(T_sp orig_pathname) {
 #endif
   Pathname_mv truename = file_truename(pathname, nil<T_O>(), FOLLOW_SYMLINKS);
   return truename;
+}
+
+CL_LAMBDA(filespec);
+CL_DECLARE();
+CL_DOCSTRING(R"dx(truename tries to find the file indicated by filespec and returns its truename.
+If the gray-streams module has been loaded then this function will be made generic.)dx");
+DOCGROUP(clasp);
+CL_DEFUN Pathname_sp cl__truename(T_sp filespec) {
+  return core__truenameSTAR(filespec);
 }
 
 int clasp_backup_open(const char* filename, int option, int mode) {

--- a/src/lisp/kernel/clos/streams.lisp
+++ b/src/lisp/kernel/clos/streams.lisp
@@ -292,7 +292,7 @@
 
 ;; CLEAR-INPUT
 
-(defmethod stream-clear-input ((stream fundamental-character-input-stream))
+(defmethod stream-clear-input ((stream fundamental-input-stream))
   (declare (ignore stream))
   nil)
 
@@ -401,6 +401,9 @@
 
 
 ;; INTERACTIVE-STREAM-P
+
+(defmethod stream-interactive-p ((stream fundamental-input-stream))
+  nil)
 
 (defmethod stream-interactive-p ((stream ansi-stream))
   (cl:interactive-stream-p stream))

--- a/src/lisp/kernel/clos/streams.lisp
+++ b/src/lisp/kernel/clos/streams.lisp
@@ -79,6 +79,13 @@
 (defgeneric stream-p (stream)
   (:documentation "Is this object a STREAM?"))
 
+(defgeneric pathname (pathspec)
+  (:documentation "Returns the pathname denoted by pathspec."))
+
+(defgeneric truename (filespec)
+  (:documentation "truename tries to find the file indicated by filespec and returns its
+truename."))
+
 (defgeneric stream-interactive-p (stream)
   (:documentation "Is stream interactive (For instance, a tty)?"))
 
@@ -411,6 +418,15 @@
 (defmethod stream-interactive-p ((stream t))
   (bug-or-error stream 'stream-interactive-p))
 
+;; PATHNAME
+
+(defmethod pathname (pathspec)
+  (core:pathname* pathspec))
+
+;; TRUENAME
+
+(defmethod truename (filespec)
+  (core:truename* filespec))
 
 ;; LINE-COLUMN
 
@@ -781,8 +797,15 @@
 
 ;;; Setup
 
-(core:defconstant-equal +conflicting-symbols+ '(cl:close cl:stream-element-type cl:input-stream-p
-                                                cl:open-stream-p cl:output-stream-p cl:streamp))
+(core:defconstant-equal +conflicting-symbols+
+  '(cl:close
+    cl:stream-element-type
+    cl:input-stream-p
+    cl:open-stream-p
+    cl:output-stream-p
+    cl:streamp
+    cl:pathname
+    cl:truename))
 
 (defun redefine-cl-functions ()
   "Some functions in CL package are expected to be generic. We make them so."


### PR DESCRIPTION
Some small tweaks to some default methods and making PATHNAME and TRUENAME generic functions. This is optional per the Gray stream proposal. 