### PR TITLE
More Stream Cleanup

### DIFF
--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -74,7 +74,6 @@ void wrong_file_handler(T_sp strm) NO_RETURN;
 void wsock_error(const char* err_msg, T_sp strm) NO_RETURN;
 #endif
 
-
 int safe_open(const char* filename, int flags, clasp_mode_t mode);
 
 enum StreamMode {
@@ -274,25 +273,14 @@ class AnsiStream_O : public Stream_O {
 
 public:
   bool _open;
-  int _byte_size;
-  int _flags;          // bitmap of flags
-  List_sp _byte_stack; // For unget in input streams
-  T_sp _format_table;
-  Fixnum _last_code[2];
-  claspCharacter _eof_char;
-  int _last_op;
-  int _last_char;
-  T_sp _external_format;
+  int _flags; // bitmap of flags
   int _output_column;
   StreamCursor _input_cursor;
 
 public:
-  AnsiStream_O()
-      : _open(true), _byte_size(8), _flags(0), _byte_stack(nil<T_O>()), _format_table(nil<T_O>()), _last_code{EOF, EOF},
-        _eof_char(EOF), _external_format(nil<T_O>()), _output_column(0){};
+  AnsiStream_O() : _open(true), _output_column(0){};
   virtual ~AnsiStream_O(); // nontrivial
 
-  cl_index consume_byte_stack(unsigned char* c, cl_index n);
   int restartable_io_error(const char* s);
   void update_column(claspCharacter c);
 
@@ -364,6 +352,14 @@ class FileStream_O : public AnsiStream_O {
 
 public:
   StreamMode _mode;
+  int _byte_size;
+  List_sp _byte_stack; // For unget in input streams
+  T_sp _format_table;
+  Fixnum _last_code[2];
+  claspCharacter _eof_char;
+  int _last_char;
+  int _last_op;
+  T_sp _external_format;
   T_sp _filename;
   T_sp _temp_filename;
   bool _created = false;
@@ -371,10 +367,13 @@ public:
   T_sp _element_type;
 
 public: // Functions here
-  FileStream_O() : _format(nil<Symbol_O>()){};
+  FileStream_O()
+      : _byte_size(8), _byte_stack(nil<T_O>()), _format_table(nil<T_O>()), _last_code{EOF, EOF}, _eof_char(EOF),
+        _external_format(nil<T_O>()), _format(nil<Symbol_O>()){};
 
   virtual string __repr__() const override;
   virtual bool has_file_position() const;
+  cl_index consume_byte_stack(unsigned char* c, cl_index n);
   ListenResult _fd_listen(int fd);
   void close_cleanup(T_sp abort);
   cl_index compute_char_size(claspCharacter c);
@@ -901,6 +900,7 @@ class EchoStream_O : public AnsiStream_O {
   LISP_CLASS(core, ClPkg, EchoStream_O, "EchoStream", AnsiStream_O);
 
 protected:
+  int _last_char;
   T_sp _input_stream;
   T_sp _output_stream;
 

--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -182,6 +182,7 @@ T_sp stream_set_position(T_sp stream, T_sp pos);
 T_sp stream_string_length(T_sp stream, T_sp string);
 int stream_column(T_sp stream);
 int stream_set_column(T_sp stream, int column);
+int stream_line(T_sp stream);
 
 int stream_input_handle(T_sp stream);
 int stream_output_handle(T_sp stream);
@@ -272,15 +273,16 @@ class AnsiStream_O : public Stream_O {
 public:
   bool _open;
   int _flags; // bitmap of flags
-  int _output_column;
+  int _column;
+  int _line;
   StreamCursor _input_cursor;
 
 public:
-  AnsiStream_O() : _open(true), _output_column(0){};
+  AnsiStream_O() : _open(true), _column(0), _line(0){};
   virtual ~AnsiStream_O(); // nontrivial
 
   int restartable_io_error(const char* s);
-  void update_column(claspCharacter c);
+  void update_line_column(claspCharacter c);
 
   virtual cl_index write_byte8(unsigned char* c, cl_index n);
   virtual cl_index read_byte8(unsigned char* c, cl_index n);
@@ -317,6 +319,7 @@ public:
   virtual T_sp string_length(T_sp string);
   virtual int column() const;
   virtual int set_column(int column);
+  virtual int line() const;
 
   virtual int input_handle();
   virtual int output_handle();
@@ -325,7 +328,6 @@ public:
 
   virtual T_sp pathname() const;
   virtual T_sp truename() const;
-  virtual int lineno() const;
 
   inline void check_open() {
     if (!_open)

--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -129,7 +129,6 @@ FileScope_sp clasp_input_source_file_info(T_sp strm);
 Pathname_sp clasp_input_pathname(T_sp strm);
 
 T_sp cl__unread_char(Character_sp ch, T_sp dstrm);
-T_sp cl__get_output_stream_string(T_sp strm);
 
 T_sp clasp_off_t_to_integer(clasp_off_t offset);
 clasp_off_t clasp_integer_to_off_t(T_sp i);
@@ -144,7 +143,6 @@ T_sp cl__make_string_input_stream(String_sp strng, cl_index istart, T_sp iend);
 #define STRING_OUTPUT_STREAM_DEFAULT_SIZE 128
 T_sp clasp_make_string_output_stream(cl_index line_length = STRING_OUTPUT_STREAM_DEFAULT_SIZE, bool extended = false);
 T_sp cl__make_string_output_stream(Symbol_sp elementType);
-T_sp cl__get_output_stream_string(T_sp strm);
 
 T_sp cl__close(T_sp strm, T_sp abort = nil<T_O>());
 
@@ -628,9 +626,11 @@ class StringOutputStream_O : public StringStream_O {
 public:
   DEFAULT_CTOR_DTOR(StringOutputStream_O);
 
+  static String_sp get_string(T_sp string_output_stream);
+
   void fill(const string& data);
   void clear();
-  String_sp getAndReset();
+  String_sp get_string();
 
   claspCharacter write_char(claspCharacter c);
 
@@ -666,6 +666,8 @@ public:
   DEFAULT_CTOR_DTOR(StringInputStream_O);
 
   static T_sp make(const string& str);
+  static StringInputStream_sp make(String_sp string, cl_index istart, cl_index iend);
+
   string peer(size_t len);
   string peerFrom(size_t start, size_t len);
 

--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -269,7 +269,7 @@ public:
   bool _open;
   T_sp _Format;
   int _byte_size;
-  int _flags;         // bitmap of flags
+  int _flags;          // bitmap of flags
   List_sp _byte_stack; // For unget in input streams
   T_sp _format_table;
   Fixnum _last_code[2];
@@ -752,11 +752,11 @@ class TwoWayStream_O : public AnsiStream_O {
   LISP_CLASS(core, ClPkg, TwoWayStream_O, "two-way-stream", AnsiStream_O);
 
 public: // Simple default ctor/dtor
-  TwoWayStream_O() : _In(nil<T_O>()), _Out(nil<T_O>()){};
+  TwoWayStream_O() : _input_stream(nil<T_O>()), _output_stream(nil<T_O>()){};
 
 public: // instance variables here
-  T_sp _In;
-  T_sp _Out;
+  T_sp _input_stream;
+  T_sp _output_stream;
 
 public:
   static T_sp make(T_sp in, T_sp out) { return cl__make_two_way_stream(in, out); };
@@ -886,8 +886,8 @@ public: // Simple default ctor/dtor
   DEFAULT_CTOR_DTOR(EchoStream_O);
 
 public: // instance variables here
-  T_sp _In;
-  T_sp _Out;
+  T_sp _input_stream;
+  T_sp _output_stream;
 
 public: // Functions here
   cl_index read_byte8(unsigned char* c, cl_index n);

--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -377,6 +377,7 @@ public: // Functions here
   ListenResult _fd_listen(int fd);
   void close_cleanup(T_sp abort);
   cl_index compute_char_size(claspCharacter c);
+  void parse_external_format(T_sp format);
 
   claspCharacter decode_passthrough(unsigned char** buffer, unsigned char* buffer_end);
   int encode_passthrough(unsigned char* buffer, claspCharacter c);
@@ -766,8 +767,8 @@ public: // instance variables here
 
 public:
   static TwoWayStream_sp make(T_sp input_stream, T_sp output_stream);
-  static T_sp input_stream(T_sp echo_stream);
-  static T_sp output_stream(T_sp echo_stream);
+  static T_sp input_stream(T_sp two_way_stream);
+  static T_sp output_stream(T_sp two_way_stream);
 
   T_sp input_stream() const { return _input_stream; }
   T_sp output_stream() const { return _output_stream; }
@@ -905,7 +906,7 @@ protected:
   T_sp _output_stream;
 
 public:
-  DEFAULT_CTOR_DTOR(EchoStream_O);
+  EchoStream_O() : _last_char(EOF){};
 
   static EchoStream_sp make(T_sp input_stream, T_sp output_stream);
   static T_sp input_stream(T_sp echo_stream);

--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -147,8 +147,6 @@ SourcePosInfo_sp core__input_stream_source_pos_info(T_sp, FileScope_sp, size_t, 
 SourcePosInfo_sp clasp_simple_input_stream_source_pos_info(T_sp);
 FileScope_sp clasp_input_source_file_info(T_sp strm);
 Pathname_sp clasp_input_pathname(T_sp strm);
-/*! Return the filename of the stream if possible, error if errorp=true and no name can be determined */
-T_sp clasp_filename(T_sp strm, bool errorp = false);
 
 T_sp cl__unread_char(Character_sp ch, T_sp dstrm);
 T_sp cl__get_output_stream_string(T_sp strm);
@@ -205,6 +203,7 @@ void stream_clear_output(T_sp stream);
 void stream_finish_output(T_sp stream);
 void stream_force_output(T_sp stream);
 
+bool stream_p(T_sp stream);
 bool stream_open_p(T_sp stream);
 bool stream_input_p(T_sp stream);
 bool stream_output_p(T_sp stream);
@@ -225,6 +224,9 @@ int stream_input_handle(T_sp stream);
 int stream_output_handle(T_sp stream);
 
 T_sp stream_close(T_sp stream, T_sp abort);
+
+T_sp stream_pathname(T_sp stream);
+T_sp stream_truename(T_sp stream);
 
 // Define types of streams
 // See ecl object.h:600
@@ -363,7 +365,8 @@ public:
 
   virtual T_sp close(T_sp abort);
 
-  virtual T_sp filename() const;
+  virtual T_sp pathname() const;
+  virtual T_sp truename() const;
   virtual int lineno() const;
 
   inline void check_open() {
@@ -400,7 +403,6 @@ public:
 
 public: // Functions here
   virtual string __repr__() const override;
-  T_sp filename() const override { return this->_Filename; };
   virtual bool has_file_position() const;
   ListenResult _fd_listen(int fd);
   void close_cleanup(T_sp abort);
@@ -472,6 +474,9 @@ public: // Functions here
   T_sp set_external_format(T_sp format);
 
   T_sp string_length(T_sp string);
+
+  T_sp pathname() const;
+  T_sp truename() const;
 }; // FileStream class
 
 }; // namespace core
@@ -750,7 +755,6 @@ public:
 
 public: // Functions here
   virtual string __repr__() const override;
-  T_sp filename() const override;
 
   T_sp stream() const { return _SynonymSymbol->symbolValue(); }
 
@@ -786,6 +790,9 @@ public: // Functions here
 
   int input_handle();
   int output_handle();
+
+  T_sp pathname() const;
+  T_sp truename() const;
 }; // SynonymStream class
 
 }; // namespace core

--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -267,7 +267,6 @@ class AnsiStream_O : public Stream_O {
 
 public:
   bool _open;
-  T_sp _Format;
   int _byte_size;
   int _flags;          // bitmap of flags
   List_sp _byte_stack; // For unget in input streams
@@ -275,15 +274,15 @@ public:
   Fixnum _last_code[2];
   claspCharacter _eof_char;
   int _last_op;
-  int _LastChar;
+  int _last_char;
   T_sp _external_format;
   int _output_column;
   StreamCursor _input_cursor;
 
 public:
   AnsiStream_O()
-      : _open(true), _Format(nil<Symbol_O>()), _byte_size(8), _flags(0), _byte_stack(nil<T_O>()), _format_table(nil<T_O>()),
-        _last_code{EOF, EOF}, _eof_char(EOF), _external_format(nil<T_O>()), _output_column(0){};
+      : _open(true), _byte_size(8), _flags(0), _byte_stack(nil<T_O>()), _format_table(nil<T_O>()), _last_code{EOF, EOF},
+        _eof_char(EOF), _external_format(nil<T_O>()), _output_column(0){};
   virtual ~AnsiStream_O(); // nontrivial
 
   cl_index consume_byte_stack(unsigned char* c, cl_index n);
@@ -361,10 +360,11 @@ public:
   T_sp _filename;
   T_sp _temp_filename;
   bool _created = false;
+  T_sp _format;
   T_sp _element_type;
 
 public: // Functions here
-  FileStream_O(){};
+  FileStream_O() : _format(nil<Symbol_O>()){};
 
   virtual string __repr__() const override;
   virtual bool has_file_position() const;
@@ -438,6 +438,7 @@ public: // Functions here
 
   T_sp element_type() const;
   T_sp set_element_type(T_sp type);
+  T_sp external_format() const;
   T_sp set_external_format(T_sp format);
 
   T_sp string_length(T_sp string);
@@ -597,7 +598,11 @@ class StringStream_O : public AnsiStream_O {
   LISP_CLASS(core, ClPkg, StringStream_O, "string-stream", AnsiStream_O);
 
 public:
+  String_sp _contents;
+
   DEFAULT_CTOR_DTOR(StringStream_O);
+
+  T_sp external_format() const;
 };
 
 }; // namespace core
@@ -612,9 +617,6 @@ namespace core {
 
 class StringOutputStream_O : public StringStream_O {
   LISP_CLASS(core, CorePkg, StringOutputStream_O, "string-output-stream", StringStream_O);
-
-public:
-  String_sp _contents;
 
 public:
   DEFAULT_CTOR_DTOR(StringOutputStream_O);
@@ -650,7 +652,6 @@ class StringInputStream_O : public StringStream_O {
   LISP_CLASS(core, CorePkg, StringInputStream_O, "string-input-stream", StringStream_O);
 
 public:
-  String_sp _contents;
   gctools::Fixnum _input_position;
   gctools::Fixnum _input_limit;
 

--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -613,6 +613,7 @@ public:
 
   DEFAULT_CTOR_DTOR(StringStream_O);
 
+  T_sp element_type() const;
   T_sp external_format() const;
 };
 
@@ -645,7 +646,6 @@ public:
   void force_output();
 
   bool output_p() const;
-  T_sp element_type() const;
 
   T_sp position();
   T_sp set_position(T_sp pos);
@@ -684,7 +684,6 @@ public:
   void clear_input();
 
   bool input_p() const;
-  T_sp element_type() const;
 
   T_sp position();
   T_sp set_position(T_sp pos);

--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -141,8 +141,9 @@ T_sp cl__stream_external_format(T_sp strm);
 
 T_sp cl__make_string_input_stream(String_sp strng, cl_index istart, T_sp iend);
 #define STRING_OUTPUT_STREAM_DEFAULT_SIZE 128
-T_sp clasp_make_string_output_stream(cl_index line_length = STRING_OUTPUT_STREAM_DEFAULT_SIZE, bool extended = false);
-T_sp cl__make_string_output_stream(Symbol_sp elementType);
+StringOutputStream_sp clasp_make_string_output_stream(cl_index line_length = STRING_OUTPUT_STREAM_DEFAULT_SIZE,
+                                                      bool extended = false);
+StringOutputStream_sp cl__make_string_output_stream(Symbol_sp elementType);
 
 T_sp cl__close(T_sp strm, T_sp abort = nil<T_O>());
 
@@ -473,8 +474,9 @@ public:
 public:
   IOFileStream_O(){};
 
-  static T_sp make(T_sp fname, int fd, StreamMode smm, gctools::Fixnum byte_size = 8, int flags = CLASP_STREAM_DEFAULT_FORMAT,
-                   T_sp external_format = nil<T_O>(), T_sp tempName = nil<T_O>(), bool created = false);
+  static IOFileStream_sp make(T_sp fname, int fd, StreamMode smm, gctools::Fixnum byte_size = 8,
+                              int flags = CLASP_STREAM_DEFAULT_FORMAT, T_sp external_format = nil<T_O>(),
+                              T_sp tempName = nil<T_O>(), bool created = false);
 
   int fileDescriptor() const { return this->_file_descriptor; };
   virtual bool has_file_position() const override;
@@ -568,11 +570,13 @@ public:
 
   void fixupInternalsForSnapshotSaveLoad(snapshotSaveLoad::Fixup* fixup);
 
-  static T_sp make(T_sp fname, FILE* f, StreamMode smm, gctools::Fixnum byte_size = 8, int flags = CLASP_STREAM_DEFAULT_FORMAT,
-                   T_sp external_format = nil<T_O>(), T_sp tempName = nil<T_O>(), bool created = false);
+  static IOStreamStream_sp make(T_sp fname, FILE* f, StreamMode smm, gctools::Fixnum byte_size = 8,
+                                int flags = CLASP_STREAM_DEFAULT_FORMAT, T_sp external_format = nil<T_O>(),
+                                T_sp tempName = nil<T_O>(), bool created = false);
 
-  static T_sp make(T_sp fname, int fd, StreamMode smm, gctools::Fixnum byte_size = 8, int flags = CLASP_STREAM_DEFAULT_FORMAT,
-                   T_sp external_format = nil<T_O>(), T_sp tempName = nil<T_O>(), bool created = false);
+  static IOStreamStream_sp make(T_sp fname, int fd, StreamMode smm, gctools::Fixnum byte_size = 8,
+                                int flags = CLASP_STREAM_DEFAULT_FORMAT, T_sp external_format = nil<T_O>(),
+                                T_sp tempName = nil<T_O>(), bool created = false);
 
   FILE* file() const { return this->_file; };
 

--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -133,6 +133,13 @@ typedef enum {
   CLASP_STREAM_CLOSE_COMPONENTS = 1024
 } StreamFlagsEnum;
 
+typedef enum {
+    listen_result_no_char = 0,
+    listen_result_available = 1,
+    listen_result_eof = -1,
+    listen_result_unknown = -3
+} ListenResult;
+
 size_t clasp_input_filePos(T_sp strm);
 int clasp_input_lineno(T_sp strm);
 int clasp_input_column(T_sp strm);
@@ -178,11 +185,6 @@ T_sp cl__get_output_stream_string(T_sp strm);
 
 T_sp cl__close(T_sp strm, T_sp abort = nil<T_O>());
 
-#define CLASP_LISTEN_NO_CHAR 0
-#define CLASP_LISTEN_AVAILABLE 1
-#define CLASP_LISTEN_EOF -1
-#define CLASP_LISTEN_UNKNOWN -3
-
 cl_index stream_write_byte8(T_sp stream, unsigned char* c, cl_index n);
 cl_index stream_read_byte8(T_sp stream, unsigned char* c, cl_index n);
 
@@ -197,7 +199,7 @@ claspCharacter stream_peek_char(T_sp stream);
 cl_index stream_read_vector(T_sp stream, T_sp data, cl_index start, cl_index end);
 cl_index stream_write_vector(T_sp stream, T_sp data, cl_index start, cl_index end);
 
-int stream_listen(T_sp stream);
+ListenResult stream_listen(T_sp stream);
 void stream_clear_input(T_sp stream);
 void stream_clear_output(T_sp stream);
 void stream_finish_output(T_sp stream);
@@ -334,7 +336,7 @@ public:
   virtual cl_index read_vector(T_sp data, cl_index start, cl_index end);
   virtual cl_index write_vector(T_sp data, cl_index start, cl_index end);
 
-  virtual int listen();
+  virtual ListenResult listen();
   virtual void clear_input();
   virtual void clear_output();
   virtual void finish_output();
@@ -400,7 +402,7 @@ public: // Functions here
   virtual string __repr__() const override;
   T_sp filename() const override { return this->_Filename; };
   virtual bool has_file_position() const;
-  int _fd_listen(int fd);
+  ListenResult _fd_listen(int fd);
   void close_cleanup(T_sp abort);
   cl_index compute_char_size(claspCharacter c);
 
@@ -511,7 +513,7 @@ public:
   cl_index read_byte8(unsigned char* c, cl_index n);
   cl_index write_byte8(unsigned char* c, cl_index n);
 
-  int listen();
+  ListenResult listen();
   void clear_input();
   void clear_output();
   void force_output();
@@ -541,7 +543,7 @@ public:
 
   cl_index read_byte8(unsigned char* c, cl_index n);
   cl_index write_byte8(unsigned char* c, cl_index n);
-  int listen();
+  ListenResult listen();
   void clear_input();
   T_sp close(T_sp abort);
 };
@@ -558,7 +560,7 @@ public:
 
   cl_index read_byte8(unsigned char* c, cl_index n);
   cl_index write_byte8(unsigned char* c, cl_index n);
-  int listen();
+  ListenResult listen();
   void clear_input();
   void force_output();
 };
@@ -604,9 +606,9 @@ public:
   cl_index read_byte8(unsigned char* c, cl_index n);
   cl_index write_byte8(unsigned char* c, cl_index n);
 
-  int _file_listen();
+  ListenResult _file_listen();
 
-  int listen();
+  ListenResult listen();
   void clear_input();
   void clear_output();
   void force_output();
@@ -712,7 +714,7 @@ public: // Functions here
   claspCharacter read_char();
   void unread_char(claspCharacter c);
   claspCharacter peek_char();
-  int listen();
+  ListenResult listen();
   void clear_input();
 
   bool input_p() const;
@@ -763,7 +765,7 @@ public: // Functions here
   cl_index read_vector(T_sp data, cl_index start, cl_index n);
   cl_index write_vector(T_sp data, cl_index start, cl_index n);
 
-  int listen();
+  ListenResult listen();
   void clear_input();
   void clear_output();
   void force_output();
@@ -822,7 +824,7 @@ public:
   cl_index read_vector(T_sp data, cl_index start, cl_index n);
   cl_index write_vector(T_sp data, cl_index start, cl_index n);
 
-  int listen();
+  ListenResult listen();
   void clear_input();
   void clear_output();
   void force_output();
@@ -911,7 +913,7 @@ public: // Functions here
   T_sp read_byte();
   claspCharacter read_char();
   void unread_char(claspCharacter c);
-  int listen();
+  ListenResult listen();
   void clear_input();
 
   bool input_p() const;
@@ -953,7 +955,7 @@ public: // Functions here
   void unread_char(claspCharacter c);
   claspCharacter peek_char();
 
-  int listen();
+  ListenResult listen();
   void clear_input();
   void clear_output();
   void force_output();

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -262,6 +262,36 @@ public:
     core::lisp_errorCast<o_class, Type>(this->theObject);
   }
 
+  template <class o_class> inline base_ptr<o_class> as_unsafe() {
+    base_ptr<o_class> ret((Tagged)this->theObject);
+    return ret;
+  }
+
+  template <class o_class> inline base_ptr<o_class> as_unsafe() const {
+    base_ptr<o_class> ret((Tagged)this->theObject);
+    return ret;
+  }
+
+  template <class o_class> inline base_ptr<o_class> as_assert() {
+#ifdef DEBUG_ASSERT
+    if (!TaggedCast<o_class*, Type*>::isA(this->theObject)) {
+      throw_hard_error_failed_assertion("as_assert failed!");
+    }
+#endif
+    base_ptr<o_class> ret((Tagged)this->theObject);
+    return ret;
+  }
+
+  template <class o_class> inline base_ptr<o_class> as_assert() const {
+#ifdef DEBUG_ASSERT
+    if (!TaggedCast<o_class*, Type*>::isA(this->theObject)) {
+      throw_hard_error_failed_assertion("as_assert failed!");
+    }
+#endif
+    base_ptr<o_class> ret((Tagged)this->theObject);
+    return ret;
+  }
+
   template <class o_class> inline bool isA() { return TaggedCast<o_class*, Type*>::isA(this->theObject); }
 
   template <class o_class> inline bool isA() const { return TaggedCast<o_class*, Type*>::isA(this->theObject); }
@@ -582,6 +612,36 @@ public:
     if (ret)
       return ret;
     core::lisp_errorCast<o_class, Type>(this->theObject);
+  }
+
+  template <class o_class> inline smart_ptr<o_class> as_unsafe() {
+    smart_ptr<o_class> ret((Tagged)this->theObject);
+    return ret;
+  }
+
+  template <class o_class> inline smart_ptr<o_class> as_unsafe() const {
+    smart_ptr<o_class> ret((Tagged)this->theObject);
+    return ret;
+  }
+
+  template <class o_class> inline smart_ptr<o_class> as_assert() {
+#ifdef DEBUG_ASSERT
+    if (!TaggedCast<o_class*, Type*>::isA(this->theObject)) {
+      throw_hard_error_failed_assertion("as_assert failed!");
+    }
+#endif
+    smart_ptr<o_class> ret((Tagged)this->theObject);
+    return ret;
+  }
+
+  template <class o_class> inline smart_ptr<o_class> as_assert() const {
+#ifdef DEBUG_ASSERT
+    if (!TaggedCast<o_class*, Type*>::isA(this->theObject)) {
+      throw_hard_error_failed_assertion("as_assert failed!");
+    }
+#endif
+    smart_ptr<o_class> ret((Tagged)this->theObject);
+    return ret;
   }
 
   template <class o_class> inline bool isA() {

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -560,7 +560,7 @@ template <typename To_SP, typename From_SP> inline To_SP As_unsafe(From_SP const
 template <typename To_SP, typename From_SP> inline To_SP As_assert(From_SP const& rhs) {
 #ifdef DEBUG_ASSERT
   if (!gctools::IsA<To_SP>(rhs)) {
-    throw_hard_error_failed_assertion("!gctools::IsA<To_SP>(rhs)");
+    throw_hard_error_cast_failed(typeid(To_SP).name(), typeid(From_SP).name());
   }
 #endif
   To_SP ret((Tagged)rhs.raw_());

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -5038,28 +5038,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
@@ -5082,29 +5062,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::TwoWayStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -5135,30 +5094,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::SynonymStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -5186,35 +5123,8 @@
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -5242,28 +5152,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
@@ -5281,6 +5171,23 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::FileStream_O"
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_stack")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
+             :layout-offset-field-names ("_format_table")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_eof_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_last_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_last_op")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
              :layout-offset-field-names ("_filename")}
@@ -5291,35 +5198,17 @@
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_created")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
+             :layout-offset-field-names ("_format")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
              :layout-offset-field-names ("_element_type")}
 {class-kind :stamp-name "STAMPWTAG_core__IOFileStream_O" :stamp-key "core::IOFileStream_O"
             :parent-class "core::FileStream_O" :lisp-class-base "core::FileStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -5338,6 +5227,24 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::IOFileStream_O"
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_stack")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_format_table")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_eof_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_last_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_last_op")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_filename")}
@@ -5349,6 +5256,9 @@
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_created")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_format")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_element_type")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O"
@@ -5358,30 +5268,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOStreamStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -5400,6 +5288,25 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::IOStreamStream_O"
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_stack")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOStreamStream_O"
+             :layout-offset-field-names ("_format_table")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_eof_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_last_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_last_op")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOStreamStream_O"
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_filename")}
@@ -5409,6 +5316,9 @@
              :layout-offset-field-names ("_temp_filename")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_created")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_format")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O"
@@ -5422,31 +5332,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::BroadcastStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -5473,29 +5360,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -5514,41 +5380,17 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringStream_O"
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::Array_O>"
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_contents")}
 {class-kind :stamp-name "STAMPWTAG_core__StringOutputStream_O"
             :stamp-key "core::StringOutputStream_O" :parent-class "core::StringStream_O"
             :lisp-class-base "core::StringStream_O" :root-class "core::T_O" :stamp-wtag 3
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -5577,34 +5419,8 @@
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -5638,28 +5454,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
@@ -5677,6 +5473,8 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::EchoStream_O"
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_last_char")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
              :layout-offset-field-names ("_input_stream")}

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -5125,10 +5125,11 @@
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_In")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_input_stream")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Out")}
+             :offset-base-ctype "core::TwoWayStream_O"
+             :layout-offset-field-names ("_output_stream")}
 {class-kind :stamp-name "STAMPWTAG_core__SynonymStream_O" :stamp-key "core::SynonymStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -5678,10 +5679,10 @@
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_In")}
+             :layout-offset-field-names ("_input_stream")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_Out")}
+             :layout-offset-field-names ("_output_stream")}
 {class-kind :stamp-name "STAMPWTAG_core__Package_O" :stamp-key "core::Package_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -5037,95 +5037,92 @@
             :parent-class "core::Stream_O" :lisp-class-base "core::Stream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
              :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_OutputColumn")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {class-kind :stamp-name "STAMPWTAG_core__TwoWayStream_O" :stamp-key "core::TwoWayStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_FormatTable")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_OutputColumn")}
