### PR TITLE
Add generic setf for gray:stream-element-type

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,8 @@
   for Gray streams.
 * Generic versions of `cl:pathname` and `cl:truename`, both of which
   are available after the Gray stream modules is required.
+* Generic `(setf gray:stream-element-type)` for basic support of
+  bivalent streams.
 
 ## Changed
 * `cl:format` and `pprint` now respect the value returned bye

--- a/src/lisp/kernel/clos/streams.lisp
+++ b/src/lisp/kernel/clos/streams.lisp
@@ -55,6 +55,12 @@
   STREAM. The class FUNDAMENTAL-CHARACTER-STREAM provides a default method
   which returns CHARACTER."))
 
+(defgeneric (setf stream-element-type) (new-value stream)
+  (:documentation
+   "Set the type specifier of the kind of object returned by the
+  STREAM. There is no default method as this is optional and only
+  needed for bivalent streams."))
+
 (defgeneric stream-finish-output (stream)
   (:documentation
    "Attempts to ensure that all output sent to the Stream has reached


### PR DESCRIPTION
Allows implementation of basic bivalent Gray streams. This is done by CLISP also. I've tested that this works, although generic versions STREAM-EXTERNAL-FORMAT will also probably need to be done at some point.