+             :offset-base-ctype "core::TwoWayStream_O"
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_In")}
@@ -5136,559 +5133,549 @@
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_FormatTable")}
+             :offset-base-ctype "core::SynonymStream_O"
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::Symbol_O>"
-             :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_SynonymSymbol")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_symbol")}
 {class-kind :stamp-name "STAMPWTAG_core__ConcatenatedStream_O"
             :stamp-key "core::ConcatenatedStream_O" :parent-class "core::AnsiStream_O"
             :lisp-class-base "core::AnsiStream_O" :root-class "core::T_O" :stamp-wtag 3
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_ByteSize")}
+             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_ByteStack")}
+             :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_EofChar")}
+             :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::ConcatenatedStream_O"
+             :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O"
              :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_List")}
+             :offset-base-ctype "core::ConcatenatedStream_O"
+             :layout-offset-field-names ("_streams")}
 {class-kind :stamp-name "STAMPWTAG_core__FileStream_O" :stamp-key "core::FileStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
              :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_OutputColumn")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_Filename")}
+             :layout-offset-field-names ("_filename")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_TempFilename")}
+             :layout-offset-field-names ("_temp_filename")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_Created")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_created")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_ElementType")}
+             :layout-offset-field-names ("_element_type")}
 {class-kind :stamp-name "STAMPWTAG_core__IOFileStream_O" :stamp-key "core::IOFileStream_O"
             :parent-class "core::FileStream_O" :lisp-class-base "core::FileStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_FormatTable")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_OutputColumn")}
-{fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
-{fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
-{fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Filename")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_TempFilename")}
-{fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Created")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_ElementType")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_FileDescriptor")}
+             :layout-offset-field-names ("_output_column")}
+{fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
+{fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_input_cursor" "._column")}
+{fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_filename")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_temp_filename")}
+{fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_created")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_element_type")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_file_descriptor")}
 {class-kind :stamp-name "STAMPWTAG_core__IOStreamStream_O" :stamp-key "core::IOStreamStream_O"
             :parent-class "core::FileStream_O" :lisp-class-base "core::FileStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Filename")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_filename")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_TempFilename")}
+             :layout-offset-field-names ("_temp_filename")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Created")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_created")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_ElementType")}
+             :layout-offset-field-names ("_element_type")}
 {fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_File")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_file")}
+{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_buffer")}
 {class-kind :stamp-name "STAMPWTAG_core__BroadcastStream_O" :stamp-key "core::BroadcastStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::BroadcastStream_O"
+             :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Streams")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_streams")}
 {class-kind :stamp-name "STAMPWTAG_core__StringStream_O" :stamp-key "core::StringStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_FormatTable")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_OutputColumn")}
+             :offset-base-ctype "core::StringStream_O"
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {class-kind :stamp-name "STAMPWTAG_core__StringOutputStream_O"
             :stamp-key "core::StringOutputStream_O" :parent-class "core::StringStream_O"
             :lisp-class-base "core::StringStream_O" :root-class "core::T_O" :stamp-wtag 3
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_ByteSize")}
+             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_ByteStack")}
+             :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_EofChar")}
+             :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::StringOutputStream_O"
+             :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O"
              :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::Array_O>"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_Contents")}
+             :layout-offset-field-names ("_contents")}
 {class-kind :stamp-name "STAMPWTAG_core__StringInputStream_O"
             :stamp-key "core::StringInputStream_O" :parent-class "core::StringStream_O"
             :lisp-class-base "core::StringStream_O" :root-class "core::T_O" :stamp-wtag 3
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_ByteSize")}
+             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_ByteStack")}
+             :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::StringInputStream_O"
+             :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O"
              :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::Array_O>"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_Contents")}
+             :layout-offset-field-names ("_contents")}
 {fixed-field :offset-type-cxx-identifier "ctype_long" :offset-ctype "long"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputPosition")}
+             :layout-offset-field-names ("_input_position")}
 {fixed-field :offset-type-cxx-identifier "ctype_long" :offset-ctype "long"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputLimit")}
+             :layout-offset-field-names ("_input_limit")}
 {class-kind :stamp-name "STAMPWTAG_core__EchoStream_O" :stamp-key "core::EchoStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
              :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_OutputColumn")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
              :layout-offset-field-names ("_In")}

--- a/src/analysis/clasp_gc.sif
+++ b/src/analysis/clasp_gc.sif
@@ -5041,7 +5041,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::AnsiStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -5065,8 +5067,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::TwoWayStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -5097,8 +5100,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::SynonymStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -5126,8 +5130,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::ConcatenatedStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -5155,7 +5160,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::FileStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -5210,8 +5217,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOFileStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -5271,8 +5279,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOStreamStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -5335,8 +5344,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::BroadcastStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -5363,8 +5373,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -5392,8 +5403,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringOutputStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -5422,8 +5434,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringInputStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -5457,7 +5470,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::EchoStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}

--- a/src/analysis/clasp_gc_cando.sif
+++ b/src/analysis/clasp_gc_cando.sif
@@ -9981,10 +9981,11 @@
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_In")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_input_stream")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Out")}
+             :offset-base-ctype "core::TwoWayStream_O"
+             :layout-offset-field-names ("_output_stream")}
 {class-kind :stamp-name "STAMPWTAG_core__SynonymStream_O" :stamp-key "core::SynonymStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
@@ -10246,10 +10247,10 @@
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_In")}
+             :layout-offset-field-names ("_input_stream")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_Out")}
+             :layout-offset-field-names ("_output_stream")}
 {class-kind :stamp-name "STAMPWTAG_core__ConcatenatedStream_O"
             :stamp-key "core::ConcatenatedStream_O" :parent-class "core::AnsiStream_O"
             :lisp-class-base "core::AnsiStream_O" :root-class "core::T_O" :stamp-wtag 3

--- a/src/analysis/clasp_gc_cando.sif
+++ b/src/analysis/clasp_gc_cando.sif
@@ -9893,95 +9893,92 @@
             :parent-class "core::Stream_O" :lisp-class-base "core::Stream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
              :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_OutputColumn")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {class-kind :stamp-name "STAMPWTAG_core__TwoWayStream_O" :stamp-key "core::TwoWayStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_FormatTable")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_OutputColumn")}
+             :offset-base-ctype "core::TwoWayStream_O"
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_In")}
@@ -9992,268 +9989,261 @@
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_FormatTable")}
+             :offset-base-ctype "core::SynonymStream_O"
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::Symbol_O>"
-             :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_SynonymSymbol")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_symbol")}
 {class-kind :stamp-name "STAMPWTAG_core__StringStream_O" :stamp-key "core::StringStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_FormatTable")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_OutputColumn")}
+             :offset-base-ctype "core::StringStream_O"
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {class-kind :stamp-name "STAMPWTAG_core__StringOutputStream_O"
             :stamp-key "core::StringOutputStream_O" :parent-class "core::StringStream_O"
             :lisp-class-base "core::StringStream_O" :root-class "core::T_O" :stamp-wtag 3
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_ByteSize")}
+             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_ByteStack")}
+             :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_EofChar")}
+             :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::StringOutputStream_O"
+             :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O"
              :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::Array_O>"
              :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_Contents")}
+             :layout-offset-field-names ("_contents")}
 {class-kind :stamp-name "STAMPWTAG_core__StringInputStream_O"
             :stamp-key "core::StringInputStream_O" :parent-class "core::StringStream_O"
             :lisp-class-base "core::StringStream_O" :root-class "core::T_O" :stamp-wtag 3
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_ByteSize")}
+             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_ByteStack")}
+             :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::StringInputStream_O"
+             :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O"
              :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::Array_O>"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_Contents")}
+             :layout-offset-field-names ("_contents")}
 {fixed-field :offset-type-cxx-identifier "ctype_long" :offset-ctype "long"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputPosition")}
+             :layout-offset-field-names ("_input_position")}
 {fixed-field :offset-type-cxx-identifier "ctype_long" :offset-ctype "long"
              :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_InputLimit")}
+             :layout-offset-field-names ("_input_limit")}
 {class-kind :stamp-name "STAMPWTAG_core__EchoStream_O" :stamp-key "core::EchoStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
              :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_OutputColumn")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
              :layout-offset-field-names ("_In")}
@@ -10265,292 +10255,289 @@
             :lisp-class-base "core::AnsiStream_O" :root-class "core::T_O" :stamp-wtag 3
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_ByteSize")}
+             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_ByteStack")}
+             :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_EofChar")}
+             :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::ConcatenatedStream_O"
+             :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O"
              :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_List")}
+             :offset-base-ctype "core::ConcatenatedStream_O"
+             :layout-offset-field-names ("_streams")}
 {class-kind :stamp-name "STAMPWTAG_core__FileStream_O" :stamp-key "core::FileStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
              :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_OutputColumn")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_Filename")}
+             :layout-offset-field-names ("_filename")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_TempFilename")}
+             :layout-offset-field-names ("_temp_filename")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_Created")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_created")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_ElementType")}
+             :layout-offset-field-names ("_element_type")}
 {class-kind :stamp-name "STAMPWTAG_core__IOFileStream_O" :stamp-key "core::IOFileStream_O"
             :parent-class "core::FileStream_O" :lisp-class-base "core::FileStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_FormatTable")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_OutputColumn")}
-{fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
-{fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
-{fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Filename")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_TempFilename")}
-{fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Created")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_ElementType")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_FileDescriptor")}
+             :layout-offset-field-names ("_output_column")}
+{fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
+{fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_input_cursor" "._column")}
+{fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_filename")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_temp_filename")}
+{fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_created")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_element_type")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_file_descriptor")}
 {class-kind :stamp-name "STAMPWTAG_core__IOStreamStream_O" :stamp-key "core::IOStreamStream_O"
             :parent-class "core::FileStream_O" :lisp-class-base "core::FileStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Filename")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_filename")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_TempFilename")}
+             :layout-offset-field-names ("_temp_filename")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Created")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_created")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_ElementType")}
+             :layout-offset-field-names ("_element_type")}
 {fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_File")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_file")}
+{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_buffer")}
 {class-kind :stamp-name "STAMPWTAG_core__BroadcastStream_O" :stamp-key "core::BroadcastStream_O"
             :parent-class "core::AnsiStream_O" :lisp-class-base "core::AnsiStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Open")}
-{fixed-field :offset-type-cxx-identifier "RAW_POINTER_OFFSET" :offset-ctype "UnknownType"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Buffer")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_open")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_ByteSize")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Flags")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_ByteStack")}
+             :offset-base-ctype "core::BroadcastStream_O"
+             :layout-offset-field-names ("_byte_stack")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_FormatTable")}
+             :layout-offset-field-names ("_format_table")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_EofChar")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_eof_char")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_LastOp")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_last_op")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_LastChar")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_ExternalFormat")}
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_OutputColumn")}
+             :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_InputCursor" "._CursorIsValid")}
+             :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_InputCursor" "._LineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_InputCursor" "._Column")}
+             :layout-offset-field-names ("_input_cursor" "._column")}
 {fixed-field :offset-type-cxx-identifier "ctype_long_long" :offset-ctype "long long"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevLineNumber")}
+             :layout-offset-field-names ("_input_cursor" "._prev_line_number")}
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_InputCursor" "._PrevColumn")}
+             :layout-offset-field-names ("_input_cursor" "._prev_column")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Streams")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_streams")}
 {class-kind :stamp-name "STAMPWTAG_core__Package_O" :stamp-key "core::Package_O"
             :parent-class "core::General_O" :lisp-class-base "core::General_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}

--- a/src/analysis/clasp_gc_cando.sif
+++ b/src/analysis/clasp_gc_cando.sif
@@ -9894,28 +9894,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::AnsiStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
@@ -9938,29 +9918,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::TwoWayStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -9991,30 +9950,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::SynonymStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -10041,29 +9978,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -10082,41 +9998,17 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::StringStream_O"
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::Array_O>"
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_contents")}
 {class-kind :stamp-name "STAMPWTAG_core__StringOutputStream_O"
             :stamp-key "core::StringOutputStream_O" :parent-class "core::StringStream_O"
             :lisp-class-base "core::StringStream_O" :root-class "core::T_O" :stamp-wtag 3
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -10145,34 +10037,8 @@
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -10206,28 +10072,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
@@ -10245,6 +10091,8 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::EchoStream_O"
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_last_char")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::EchoStream_O"
              :layout-offset-field-names ("_input_stream")}
@@ -10257,35 +10105,8 @@
             :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -10313,28 +10134,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_output_column")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
@@ -10352,6 +10153,23 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::FileStream_O"
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_byte_stack")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
+             :layout-offset-field-names ("_format_table")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_eof_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_last_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_last_op")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
              :layout-offset-field-names ("_filename")}
@@ -10362,35 +10180,17 @@
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_created")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
+             :layout-offset-field-names ("_format")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>" :offset-base-ctype "core::FileStream_O"
              :layout-offset-field-names ("_element_type")}
 {class-kind :stamp-name "STAMPWTAG_core__IOFileStream_O" :stamp-key "core::IOFileStream_O"
             :parent-class "core::FileStream_O" :lisp-class-base "core::FileStream_O"
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -10409,6 +10209,24 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::IOFileStream_O"
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_byte_stack")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_format_table")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_eof_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_last_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_last_op")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O"
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_filename")}
@@ -10420,6 +10238,9 @@
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_created")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_format")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_element_type")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O"
@@ -10429,30 +10250,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOStreamStream_O"
              :layout-offset-field-names ("_output_column")}
@@ -10471,6 +10270,25 @@
 {fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
              :offset-base-ctype "core::IOStreamStream_O"
              :layout-offset-field-names ("_input_cursor" "._prev_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_size")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::List_V>"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_byte_stack")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOStreamStream_O"
+             :layout-offset-field-names ("_format_table")}
+{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_eof_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_last_char")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_last_op")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOStreamStream_O"
+             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_filename")}
@@ -10480,6 +10298,9 @@
              :layout-offset-field-names ("_temp_filename")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_created")}
+{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
+             :offset-ctype "gctools::smart_ptr<core::T_O>"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_format")}
 {fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
              :offset-ctype "gctools::smart_ptr<core::T_O>"
              :offset-base-ctype "core::IOStreamStream_O"
@@ -10493,31 +10314,8 @@
             :root-class "core::T_O" :stamp-wtag 3 :definition-data "IS_POLYMORPHIC"}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_open")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_Format")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_byte_size")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_flags")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::List_V>"
-             :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_byte_stack")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_format_table")}
-{fixed-field :offset-type-cxx-identifier "ctype_unsigned_int" :offset-ctype "unsigned int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_eof_char")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_last_op")}
-{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_LastChar")}
-{fixed-field :offset-type-cxx-identifier "SMART_PTR_OFFSET"
-             :offset-ctype "gctools::smart_ptr<core::T_O>"
-             :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_external_format")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::BroadcastStream_O"
              :layout-offset-field-names ("_output_column")}

--- a/src/analysis/clasp_gc_cando.sif
+++ b/src/analysis/clasp_gc_cando.sif
@@ -9897,7 +9897,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::AnsiStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::AnsiStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -9921,8 +9923,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::TwoWayStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::TwoWayStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::TwoWayStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -9953,8 +9956,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::SynonymStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::SynonymStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::SynonymStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -9981,8 +9985,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::StringStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -10010,8 +10015,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringOutputStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::StringOutputStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringOutputStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -10040,8 +10046,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::StringInputStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::StringInputStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::StringInputStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -10075,7 +10082,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::EchoStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::EchoStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -10108,8 +10117,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::ConcatenatedStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::ConcatenatedStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::ConcatenatedStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -10137,7 +10147,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::FileStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::FileStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -10192,8 +10204,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOFileStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOFileStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOFileStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -10253,8 +10266,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::IOStreamStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::IOStreamStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::IOStreamStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}
@@ -10317,8 +10331,9 @@
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
              :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_flags")}
 {fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
-             :offset-base-ctype "core::BroadcastStream_O"
-             :layout-offset-field-names ("_output_column")}
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_column")}
+{fixed-field :offset-type-cxx-identifier "ctype_int" :offset-ctype "int"
+             :offset-base-ctype "core::BroadcastStream_O" :layout-offset-field-names ("_line")}
 {fixed-field :offset-type-cxx-identifier "ctype__Bool" :offset-ctype "_Bool"
              :offset-base-ctype "core::BroadcastStream_O"
              :layout-offset-field-names ("_input_cursor" "._cursor_is_valid")}

--- a/src/core/bformat.cc
+++ b/src/core/bformat.cc
@@ -122,12 +122,7 @@ template <int FMT> struct formatter {
         clasp_write_string(this->_controls[ii], output);
       }
     }
-    if (destination.nilp()) {
-      StringOutputStream_sp sout = gc::As_unsafe<StringOutputStream_sp>(output);
-      String_sp result = sout->getAndReset();
-      return result;
-    }
-    return nil<T_O>();
+    return destination.nilp() ? (T_sp)StringOutputStream_O::get_string(output) : nil<T_O>();
   }
 };
 

--- a/src/core/compiler.cc
+++ b/src/core/compiler.cc
@@ -1590,7 +1590,7 @@ void dump_start_code(T_sp fin, size_t length, bool useFrom = false, size_t from 
   if (useFrom) {
     peer = sis->peerFrom(from, length);
   } else {
-    from = sis->_InputPosition;
+    from = sis->_input_position;
     peer = sis->peer(length);
   }
   clasp_write_string(fmt::format("{}lu: ", from));

--- a/src/core/corePackage.cc
+++ b/src/core/corePackage.cc
@@ -1019,9 +1019,9 @@ void CoreExposer_O::define_essential_globals(LispPtr lisp) {
 
   //        testPointers();
 
-  T_sp stdin_stream = IOStreamStream_O::makeInput("*STDIN*", stdin);
-  T_sp stdout_stream = IOStreamStream_O::makeOutput("*STDOUT*", stdout);
-  T_sp stderr_stream = IOStreamStream_O::makeOutput("*STDERR*", stderr);
+  T_sp stdin_stream = IOStreamStream_O::make(str_create("*STDIN*"), stdin, stream_mode_input);
+  T_sp stdout_stream = IOStreamStream_O::make(str_create("*STDOUT*"), stdout, stream_mode_output);
+  T_sp stderr_stream = IOStreamStream_O::make(str_create("*STDERR*"), stderr, stream_mode_output);
 
   ext::_sym__PLUS_processStandardInput_PLUS_->defparameter(stdin_stream);
   ext::_sym__PLUS_processStandardOutput_PLUS_->defparameter(stdout_stream);

--- a/src/core/foundation.cc
+++ b/src/core/foundation.cc
@@ -772,9 +772,9 @@ Instance_sp lisp_static_class(T_sp o) {
 string _rep_(T_sp obj) {
 // #define USE_WRITE_OBJECT
 #if defined(USE_WRITE_OBJECT)
-  T_sp sout = clasp_make_string_output_stream();
+  StringOutputStream_sp sout = clasp_make_string_output_stream();
   write_object(obj, sout);
-  return cl__get_output_stream_string(sout).as<String_O>()->get();
+  return sout->get_string()->get();
 #else
   if (obj.fixnump()) {
     stringstream ss;

--- a/src/core/grayPackage.cc
+++ b/src/core/grayPackage.cc
@@ -68,6 +68,7 @@ SYMBOL_SHADOW_EXPORT_SC_(GrayPkg, stream_element_type);
 SYMBOL_EXPORT_SC_(GrayPkg, stream_file_length);
 SYMBOL_EXPORT_SC_(GrayPkg, stream_file_position);
 SYMBOL_EXPORT_SC_(GrayPkg, stream_line_column);
+SYMBOL_EXPORT_SC_(GrayPkg, stream_line_number);
 SYMBOL_EXPORT_SC_(GrayPkg, stream_line_length);
 SYMBOL_EXPORT_SC_(GrayPkg, stream_advance_to_column);
 SYMBOL_SHADOW_EXPORT_SC_(GrayPkg, close);

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -533,7 +533,7 @@ void Lisp::startupLispEnvironment() {
   this->switchToClassNameHashTable();
   {
     FILE* null_out = fopen("/dev/null", "w");
-    this->_Roots._NullStream = IOStreamStream_O::makeIO("/dev/null", null_out);
+    this->_Roots._NullStream = IOStreamStream_O::make(str_create("/dev/null"), null_out, stream_mode_io);
     this->_Roots._RehashSize = DoubleFloat_O::create(2.0);
     this->_Roots._RehashThreshold = DoubleFloat_O::create(maybeFixRehashThreshold(0.7));
     this->_Roots._ImaginaryUnit = Complex_O::create(0.0, 1.0);

--- a/src/core/lispReader.cc
+++ b/src/core/lispReader.cc
@@ -828,7 +828,7 @@ T_sp interpret_token_or_throw_reader_error(T_sp sin, Token& token, bool only_dot
     // interpret failed symbols
     SIMPLE_ERROR("Error encountered while reading source file {} at character position {} - Could not interpret symbol state({}) "
                  "symbol: [{}]",
-                 _rep_(clasp_filename(sin, false)), _rep_(stream_position(sin)), stateString(state),
+                 _rep_(stream_pathname(sin)), _rep_(stream_position(sin)), stateString(state),
                  symbolTokenStr(sin, token, start - token.data(), token.size())->get_std_string());
     break;
   case tintt:
@@ -1062,7 +1062,7 @@ T_mv lisp_object_query(T_sp sin, bool eofErrorP, T_sp eofValue, bool recursiveP)
 #if 0
   static int monitorReaderStep = 0;
   if ((monitorReaderStep % 1000) == 0 && cl__member(_sym_monitorReader, _sym_STARdebugMonitorSTAR->symbolValue(), nil<T_O>()).notnilp()) {
-    printf("%s:%d:%s stream %s -> pos = %" PRF "\n", __FILE__, __LINE__, __FUNCTION__, _rep_(clasp_filename(sin, false)).c_str(), unbox_fixnum(gc::As<Fixnum_sp>(stream_position(sin))));
+    printf("%s:%d:%s stream %s -> pos = %" PRF "\n", __FILE__, __LINE__, __FUNCTION__, _rep_(stream_pathname(sin)).c_str(), unbox_fixnum(gc::As<Fixnum_sp>(stream_position(sin))));
   }
   ++monitorReaderStep;
 #endif

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -1179,7 +1179,9 @@ claspCharacter StringInputStream_O::peek_char() {
   return (_input_position >= _input_limit) ? EOF : clasp_as_claspCharacter(cl__char(_contents, _input_position));
 }
 
-ListenResult StringInputStream_O::listen() { return (_input_position < _input_limit) ? listen_result_available : listen_result_eof; }
+ListenResult StringInputStream_O::listen() {
+  return (_input_position < _input_limit) ? listen_result_available : listen_result_eof;
+}
 
 void StringInputStream_O::clear_input() {}
 
@@ -4977,9 +4979,8 @@ CL_DEFUN T_sp core__copy_stream(T_sp in, T_sp out, T_sp wait) {
 void lisp_write(const std::string& s) { clasp_write_string(s); }
 
 cl_index stream_write_byte8(T_sp stream, unsigned char* c, cl_index n) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    return ansi_stream->write_byte8(c, n);
+  if (stream.isA<AnsiStream_O>())
+    return stream.as_unsafe<AnsiStream_O>()->write_byte8(c, n);
 
   cl_index i;
   for (i = 0; i < n; i++) {
@@ -4991,9 +4992,8 @@ cl_index stream_write_byte8(T_sp stream, unsigned char* c, cl_index n) {
 }
 
 cl_index stream_read_byte8(T_sp stream, unsigned char* c, cl_index n) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    return ansi_stream->read_byte8(c, n);
+  if (stream.isA<AnsiStream_O>())
+    return stream.as_unsafe<AnsiStream_O>()->read_byte8(c, n);
 
   cl_index i;
   for (i = 0; i < n; i++) {
@@ -5006,17 +5006,15 @@ cl_index stream_read_byte8(T_sp stream, unsigned char* c, cl_index n) {
 }
 
 void stream_write_byte(T_sp stream, T_sp c) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    ansi_stream->write_byte(c);
+  if (stream.isA<AnsiStream_O>())
+    stream.as_unsafe<AnsiStream_O>()->write_byte(c);
   else
     eval::funcall(gray::_sym_stream_write_byte, stream, c);
 }
 
 T_sp stream_read_byte(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    return ansi_stream->read_byte();
+  if (stream.isA<AnsiStream_O>())
+    return stream.as_unsafe<AnsiStream_O>()->read_byte();
 
   T_sp b = eval::funcall(gray::_sym_stream_read_byte, stream);
   if (b == kw::_sym_eof)
@@ -5025,9 +5023,8 @@ T_sp stream_read_byte(T_sp stream) {
 }
 
 claspCharacter stream_read_char(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    return ansi_stream->read_char();
+  if (stream.isA<AnsiStream_O>())
+    return stream.as_unsafe<AnsiStream_O>()->read_char();
 
   T_sp output = eval::funcall(gray::_sym_stream_read_char, stream);
   gctools::Fixnum value;
@@ -5045,28 +5042,25 @@ claspCharacter stream_read_char(T_sp stream) {
 
 claspCharacter stream_write_char(T_sp stream, claspCharacter c) {
   if (!_lisp->_Roots._Started && !stream)
-    putchar(c);
+    return putchar(c);
 
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    return ansi_stream->write_char(c);
+  if (stream.isA<AnsiStream_O>())
+    return stream.as_unsafe<AnsiStream_O>()->write_char(c);
 
   eval::funcall(gray::_sym_stream_write_char, stream, clasp_make_character(c));
   return c;
 }
 
 void stream_unread_char(T_sp stream, claspCharacter c) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    ansi_stream->unread_char(c);
+  if (stream.isA<AnsiStream_O>())
+    stream.as_unsafe<AnsiStream_O>()->unread_char(c);
   else
     eval::funcall(gray::_sym_stream_unread_char, stream, clasp_make_character(c));
 }
 
 claspCharacter stream_peek_char(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    return ansi_stream->peek_char();
+  if (stream.isA<AnsiStream_O>())
+    return stream.as_unsafe<AnsiStream_O>()->peek_char();
 
   T_sp out = eval::funcall(gray::_sym_stream_peek_char, stream);
   if (out == kw::_sym_eof)
@@ -5075,9 +5069,8 @@ claspCharacter stream_peek_char(T_sp stream) {
 }
 
 cl_index stream_read_vector(T_sp stream, T_sp data, cl_index start, cl_index end) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    return ansi_stream->read_vector(data, start, end);
+  if (stream.isA<AnsiStream_O>())
+    return stream.as_unsafe<AnsiStream_O>()->read_vector(data, start, end);
 
   T_sp fn = eval::funcall(gray::_sym_stream_read_sequence, stream, data, clasp_make_fixnum(start), clasp_make_fixnum(end));
   if (fn.fixnump()) {
@@ -5087,9 +5080,8 @@ cl_index stream_read_vector(T_sp stream, T_sp data, cl_index start, cl_index end
 }
 
 cl_index stream_write_vector(T_sp stream, T_sp data, cl_index start, cl_index end) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    return ansi_stream->write_vector(data, start, end);
+  if (stream.isA<AnsiStream_O>())
+    return stream.as_unsafe<AnsiStream_O>()->write_vector(data, start, end);
 
   eval::funcall(gray::_sym_stream_write_sequence, stream, data, clasp_make_fixnum(start), clasp_make_fixnum(end));
   if (start >= end)
@@ -5098,47 +5090,42 @@ cl_index stream_write_vector(T_sp stream, T_sp data, cl_index start, cl_index en
 }
 
 ListenResult stream_listen(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream
-             ? ansi_stream->listen()
+  return stream.isA<AnsiStream_O>()
+             ? stream.as_unsafe<AnsiStream_O>()->listen()
              : ((T_sp(eval::funcall(gray::_sym_stream_listen, stream))).nilp() ? listen_result_no_char : listen_result_available);
 }
 
 void stream_clear_input(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    ansi_stream->clear_input();
+  if (stream.isA<AnsiStream_O>())
+    stream.as_unsafe<AnsiStream_O>()->clear_input();
   else
     eval::funcall(gray::_sym_stream_clear_input, stream);
 }
 
 void stream_clear_output(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    ansi_stream->clear_output();
+  if (stream.isA<AnsiStream_O>())
+    stream.as_unsafe<AnsiStream_O>()->clear_output();
   else
     eval::funcall(gray::_sym_stream_clear_output, stream);
 }
 
 void stream_finish_output(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    ansi_stream->finish_output();
+  if (stream.isA<AnsiStream_O>())
+    stream.as_unsafe<AnsiStream_O>()->finish_output();
   else
     eval::funcall(gray::_sym_stream_finish_output, stream);
 }
 
 void stream_force_output(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    ansi_stream->force_output();
+  if (stream.isA<AnsiStream_O>())
+    stream.as_unsafe<AnsiStream_O>()->force_output();
   else
     eval::funcall(gray::_sym_stream_force_output, stream);
 }
 
 bool stream_open_p(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->open_p() : T_sp(eval::funcall(gray::_sym_open_stream_p, stream)).notnilp();
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->open_p()
+                                    : T_sp(eval::funcall(gray::_sym_open_stream_p, stream)).notnilp();
 }
 
 bool stream_p(T_sp stream) {
@@ -5146,64 +5133,59 @@ bool stream_p(T_sp stream) {
 }
 
 bool stream_input_p(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->input_p() : T_sp(eval::funcall(gray::_sym_input_stream_p, stream)).notnilp();
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->input_p()
+                                    : T_sp(eval::funcall(gray::_sym_input_stream_p, stream)).notnilp();
 }
 
 bool stream_output_p(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->output_p() : T_sp(eval::funcall(gray::_sym_output_stream_p, stream)).notnilp();
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->output_p()
+                                    : T_sp(eval::funcall(gray::_sym_output_stream_p, stream)).notnilp();
 }
 
 bool stream_interactive_p(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->interactive_p() : T_sp(eval::funcall(gray::_sym_stream_interactive_p, stream)).notnilp();
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->interactive_p()
+                                    : T_sp(eval::funcall(gray::_sym_stream_interactive_p, stream)).notnilp();
 }
 
 T_sp stream_element_type(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->element_type() : eval::funcall(gray::_sym_stream_element_type, stream);
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->element_type()
+                                    : eval::funcall(gray::_sym_stream_element_type, stream);
 }
 
 T_sp stream_set_element_type(T_sp stream, T_sp type) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->set_element_type(type) : _lisp->_true();
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->set_element_type(type) : _lisp->_true();
 }
 
 T_sp stream_external_format(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->external_format() : (T_sp)kw::_sym_default;
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->external_format() : (T_sp)kw::_sym_default;
 }
 
 T_sp stream_set_external_format(T_sp stream, T_sp format) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->set_external_format(format) : (T_sp)kw::_sym_default;
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->set_external_format(format) : (T_sp)kw::_sym_default;
 }
 
 T_sp stream_length(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->length() : eval::funcall(gray::_sym_stream_file_length, stream);
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->length()
+                                    : eval::funcall(gray::_sym_stream_file_length, stream);
 }
 
 T_sp stream_position(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->position() : eval::funcall(gray::_sym_stream_file_position, stream);
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->position()
+                                    : eval::funcall(gray::_sym_stream_file_position, stream);
 }
 
 T_sp stream_set_position(T_sp stream, T_sp pos) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->set_position(pos) : eval::funcall(gray::_sym_stream_file_position, stream, pos);
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->set_position(pos)
+                                    : eval::funcall(gray::_sym_stream_file_position, stream, pos);
 }
 
 T_sp stream_string_length(T_sp stream, T_sp string) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->string_length(string) : nil<T_O>();
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->string_length(string) : nil<T_O>();
 }
 
 int stream_column(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  if (ansi_stream)
-    return ansi_stream->column();
+  if (stream.isA<AnsiStream_O>())
+    return stream.as_unsafe<AnsiStream_O>()->column();
 
   T_sp col = eval::funcall(gray::_sym_stream_line_column, stream);
   // negative columns represent NIL
@@ -5211,33 +5193,26 @@ int stream_column(T_sp stream) {
 }
 
 int stream_set_column(T_sp stream, int column) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->set_column(column) : column;
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->set_column(column) : column;
 }
 
-int stream_input_handle(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->input_handle() : -1;
-}
+int stream_input_handle(T_sp stream) { return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->input_handle() : -1; }
 
 int stream_output_handle(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->output_handle() : -1;
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->output_handle() : -1;
 }
 
 T_sp stream_close(T_sp stream, T_sp abort) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->close(abort) : eval::funcall(gray::_sym_close, stream, kw::_sym_abort, abort);
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->close(abort)
+                                    : eval::funcall(gray::_sym_close, stream, kw::_sym_abort, abort);
 }
 
 T_sp stream_pathname(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->pathname() : eval::funcall(gray::_sym_pathname, stream);
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->pathname() : eval::funcall(gray::_sym_pathname, stream);
 }
 
 T_sp stream_truename(T_sp stream) {
-  AnsiStream_sp ansi_stream = stream.asOrNull<AnsiStream_O>();
-  return ansi_stream ? ansi_stream->truename() : eval::funcall(gray::_sym_truename, stream);
+  return stream.isA<AnsiStream_O>() ? stream.as_unsafe<AnsiStream_O>()->truename() : eval::funcall(gray::_sym_truename, stream);
 }
 
 }; // namespace core

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -1093,7 +1093,7 @@ CL_DECLARE();
 CL_UNWIND_COOP(true);
 CL_DOCSTRING(R"dx(make_string_output_stream_from_string)dx");
 DOCGROUP(clasp);
-CL_DEFUN T_sp core__make_string_output_stream_from_string(T_sp s) {
+CL_DEFUN StringOutputStream_sp core__make_string_output_stream_from_string(T_sp s) {
   StringOutputStream_sp strm = StringOutputStream_O::create();
   bool stringp = cl__stringp(s);
   unlikely_if(!stringp || !gc::As<Array_sp>(s)->arrayHasFillPointerP()) {
@@ -1104,7 +1104,7 @@ CL_DEFUN T_sp core__make_string_output_stream_from_string(T_sp s) {
   return strm;
 }
 
-T_sp clasp_make_string_output_stream(cl_index line_length, bool extended) {
+StringOutputStream_sp clasp_make_string_output_stream(cl_index line_length, bool extended) {
 #ifdef CLASP_UNICODE
   T_sp s;
   if (extended) {
@@ -1123,7 +1123,7 @@ CL_DECLARE();
 CL_UNWIND_COOP(true);
 CL_DOCSTRING(R"dx(makeStringOutputStream)dx");
 DOCGROUP(clasp);
-CL_DEFUN T_sp cl__make_string_output_stream(Symbol_sp elementType) {
+CL_DEFUN StringOutputStream_sp cl__make_string_output_stream(Symbol_sp elementType) {
   int extended = 0;
   if (elementType == cl::_sym_base_char) {
     (void)0;
@@ -2104,7 +2104,7 @@ T_sp IOFileStream_O::close(T_sp abort) {
   return _lisp->_true();
 }
 
-T_sp IOFileStream_O::make(T_sp fname, int fd, StreamMode smm, gctools::Fixnum byte_size, int flags, T_sp external_format,
+IOFileStream_sp IOFileStream_O::make(T_sp fname, int fd, StreamMode smm, gctools::Fixnum byte_size, int flags, T_sp external_format,
                           T_sp tempName, bool created) {
   IOFileStream_sp stream = IOFileStream_O::create();
   stream->_temp_filename = tempName;
@@ -2749,8 +2749,8 @@ T_sp IOStreamStream_O::close(T_sp abort) {
   return _lisp->_true();
 }
 
-T_sp IOStreamStream_O::make(T_sp fname, FILE* f, StreamMode smm, gctools::Fixnum byte_size, int flags, T_sp external_format,
-                            T_sp tempName, bool created) {
+IOStreamStream_sp IOStreamStream_O::make(T_sp fname, FILE* f, StreamMode smm, gctools::Fixnum byte_size, int flags,
+                                         T_sp external_format, T_sp tempName, bool created) {
   IOStreamStream_sp stream = IOStreamStream_O::create();
   stream->_temp_filename = tempName;
   stream->_created = created;
@@ -2972,8 +2972,8 @@ void IOStreamStream_O::set_buffering_mode(T_sp mode) {
     setvbuf(_file, NULL, _IONBF, 0);
 }
 
-T_sp IOStreamStream_O::make(T_sp fname, int fd, StreamMode smm, gctools::Fixnum byte_size, int flags, T_sp external_format,
-                            T_sp tempName, bool created) {
+IOStreamStream_sp IOStreamStream_O::make(T_sp fname, int fd, StreamMode smm, gctools::Fixnum byte_size, int flags,
+                                         T_sp external_format, T_sp tempName, bool created) {
   const char* mode; /* file open mode */
   FILE* fp;         /* file pointer */
   switch (smm) {
@@ -3464,7 +3464,7 @@ T_sp clasp_open_stream(T_sp fn, StreamMode smm, T_sp if_exists, T_sp if_does_not
       UNREACHABLE();
     }
     output = IOStreamStream_O::make(fn, fp, smm, byte_size, flags, external_format, temp_name, created);
-    gc::As<IOStreamStream_sp>(output)->set_buffering_mode(byte_size ? kw::_sym_full : kw::_sym_line);
+    output.as_unsafe<IOStreamStream_O>()->set_buffering_mode(byte_size ? kw::_sym_full : kw::_sym_line);
   } else {
     output = IOFileStream_O::make(fn, f, smm, byte_size, flags, external_format, temp_name, created);
   }

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -2345,94 +2345,112 @@ SYMBOL_EXPORT_SC_(KeywordPkg, latin_1);
 SYMBOL_EXPORT_SC_(KeywordPkg, us_ascii);
 SYMBOL_EXPORT_SC_(ExtPkg, make_encoding);
 
-static int parse_external_format(T_sp tstream, T_sp format, int flags) {
-  FileStream_sp stream = gc::As_unsafe<FileStream_sp>(tstream);
+void FileStream_O::parse_external_format(T_sp format) {
   if (format == kw::_sym_default) {
     format = ext::_sym_STARdefault_external_formatSTAR->symbolValue();
   }
-  if ((format).consp()) {
-    flags = parse_external_format(stream, oCdr(format), flags);
+  if (format.consp()) {
+    parse_external_format(oCdr(format));
     format = oCar(format);
   }
   if (format == _lisp->_true()) {
 #ifdef CLASP_UNICODE
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UTF_8;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UTF_8;
 #else
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_DEFAULT_FORMAT;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_DEFAULT_FORMAT;
 #endif
+    return;
   }
   if (format == nil<T_O>()) {
-    return flags;
+    return;
   }
   if (format == kw::_sym_cr) {
-    return (flags | CLASP_STREAM_CR) & ~CLASP_STREAM_LF;
+    _flags = (_flags | CLASP_STREAM_CR) & ~CLASP_STREAM_LF;
+    return;
   }
   if (format == kw::_sym_lf) {
-    return (flags | CLASP_STREAM_LF) & ~CLASP_STREAM_CR;
+    _flags = (_flags | CLASP_STREAM_LF) & ~CLASP_STREAM_CR;
+    return;
   }
   if (format == kw::_sym_crlf) {
-    return flags | (CLASP_STREAM_CR + CLASP_STREAM_LF);
+    _flags = _flags | (CLASP_STREAM_CR + CLASP_STREAM_LF);
+    return;
   }
   if (format == kw::_sym_littleEndian) {
-    return flags | CLASP_STREAM_LITTLE_ENDIAN;
+    _flags = _flags | CLASP_STREAM_LITTLE_ENDIAN;
+    return;
   }
   if (format == kw::_sym_bigEndian) {
-    return flags & ~CLASP_STREAM_LITTLE_ENDIAN;
+    _flags = _flags & ~CLASP_STREAM_LITTLE_ENDIAN;
+    return;
   }
   if (format == kw::_sym_passThrough) {
 #ifdef CLASP_UNICODE
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_LATIN_1;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_LATIN_1;
 #else
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_DEFAULT_FORMAT;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_DEFAULT_FORMAT;
 #endif
+    return;
   }
 #ifdef CLASP_UNICODE
-PARSE_SYMBOLS:
   if (format == kw::_sym_utf_8) {
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UTF_8;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UTF_8;
+    return;
   }
   if (format == kw::_sym_ucs_2) {
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_2;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_2;
+    return;
   }
   if (format == kw::_sym_ucs_2be) {
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_2BE;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_2BE;
+    return;
   }
   if (format == kw::_sym_ucs_2le) {
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_2LE;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_2LE;
+    return;
   }
   if (format == kw::_sym_ucs_4) {
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_4;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_4;
+    return;
   }
   if (format == kw::_sym_ucs_4be) {
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_4BE;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_4BE;
+    return;
   }
   if (format == kw::_sym_ucs_4le) {
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_4LE;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_UCS_4LE;
+    return;
   }
   if (format == kw::_sym_iso_8859_1) {
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_ISO_8859_1;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_ISO_8859_1;
+    return;
   }
   if (format == kw::_sym_latin_1) {
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_LATIN_1;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_LATIN_1;
+    return;
   }
   if (format == kw::_sym_us_ascii) {
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_US_ASCII;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_US_ASCII;
+    return;
   }
   if (gc::IsA<HashTable_sp>(format)) {
-    stream->_format_table = format;
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_USER_FORMAT;
+    _format_table = format;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_USER_FORMAT;
+    return;
   }
   if (gc::IsA<Symbol_sp>(format)) {
     ASSERT(format.notnilp());
     format = eval::funcall(ext::_sym_make_encoding, format);
-    if (gc::IsA<Symbol_sp>(format))
-      goto PARSE_SYMBOLS;
-    stream->_format_table = format;
-    return (flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_USER_FORMAT;
+    if (gc::IsA<Symbol_sp>(format)) {
+      parse_external_format(format);
+      return;
+    }
+    _format_table = format;
+    _flags = (_flags & ~CLASP_STREAM_FORMAT) | CLASP_STREAM_USER_FORMAT;
+    return;
   }
 #endif
   FEerror("Unknown or unsupported external format: ~A", 1, format.raw_());
-  return CLASP_STREAM_DEFAULT_FORMAT;
 }
 
 T_sp FileStream_O::set_element_type(T_sp type) {
@@ -2450,7 +2468,7 @@ T_sp FileStream_O::set_external_format(T_sp format) {
     _flags &= ~CLASP_STREAM_SIGNED_BYTES;
     t = cl::_sym_UnsignedByte;
   }
-  _flags = parse_external_format(asSmartPtr(), format, _flags);
+  parse_external_format(format);
   switch (_flags & CLASP_STREAM_FORMAT) {
   case CLASP_STREAM_BINARY:
     // e.g. (T size) is not a valid type, use (UnsignedByte size)

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -1041,6 +1041,8 @@ T_sp FileStream_O::pathname() const { return cl__parse_namestring(_filename); }
 
 T_sp FileStream_O::truename() const { return cl__truename((_open && _temp_filename.notnilp()) ? _temp_filename : _filename); }
 
+T_sp StringStream_O::element_type() const { return _contents->element_type(); }
+
 T_sp StringStream_O::external_format() const {
 #ifdef CLASP_UNICODE
   return core__base_string_p(_contents) ? kw::_sym_latin_1 : kw::_sym_ucs_4;
@@ -1058,8 +1060,6 @@ claspCharacter StringOutputStream_O::write_char(claspCharacter c) {
   _contents->vectorPushExtend(clasp_make_character(c));
   return c;
 }
-
-T_sp StringOutputStream_O::element_type() const { return _contents->element_type(); }
 
 T_sp StringOutputStream_O::position() { return Integer_O::create((gc::Fixnum)(StringFillp(_contents))); }
 
@@ -1184,8 +1184,6 @@ ListenResult StringInputStream_O::listen() {
 }
 
 void StringInputStream_O::clear_input() {}
-
-T_sp StringInputStream_O::element_type() const { return _contents->element_type(); }
 
 T_sp StringInputStream_O::position() { return Integer_O::create((gc::Fixnum)_input_position); }
 
@@ -4135,15 +4133,14 @@ void StringOutputStream_O::fill(const string& data) { StringPushStringCharStar(t
 
 /*! Get the contents and reset them */
 void StringOutputStream_O::clear() {
-  _contents = Str8Ns_O::createBufferString(STRING_OUTPUT_STREAM_DEFAULT_SIZE);
+  SetStringFillp(_contents, 0);
   _column = 0;
 };
 
 /*! Get the contents and reset them */
 String_sp StringOutputStream_O::get_string() {
-  String_sp contents = _contents;
-  _contents = Str8Ns_O::createBufferString(STRING_OUTPUT_STREAM_DEFAULT_SIZE);
-  _column = 0;
+  String_sp contents = gc::As_unsafe<String_sp>(cl__copy_seq(_contents));
+  SetStringFillp(_contents, 0);
   return contents;
 };
 

--- a/src/core/pathname.cc
+++ b/src/core/pathname.cc
@@ -1176,7 +1176,7 @@ T_sp clasp_namestring(T_sp tx, int flags) {
    * or using clasp_make_pathname(). In all of these cases Clasp will complain
    * at creation time if the pathname has wrong components.
    */
-  T_sp buffer = clasp_make_string_output_stream(); //(128, 1);
+  StringOutputStream_sp buffer = clasp_make_string_output_stream(); //(128, 1);
   logical = core__logical_pathname_p(x);
   host = x->_Host;
   if (logical) {
@@ -1299,7 +1299,7 @@ NO_DIRECTORY:
       return nil<T_O>();
     }
   }
-  String_sp sbuffer = gc::As<String_sp>(cl__get_output_stream_string(buffer));
+  String_sp sbuffer = buffer->get_string();
 #ifdef CLASP_UNICODE
   if (core__extended_string_p(buffer) && (flags & CLASP_NAMESTRING_FORCE_BASE_STRING)) {
     unlikely_if(!core__fits_in_base_string(buffer)) FEerror("The filesystem does not accept filenames "

--- a/src/core/pathname.cc
+++ b/src/core/pathname.cc
@@ -1176,7 +1176,7 @@ T_sp clasp_namestring(T_sp tx, int flags) {
    * or using clasp_make_pathname(). In all of these cases Clasp will complain
    * at creation time if the pathname has wrong components.
    */
-  StringOutputStream_sp buffer = clasp_make_string_output_stream(); //(128, 1);
+  T_sp buffer = clasp_make_string_output_stream(); //(128, 1);
   logical = core__logical_pathname_p(x);
   host = x->_Host;
   if (logical) {
@@ -1299,7 +1299,7 @@ NO_DIRECTORY:
       return nil<T_O>();
     }
   }
-  String_sp sbuffer = buffer->get_string();
+  String_sp sbuffer = buffer.as<StringOutputStream_O>()->get_string();
 #ifdef CLASP_UNICODE
   if (core__extended_string_p(buffer) && (flags & CLASP_NAMESTRING_FORCE_BASE_STRING)) {
     unlikely_if(!core__fits_in_base_string(buffer)) FEerror("The filesystem does not accept filenames "

--- a/src/core/pathname.cc
+++ b/src/core/pathname.cc
@@ -894,29 +894,30 @@ CL_DEFUN Pathname_sp core__pathnameSTAR(T_sp x) {
     ERROR_WRONG_TYPE_ONLY_ARG(cl::_sym_pathname, x,
                               Cons_O::createList(cl::_sym_or, cl::_sym_fileStream, cl::_sym_string, cl::_sym_pathname));
   }
-L:
-  if (cl__stringp(x)) {
-    x = cl__parse_namestring(x);
-  } else if (gc::IsA<Pathname_sp>(x)) {
-    // do nothing
-  } else if ((gc::IsA<FileStream_sp>(x)) || (gc::IsA<SynonymStream_sp>(x))) {
-    // other streams don't have an associated pathname, no use return "-no-name-" here, SBCL says SynonymStream_sp also valid
-    x = clasp_filename(x);
-    goto L;
-  } else {
-    ERROR_WRONG_TYPE_ONLY_ARG(
-        cl::_sym_pathname, x,
-        Cons_O::createList(cl::_sym_or, cl::_sym_fileStream, cl::_sym_string, cl::_sym_pathname, cl::_sym_SynonymStream_O));
+
+  if (gc::IsA<Pathname_sp>(x))
+    return gc::As<Pathname_sp>(x);
+
+  if (cl__stringp(x))
+    return gc::As<Pathname_sp>(cl__parse_namestring(x));
+
+  if (stream_p(x)) {
+    T_sp pathname = stream_pathname(x);
+    if (cl__stringp(pathname))
+      pathname = cl__parse_namestring(pathname);
+    if (gc::IsA<Pathname_sp>(pathname))
+      return gc::As<Pathname_sp>(pathname);
   }
-  return gc::As<Pathname_sp>(x);
+
+  ERROR_WRONG_TYPE_ONLY_ARG(
+      cl::_sym_pathname, x,
+      Cons_O::createList(cl::_sym_or, cl::_sym_fileStream, cl::_sym_string, cl::_sym_pathname, cl::_sym_SynonymStream_O));
 }
 
 CL_DOCSTRING(R"dx(Returns the pathname denoted by pathspec. If the gray-streams module has been loaded
 then this function will be made generic.)dx")
 DOCGROUP(clasp);
-CL_DEFUN Pathname_sp cl__pathname(T_sp pathspec) {
-  return core__pathnameSTAR(pathspec);
-}
+CL_DEFUN Pathname_sp cl__pathname(T_sp pathspec) { return core__pathnameSTAR(pathspec); }
 
 CL_LAMBDA(x);
 CL_DECLARE();

--- a/src/core/unixfsys.cc
+++ b/src/core/unixfsys.cc
@@ -257,8 +257,8 @@ CL_DEFUN T_mv core__fork(bool bReturnStream) {
         close(filedes[1]);
         int flags = fcntl(filedes[0], F_GETFL, 0);
         fcntl(filedes[0], F_SETFL, flags | O_NONBLOCK);
-        T_sp stream = clasp_make_file_stream_from_fd(SimpleBaseString_O::make("execvp"), filedes[0], clasp_smm_input_file, 8,
-                                                     CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
+        T_sp stream = IOFileStream_O::make(SimpleBaseString_O::make("execvp"), filedes[0], stream_mode_input, 8,
+                                           CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
         return Values(nil<T_O>(), clasp_make_fixnum(child_PID), stream);
       }
       return Values(nil<T_O>(), clasp_make_fixnum(child_PID), nil<T_O>());
@@ -1989,8 +1989,8 @@ CL_DEFUN T_mv ext__vfork_execvp(List_sp call_and_arguments, T_sp return_stream) 
         if (bReturnStream) {
           int flags = fcntl(filedes[0], F_GETFL, 0);
           fcntl(filedes[0], F_SETFL, flags | O_NONBLOCK);
-          T_sp stream = clasp_make_file_stream_from_fd(SimpleBaseString_O::make("execvp"), filedes[0], clasp_smm_input_file, 8,
-                                                       CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
+          T_sp stream = IOFileStream_O::make(SimpleBaseString_O::make("execvp"), filedes[0], stream_mode_input, 8,
+                                             CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
 
           DEBUG_PRINT(BF("%s (%s:%d) | Values( %d %d %p )\n.") % __FUNCTION__ % __FILE__ % __LINE__ % 0 % child_PID % stream);
 
@@ -2082,8 +2082,8 @@ CL_DEFUN T_mv ext__fork_execvp(List_sp call_and_arguments, T_sp return_stream) {
         if (bReturnStream) {
           int flags = fcntl(filedes[0], F_GETFL, 0);
           fcntl(filedes[0], F_SETFL, flags | O_NONBLOCK);
-          T_sp stream = clasp_make_file_stream_from_fd(SimpleBaseString_O::make("execvp"), filedes[0], clasp_smm_input_file, 8,
-                                                       CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
+          T_sp stream = IOFileStream_O::make(SimpleBaseString_O::make("execvp"), filedes[0], stream_mode_input, 8,
+                                             CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
           return Values(nil<T_O>(), clasp_make_fixnum(child_PID), stream);
         }
         return Values(nil<T_O>(), clasp_make_fixnum(child_PID), nil<T_O>());

--- a/src/core/unixfsys.cc
+++ b/src/core/unixfsys.cc
@@ -883,6 +883,14 @@ CL_LAMBDA(filespec);
 CL_DECLARE();
 DOCGROUP(clasp);
 CL_DEFUN Pathname_sp core__truenameSTAR(T_sp filespec) {
+  if  (stream_p(filespec)) {
+    T_sp pathname = stream_truename(filespec);
+    if (cl__stringp(pathname))
+      pathname = cl__parse_namestring(pathname);
+    if (gc::IsA<Pathname_sp>(pathname))
+      return gc::As<Pathname_sp>(pathname);
+  }
+
   Pathname_sp pathname = make_absolute_pathname(filespec);
   Pathname_sp base_dir = make_base_pathname(pathname);
   Cons_sp dir;
@@ -910,9 +918,7 @@ CL_DECLARE();
 CL_DOCSTRING(R"dx(truename tries to find the file indicated by filespec and returns its truename.
 If the gray-streams module has been loaded then this function will be made generic.)dx");
 DOCGROUP(clasp);
-CL_DEFUN Pathname_sp cl__truename(T_sp filespec) {
-  return core__truenameSTAR(filespec);
-}
+CL_DEFUN Pathname_sp cl__truename(T_sp filespec) { return core__truenameSTAR(filespec); }
 
 int clasp_backup_open(const char* filename, int option, int mode) {
   stringstream sbackup;

--- a/src/core/unixsys.cc
+++ b/src/core/unixsys.cc
@@ -116,7 +116,7 @@ T_sp clasp_make_pipe() {
     T_sp fake_out_name = SimpleBaseString_O::make("PIPE-WRITE-ENDPOINT");
     T_sp in = IOStreamStream_O::make(fake_in_name, fds[0], stream_mode_input, 8, CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
     T_sp out = IOStreamStream_O::make(fake_out_name, fds[1], stream_mode_output, 8, CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
-    output = cl__make_two_way_stream(in, out);
+    output = TwoWayStream_O::make(in, out);
   }
   return output;
 #endif

--- a/src/core/unixsys.cc
+++ b/src/core/unixsys.cc
@@ -114,8 +114,8 @@ T_sp clasp_make_pipe() {
   } else {
     T_sp fake_in_name = SimpleBaseString_O::make("PIPE-READ-ENDPOINT");
     T_sp fake_out_name = SimpleBaseString_O::make("PIPE-WRITE-ENDPOINT");
-    T_sp in = clasp_make_stream_from_fd(fake_in_name, fds[0], clasp_smm_input, 8, CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
-    T_sp out = clasp_make_stream_from_fd(fake_out_name, fds[1], clasp_smm_output, 8, CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
+    T_sp in = IOStreamStream_O::make(fake_in_name, fds[0], stream_mode_input, 8, CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
+    T_sp out = IOStreamStream_O::make(fake_out_name, fds[1], stream_mode_output, 8, CLASP_STREAM_DEFAULT_FORMAT, nil<T_O>());
     output = cl__make_two_way_stream(in, out);
   }
   return output;

--- a/src/gctools/snapshotSaveLoad.cc
+++ b/src/gctools/snapshotSaveLoad.cc
@@ -2704,7 +2704,8 @@ void* snapshot_save_impl(void* data) {
 #ifdef USE_BOEHM
 //  printf("%s:%d:%s Not using GC_start_world_external();\n", __FILE__, __LINE__, __FUNCTION__ );
 #endif
-  if (snapshot_data->_Exit) exit(0);
+  if (snapshot_data->_Exit)
+    exit(0);
   return NULL;
 }
 
@@ -3367,7 +3368,8 @@ void snapshot_load(void* maybeStartOfSnapshot, void* maybeEndOfSnapshot, const s
               //
               core::T_sp tallocatedObjectFile = gctools::GCObjectAllocator<core::General_O>::snapshot_save_load_allocate(&init);
               llvmo::ObjectFile_sp allocatedObjectFile = gc::As<llvmo::ObjectFile_sp>(tallocatedObjectFile);
-//              printf("%s:%d:%s Allocated ObjectFile %p\n", __FILE__, __LINE__, __FUNCTION__, (void*)&*allocatedObjectFile );
+              //              printf("%s:%d:%s Allocated ObjectFile %p\n", __FILE__, __LINE__, __FUNCTION__,
+              //              (void*)&*allocatedObjectFile );
               allocatedObjectFile->_State = llvmo::RunState;
               DBG_OF(printf("%s:%d:%s About to pass LLJIT ObjectFile_O @ %p name: %s\n      loadedObjectFile->_Name: %s\n        "
                             "startupID: %lu  _ObjectFileOffset %lu  _ObjectFileSize %lu  of_start %p\n",
@@ -3395,8 +3397,11 @@ void snapshot_load(void* maybeStartOfSnapshot, void* maybeEndOfSnapshot, const s
                 printf("%s:%d:%s JITDylib* is NULL\n", __FILE__, __LINE__, __FUNCTION__);
                 abort();
               }
-//              printf("%s:%d:%s Allocated ObjectFile @%p before _LLJIT->addObjectFile...  _MemoryBuffer = %p\n", __FILE__, __LINE__, __FUNCTION__, (void*)&*allocatedObjectFile, (void*)allocatedObjectFile->_MemoryBuffer.get() );
-              ExitOnErr(obj_claspJIT->_LLJIT->addObjectFile(*jd, llvm::MemoryBuffer::getMemBuffer(allocatedObjectFile->_MemoryBuffer->getMemBufferRef())));
+              //              printf("%s:%d:%s Allocated ObjectFile @%p before _LLJIT->addObjectFile...  _MemoryBuffer = %p\n",
+              //              __FILE__, __LINE__, __FUNCTION__, (void*)&*allocatedObjectFile,
+              //              (void*)allocatedObjectFile->_MemoryBuffer.get() );
+              ExitOnErr(obj_claspJIT->_LLJIT->addObjectFile(
+                  *jd, llvm::MemoryBuffer::getMemBuffer(allocatedObjectFile->_MemoryBuffer->getMemBufferRef())));
 
               gctools::Tagged fwd =
                   (gctools::Tagged)gctools::untag_object<gctools::clasp_ptr_t>((gctools::clasp_ptr_t)allocatedObjectFile.raw_());
@@ -3434,7 +3439,9 @@ void snapshot_load(void* maybeStartOfSnapshot, void* maybeEndOfSnapshot, const s
                 DBG_OF(printf("%s:%d:%s Ran lookup of objectId: %lu name %s jitdylib %p in thread pool found = %d\n", __FILE__,
                               __LINE__, __FUNCTION__, objectId, start.c_str(), jitdylib.raw_(), found););
               });
-//              printf("%s:%d:%s Allocated ObjectFile @%p AFTER _LLJIT->addObjectFile...  _MemoryBuffer = %p\n", __FILE__, __LINE__, __FUNCTION__, (void*)&*allocatedObjectFile, (void*)allocatedObjectFile->_MemoryBuffer.get() );
+              //              printf("%s:%d:%s Allocated ObjectFile @%p AFTER _LLJIT->addObjectFile...  _MemoryBuffer = %p\n",
+              //              __FILE__, __LINE__, __FUNCTION__, (void*)&*allocatedObjectFile,
+              //              (void*)allocatedObjectFile->_MemoryBuffer.get() );
             }
           }
           next_header = cur_header->next(cur_header->_Kind);
@@ -3819,7 +3826,7 @@ void snapshot_load(void* maybeStartOfSnapshot, void* maybeEndOfSnapshot, const s
     comp::_sym_STARthread_safe_contextSTAR->defparameter(llvmo::ThreadSafeContext_O::create_thread_safe_context());
     comp::_sym_STARthread_local_builtins_moduleSTAR->defparameter(nil<core::T_O>());
     FILE* null_out = fopen("/dev/null", "w");
-    _lisp->_Roots._NullStream = core::IOStreamStream_O::makeIO("/dev/null", null_out);
+    _lisp->_Roots._NullStream = core::IOStreamStream_O::make(core::str_create("/dev/null"), null_out, core::stream_mode_io);
 
     //
     // Setup the pathname info for wherever the executable was loaded

--- a/src/lisp/kernel/clos/streams.lisp
+++ b/src/lisp/kernel/clos/streams.lisp
@@ -82,7 +82,7 @@
 (defgeneric input-stream-p (stream)
   (:documentation "Can STREAM perform input operations?"))
 
-(defgeneric stream-p (stream)
+(defgeneric streamp (stream)
   (:documentation "Is this object a STREAM?"))
 
 (defgeneric pathname (pathspec)
@@ -656,7 +656,7 @@ truename."))
 (defmethod stream-file-length ((stream t))
   (error 'type-error :datum stream :expected-type 'file-stream))
 
-;; STREAM-P
+;; STREAMP
 
 (defmethod streamp ((stream stream))
   (declare (ignore stream))

--- a/src/lisp/kernel/clos/streams.lisp
+++ b/src/lisp/kernel/clos/streams.lisp
@@ -105,6 +105,12 @@ truename."))
   defined for this function, although it is permissible for it to
   always return NIL."))
 
+(defgeneric stream-line-number (stream)
+  (:documentation
+   "Return the line number where the next character
+  will be written, or NIL if that is not meaningful for this stream.
+  The first line is numbered 0. The default method returns NIL."))
+
 ;; Extension from CMUCL, SBCL, Mezzano and SICL
 
 (defgeneric stream-line-length (stream)
@@ -447,6 +453,16 @@ truename."))
 
 (defmethod stream-line-column ((stream t))
   (bug-or-error stream 'stream-line-column))
+
+;; LINE-NUMBER
+
+(defmethod stream-line-number ((stream t))
+  nil)
+
+(defmethod stream-line-number ((stream ansi-stream))
+  (let ((column (sys:stream-line-number stream)))
+    (and (not (minusp column))
+         column)))
 
 ;; LINE-LENGTH
 

--- a/src/lisp/regression-tests/snapshot.lisp
+++ b/src/lisp/regression-tests/snapshot.lisp
@@ -1,5 +1,6 @@
 (in-package #:clasp-tests)
 
+#+use-precise-gc
 (test slad-snapshot
       (let ((binary (ext:argv 0))
             (snap-fname
@@ -30,6 +31,7 @@
                 (values dump-code nil)))))
       (0 89))
 
+#+use-precise-gc
 (test slad-executable
       (let ((binary (ext:argv 0))
             (snap-fname

--- a/src/llvmo/llvmoExpose.cc
+++ b/src/llvmo/llvmoExpose.cc
@@ -201,8 +201,7 @@ llvm::raw_pwrite_stream* llvm_stream(core::T_sp stream, llvm::SmallString<1024>&
     FILE* f = iostr->file();
     ostreamP = new llvm::raw_fd_ostream(fileno(f), false, true);
   } else if (core::SynonymStream_sp sstr = stream.asOrNull<core::SynonymStream_O>()) {
-    core::Symbol_sp sym = sstr->_SynonymSymbol;
-    return llvm_stream(sym->symbolValue(), stringOutput, stringOutputStream);
+    return llvm_stream(sstr->stream(), stringOutput, stringOutputStream);
   } else {
     SIMPLE_ERROR("Illegal file type {} for llvm_stream", _rep_(stream));
   }

--- a/src/sockets/sockets.cc
+++ b/src/sockets/sockets.cc
@@ -623,11 +623,8 @@ CL_LAMBDA(stream);
 CL_DECLARE();
 CL_DOCSTRING(R"dx(ll_autoCloseTwoWayStream)dx");
 DOCGROUP(clasp);
-CL_DEFUN void sockets_internal__ll_autoCloseTwoWayStream(core::Stream_sp stream) {
-#if 0
-	IMPLEMENT_MEF("Handle ECL_STREAM_CLOSE_COMPONENTS");
-	stream->stream.flags |= ECL_STREAM_CLOSE_COMPONENTS;
-#endif
+CL_DEFUN void sockets_internal__ll_autoCloseTwoWayStream(core::AnsiStream_sp stream) {
+  stream->_flags |= core::CLASP_STREAM_CLOSE_COMPONENTS;
 };
 
 CL_LAMBDA(num);

--- a/src/sockets/sockets.cc
+++ b/src/sockets/sockets.cc
@@ -615,7 +615,7 @@ CL_DEFUN core::T_sp sockets_internal__ll_makeStreamFromFd(const string& name,   
   }
   }
   core::Stream_sp stream = gc::As_unsafe<core::Stream_sp>(
-      core::IOFileStream_O::make(core::str_create(name), fd, direction, elementType, externalFormat));
+      core::IOStreamStream_O::make(core::str_create(name), fd, direction, elementType, externalFormat));
   return stream;
 }
 

--- a/src/sockets/sockets.cc
+++ b/src/sockets/sockets.cc
@@ -602,20 +602,20 @@ CL_DEFUN core::T_sp sockets_internal__ll_makeStreamFromFd(const string& name,   
   core::StreamMode direction;
   switch (streamMode) {
   case core::clasp_stream_mode_input:
-    direction = core::clasp_smm_input;
+    direction = core::stream_mode_input;
     break;
   case core::clasp_stream_mode_output:
-    direction = core::clasp_smm_output;
+    direction = core::stream_mode_output;
     break;
   case core::clasp_stream_mode_io:
-    direction = core::clasp_smm_io;
+    direction = core::stream_mode_io;
     break;
   default: {
     SIMPLE_ERROR("Illegal stream mode {}", streamMode);
   }
   }
-  core::Stream_sp stream =
-      gc::As_unsafe<core::Stream_sp>(core::IOFileStream_O::make(name, fd, direction, elementType, externalFormat));
+  core::Stream_sp stream = gc::As_unsafe<core::Stream_sp>(
+      core::IOFileStream_O::make(core::str_create(name), fd, direction, elementType, externalFormat));
   return stream;
 }
 


### PR DESCRIPTION
1. Add specific enum for listen return
2. Fix generic pathname and truename so that things like PATHNAME-TYPE work on closed streams
3. Move fields that are not needed in AnsiStream_O into FileStream_O
4. Add as_unsafe and as_assert methods to smart_ptr
5. Use snake case in field names for streams
6. Add line number tracking
7. Convert more functions into class static or methods