### PR TITLE
Fix build with musl libc

### DIFF
--- a/include/clasp/gctools/memoryManagement.h
+++ b/include/clasp/gctools/memoryManagement.h
@@ -22,9 +22,6 @@
 // Define compile-time flags that effect structure sizes
 //
 #include <atomic>
-#ifdef DEBUG_GUARD_BACKTRACE
-#include <execinfo.h>
-#endif
 #include <clasp/gctools/configure_memory.h>
 #include <clasp/gctools/hardErrors.h>
 

--- a/src/core/backtrace.cc
+++ b/src/core/backtrace.cc
@@ -675,7 +675,7 @@ __attribute__((optnone)) static T_mv lu_call_with_frame(std::function<T_mv(Debug
   // is a pain in the ass for very little gain.
   std::string sstring = lu_procname(&cursor)->get_std_string();
   int fi(0);
-  DebuggerFrame_sp bot = make_frame(fi++, (void*)ip, sstring.c_str(), (void*)fbp);
+  DebuggerFrame_sp bot = make_frame(fi++, (void*)ip, sstring.c_str(), (void*)fbp, bytecode_pc, bytecode_fp);
   DebuggerFrame_sp prev = bot;
   while (unw_step(&cursor) > 0) {
     resip = unw_get_reg(&cursor, UNW_REG_IP, &ip);

--- a/src/core/debug_macosx.cc
+++ b/src/core/debug_macosx.cc
@@ -26,7 +26,6 @@ THE SOFTWARE.
 /* -^- */
 
 #include <csignal>
-#include <execinfo.h>
 #include <dlfcn.h>
 #include <clasp/core/foundation.h>
 #include <clasp/core/object.h>

--- a/src/core/debug_unixes.cc
+++ b/src/core/debug_unixes.cc
@@ -27,7 +27,6 @@ THE SOFTWARE.
 
 #include <csignal>
 #include <iostream>
-#include <execinfo.h>
 #include <dlfcn.h>
 #include <clasp/core/foundation.h>
 #include <clasp/core/object.h>

--- a/src/core/debugger.cc
+++ b/src/core/debugger.cc
@@ -28,7 +28,6 @@ THE SOFTWARE.
 #define DEBUG_LEVEL_FULL
 
 #include <csignal>
-#include <execinfo.h>
 #include <iomanip>
 #include <clasp/core/foundation.h>
 #include <dlfcn.h>

--- a/src/core/foundation.cc
+++ b/src/core/foundation.cc
@@ -1635,7 +1635,7 @@ void maybe_register_symbol_using_dladdr_ep(void* functionPointer, size_t size, c
         return; // This means it's a virtual method.
       global_pointerCount++;
       Dl_info info;
-#if defined(_TARGET_OS_LINUX)
+#ifdef RTLD_DL_SYMENT
       const Elf64_Sym* extra_info;
       int ret = dladdr1(functionPointer, &info, (void**)&extra_info, RTLD_DL_SYMENT);
 #else

--- a/src/core/hashTable.cc
+++ b/src/core/hashTable.cc
@@ -95,7 +95,11 @@ THE SOFTWARE.
 #include <clasp/core/weakHashTable.h>
 #include <clasp/core/wrappers.h>
 #ifdef CLASP_THREADS
+#ifdef _TARGET_OS_LINUX
+#include <sched.h>
+#else
 #include <pthread.h>
+#endif
 #endif
 namespace core {
 
@@ -1121,7 +1125,9 @@ KeyValuePair* HashTable_O::rehash_upgrade_write_lock(bool expandTable, T_sp find
       this->_Mutex->write_unlock(false /*releaseReadLock*/);
       return result;
     }
-#ifdef _TARGET_OS_DARWIN
+#if defined(_TARGET_OS_LINUX)
+    sched_yield();
+#elif defined(_TARGET_OS_DARWIN)
     pthread_yield_np();
 #else
     pthread_yield();

--- a/src/gctools/gcFunctions.cc
+++ b/src/gctools/gcFunctions.cc
@@ -16,7 +16,6 @@ extern "C" {
 int gcFunctions_after;
 
 #include <stdint.h>
-#include <execinfo.h>
 #include <unistd.h>
 #include <sstream>
 #include <iomanip>

--- a/src/gctools/threadlocal.cc
+++ b/src/gctools/threadlocal.cc
@@ -6,7 +6,6 @@
 #include <sys/types.h>
 #include <sys/mman.h>
 #include <signal.h>
-#include <execinfo.h>
 #include <clasp/core/foundation.h>
 #include <clasp/gctools/threadlocal.h>
 #include <clasp/core/lisp.h>

--- a/src/main/main.cc
+++ b/src/main/main.cc
@@ -45,7 +45,9 @@ THE SOFTWARE.
 #include <signal.h>
 #include <sys/resource.h>
 #include <libgen.h>
+#ifndef USE_LIBUNWIND
 #include <execinfo.h>
+#endif
 #include <cxxabi.h>
 #endif
 
@@ -117,6 +119,7 @@ void initialize_llvm(int argc, char** argv);
 
 // PRINT STACKTRACE PROGRAMMICALLY
 
+#ifndef USE_LIBUNWIND
 static inline void print_stacktrace(FILE* out = stderr, unsigned int max_frames = 63) {
   fprintf(out, "stack trace:\n");
 
@@ -185,6 +188,7 @@ static inline void print_stacktrace(FILE* out = stderr, unsigned int max_frames 
   free(funcname);
   free(symbollist);
 }
+#endif
 
 // ABORT FLAG HANDLING
 

--- a/src/sockets/sockets.cc
+++ b/src/sockets/sockets.cc
@@ -30,6 +30,12 @@ THE SOFTWARE.
 #include <sys/un.h>
 #include <sys/time.h>
 #include <netdb.h>
+#ifndef NETDB_INTERNAL
+#define NETDB_INTERNAL (-1)
+#endif
+#ifndef NETDB_SUCCESS
+#define NETDB_SUCCESS (0)
+#endif
 #include <string.h>
 #include <unistd.h>
 #include <netinet/in.h>


### PR DESCRIPTION
Specifically, this fixes the build on Chimera Linux, which uses musl and clang, and has no gcc. Some additional changes are necessary for Clasp to actually build on Chimera Linux which I have not included in this PR, namely adding a definition for USE_LIBUNWIND in src/koga/header.lisp, removing -stdlib=libstdc++ from cflags and adding -lucontext to ldflags. Probably these fixes should be added as options to koga, e.g., --use-libunwind (or is this what the currently unused --unwinder option is for?), --stdlib=libc++|libstdc++ and --use-libucontext. I can add this is another PR if you tell me what options you would prefer.

In src/core/hashTable.cc, pthread_yield is used even if CLASP_THREADS is undefined. Since checking for CLASP_THREADS might be missing from more places than just the pthread_yield call, I did not try fixing this.

In src/main/main.cc, the print_stacktrace function is unused, but I assumed you might be keeping it for possible future use, or debugging, so I left it there though defined only if USE_LIBUNWIND is undefined.

Finally, when applied to tag 2.5.0 these changes build successfully, but on main the build fails with the following error:

```
; Compiling file: SYS:SRC;LISP;KERNEL;LSP;NUMLIB.LISP
; caught ERROR:
;   ERROR while evaluating compiler-time side effect:
;     Cannot modify value of constant COMMON-LISP::SHORT-FLOAT-EPSILON
;     at SYS:SRC;LISP;KERNEL;LSP;NUMLIB.LISP 35:0
;
Condition of type: EVAL-ERROR
ERROR while evaluating compiler-time side effect:
  Cannot modify value of constant COMMON-LISP::SHORT-FLOAT-EPSILON
   0: <unknown libunwind error>
   1: _ZN4core15call_with_frameENSt3__18functionIFN7gctools15multiple
   2: _ZN4core21core__call_with_frameEN7gctools9smart_ptrINS_10Functi
   3: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
   4: CLASP-DEBUG:CALL-WITH-STACK
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/debug.lisp:272
   5: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
   6: CLASP-DEBUG:PRINT-BACKTRACE
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/conditions.lisp:1481
   7: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
   8: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
   9: NON-DEBUGGER
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/top.lisp:994
  10: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  11: INVOKE-DEBUGGER
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/top.lisp:1004
  12: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  13: (LAMBDA ())
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/conditions.lisp:1360
  14: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  15: CLASP-DEBUG::CALL-WITH-TRUNCATED-STACK
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/debug.lisp:227
  16: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  17: UNIVERSAL-ERROR-HANDLER
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/conditions.lisp:1360
  18: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJPNS_3T_
  19: <unknown libunwind error>
  20: <unknown libunwind error>
  21: _ZN6clbind24WRAPPER_VariadicFunctionIPFvN7gctools9smart_ptrIN4c
  22: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  23: ERROR
    |---> SYS:SRC;CORE;LISP.CC:1914
  24: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  25: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  26: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  27: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  28: (LAMBDA (CONDITION))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/conditions.lisp:352
  29: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  30: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  31: %SIGNAL
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/conditions.lisp:390
  32: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  33: (LAMBDA ())
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/conditions.lisp:1360
  34: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  35: CLASP-DEBUG::CALL-WITH-TRUNCATED-STACK
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/debug.lisp:227
  36: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  37: UNIVERSAL-ERROR-HANDLER
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/conditions.lisp:1360
  38: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJPNS_3T_
  39: <unknown libunwind error>
  40: <unknown libunwind error>
  41: _ZN6clbind24WRAPPER_VariadicFunctionIPFvN7gctools9smart_ptrIN4c
  42: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  43: ERROR
    |---> SYS:SRC;CORE;LISP.CC:1914
  44: _ZN4core17apply4_inner_listEN7gctools9smart_ptrINS_10Function_O
  45: _ZN6clbind24WRAPPER_VariadicFunctionIPFN7gctools15multiple_valu
  46: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  47: APPLY4
    |---> SYS:SRC;CORE;EVALUATOR.CC:600
  48: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  49: SIGNAL-SIMPLE-ERROR
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/conditions.lisp:1216
  50: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJPNS_3T_
  51: _ZN4core17lisp_error_simpleEPKcS1_iRKNSt3__112basic_stringIcNS2
  52: _ZN4core7cl__setEN7gctools9smart_ptrINS_8Symbol_OEEENS1_INS_3T_
  53: _ZN6clbind24WRAPPER_VariadicFunctionIPFN7gctools9smart_ptrIN4co
  54: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  55: (LAMBDA ())
    |---> SYS:SRC;LISP;KERNEL;LSP;NUMLIB.LISP:35
  56: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  57: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  58: (LAMBDA (CLASP-CLEAVIR::CST CLASP-CLEAVIR::ENV))
    |---> /home/paul/external/clasp/src/lisp/kernel/cleavir/setup.lisp:454
  59: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  60: (LAMBDA (CLASP-CLEAVIR::CST CLASP-CLEAVIR::ENV))
    |---> /home/paul/external/clasp/src/lisp/kernel/cleavir/toplevel.lisp:95
  61: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  62: (LAMBDA
    (&OPTIONAL CLASP-CLEAVIR::EXPANSION CLASP-CLEAVIR::EXPANDEDP
     &REST #:G53623))
    |---> /home/paul/external/clasp/src/lisp/kernel/cleavir/toplevel.lisp:95
  63: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  64: (LAMBDA (CLASP-CLEAVIR::CST CLASP-CLEAVIR::ENV))
    |---> /home/paul/external/clasp/src/lisp/kernel/cleavir/toplevel.lisp:95
  65: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  66: CLASP-CLEAVIR::SIMPLE-EVAL-CST
    |---> /home/paul/external/clasp/src/lisp/kernel/cleavir/toplevel.lisp:95
  67: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  68: (METHOD CLEAVIR-ENVIRONMENT:CST-EVAL
 (T T CLASP-CLEAVIR:CLASP-GLOBAL-ENVIRONMENT T))
    |---> /home/paul/external/clasp/src/lisp/kernel/cleavir/setup.lisp:454
  69: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
  70: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  71: (METHOD CLEAVIR-ENVIRONMENT:CST-EVAL (T T NULL T))
    |---> /home/paul/external/clasp/src/lisp/kernel/cleavir/setup.lisp:465
  72: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
  73: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  74: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  75: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  76: CLEAVIR-CST-TO-AST::CST-EVAL
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/utilities.lisp:91
  77: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  78: (METHOD CLEAVIR-CST-TO-AST:CST-EVAL-FOR-EFFECT (T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/utilities.lisp:96
  79: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
  80: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  81: (METHOD CLEAVIR-CST-TO-AST:CONVERT-SPECIAL (:BEFORE) (T T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert-special.lisp:3
  82: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  83: CLOS::EFFECTIVE-METHOD-FUNCTION.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/queue.lisp:49
  84: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
  85: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  86: (METHOD CLEAVIR-CST-TO-AST::CONVERT-CST
 (T CLEAVIR-ENVIRONMENT:SPECIAL-OPERATOR-INFO T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert-cst.lisp:27
  87: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
  88: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  89: (METHOD CLEAVIR-CST-TO-AST:CONVERT (T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert.lisp:3
  90: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  91: CLOS::EFFECTIVE-METHOD-FUNCTION.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/queue.lisp:49
  92: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  93: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  94: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  95: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  96: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  97: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
  98: (METHOD CLEAVIR-CST-TO-AST:CONVERT (:AROUND) (T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert.lisp:32
  99: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJPNS_3T_
 100: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 101: CLOS::EMF-FROM-CONTF.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/combin.lisp:66
 102: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
 103: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 104: CLEAVIR-CST-TO-AST::CONVERT-SEQUENCE
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert-sequence.lisp:3
 105: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 106: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 107: (METHOD CLEAVIR-CST-TO-AST:CONVERT-SPECIAL ((EQL 'EVAL-WHEN) T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert-special.lisp:84
 108: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 109: CLOS::EFFECTIVE-METHOD-FUNCTION.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/queue.lisp:49
 110: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
 111: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 112: (METHOD CLEAVIR-CST-TO-AST::CONVERT-CST
 (T CLEAVIR-ENVIRONMENT:SPECIAL-OPERATOR-INFO T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert-cst.lisp:27
 113: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
 114: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 115: (METHOD CLEAVIR-CST-TO-AST:CONVERT (T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert.lisp:3
 116: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 117: CLOS::EFFECTIVE-METHOD-FUNCTION.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/queue.lisp:49
 118: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 119: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 120: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 121: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 122: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 123: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 124: (METHOD CLEAVIR-CST-TO-AST:CONVERT (:AROUND) (T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert.lisp:32
 125: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJPNS_3T_
 126: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 127: CLOS::EMF-FROM-CONTF.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/combin.lisp:66
 128: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
 129: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 130: CLEAVIR-CST-TO-AST::CONVERT-SEQUENCE
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert-sequence.lisp:3
 131: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 132: (METHOD CLEAVIR-CST-TO-AST:CONVERT-SPECIAL ((EQL 'PROGN) T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert-special.lisp:440
 133: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 134: CLOS::EFFECTIVE-METHOD-FUNCTION.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/queue.lisp:49
 135: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
 136: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 137: (METHOD CLEAVIR-CST-TO-AST::CONVERT-CST
 (T CLEAVIR-ENVIRONMENT:SPECIAL-OPERATOR-INFO T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert-cst.lisp:27
 138: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
 139: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 140: (METHOD CLEAVIR-CST-TO-AST:CONVERT (T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert.lisp:3
 141: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 142: CLOS::EFFECTIVE-METHOD-FUNCTION.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/queue.lisp:49
 143: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 144: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 145: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 146: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 147: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 148: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 149: (METHOD CLEAVIR-CST-TO-AST:CONVERT (:AROUND) (T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert.lisp:32
 150: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJPNS_3T_
 151: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 152: CLOS::EMF-FROM-CONTF.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/combin.lisp:66
 153: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
 154: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 155: (METHOD CLEAVIR-CST-TO-AST::CONVERT-CST
 (T CLEAVIR-ENVIRONMENT:GLOBAL-MACRO-INFO T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert-cst.lisp:55
 156: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
 157: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 158: (METHOD CLEAVIR-CST-TO-AST:CONVERT (T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert.lisp:3
 159: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 160: CLOS::EFFECTIVE-METHOD-FUNCTION.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/queue.lisp:49
 161: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 162: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 163: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 164: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 165: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 166: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 167: (METHOD CLEAVIR-CST-TO-AST:CONVERT (:AROUND) (T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert.lisp:32
 168: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJPNS_3T_
 169: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 170: CLOS::EMF-FROM-CONTF.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/combin.lisp:66
 171: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
 172: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 173: (METHOD CLEAVIR-CST-TO-AST::CONVERT-CST
 (T CLEAVIR-ENVIRONMENT:GLOBAL-MACRO-INFO T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert-cst.lisp:55
 174: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
 175: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 176: (METHOD CLEAVIR-CST-TO-AST:CONVERT (T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert.lisp:3
 177: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 178: CLOS::EFFECTIVE-METHOD-FUNCTION.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/queue.lisp:49
 179: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 180: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 181: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 182: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 183: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 184: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 185: (METHOD CLEAVIR-CST-TO-AST:CONVERT (:AROUND) (T T T))
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/convert.lisp:32
 186: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJPNS_3T_
 187: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 188: CLOS::EMF-FROM-CONTF.LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/clos/combin.lisp:66
 189: core::GFBytecodeEntryPoint::entry_point_n(core::T_O*, unsigned long, core::T_O**)
 190: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 191: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 192: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 193: CLEAVIR-CST-TO-AST:CST-TO-AST
    |---> /home/paul/external/clasp/src/lisp/kernel/contrib/Cleavir/CST-to-AST/cst-to-ast.lisp:8
 194: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 195: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 196: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 197: CLASP-CLEAVIR::CST->AST
    |---> /home/paul/external/clasp/src/lisp/kernel/cleavir/translate.lisp:2081
 198: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 199: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 200: CLASP-CLEAVIR::COMPILE-FILE-CST
    |---> /home/paul/external/clasp/src/lisp/kernel/cleavir/translate.lisp:2239
 201: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 202: (LAMBDA ())
    |---> /home/paul/external/clasp/src/lisp/kernel/cleavir/translate.lisp:2246
 203: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 204: UNWIND-PROTECTED-LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/claspmacros.lisp:180
 205: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJEEEN7gc
 206: <unknown libunwind error>
 207: _ZN4core21core__funwind_protectEN7gctools9smart_ptrINS_3T_OEEES
 208: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 209: DO-MEMORY-RAMP
    |---> /home/paul/external/clasp/src/lisp/kernel/lsp/claspmacros.lisp:180
 210: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 211: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 212: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 213: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 214: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 215: CLASP-CLEAVIR::BIR-LOOP-READ-AND-COMPILE-FILE-FORMS
    |---> /home/paul/external/clasp/src/lisp/kernel/cleavir/translate.lisp:2246
 216: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 217: COMPILER::LOOP-READ-AND-COMPILE-FILE-FORMS
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:158
 218: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 219: (LAMBDA ())
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:165
 220: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 221: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 222: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 223: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 224: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 225: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 226: LITERAL::DO-LITERAL-TABLE
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/cmpliteral.lisp:730
 227: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 228: (LAMBDA (COMPILER::RUN-ALL-FUNCTION))
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:165
 229: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 230: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 231: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 232: (LAMBDA ())
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/cmprunall.lisp:43
 233: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 234: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 235: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 236: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 237: (LAMBDA (&OPTIONAL FILE-SCOPE COMPILER::FILE-HANDLE &REST #:G9208))
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/debuginfo.lisp:198
 238: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 239: COMPILER::DO-DBG-FUNCTION
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/debuginfo.lisp:198
 240: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 241: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 242: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 243: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 244: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 245: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 246: COMPILER::DO-MAKE-NEW-RUN-ALL
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/cmprunall.lisp:43
 247: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 248: (LAMBDA ())
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:165
 249: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 250: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 251: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 252: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 253: UNWIND-PROTECTED-LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:165
 254: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJEEEN7gc
 255: <unknown libunwind error>
 256: _ZN4core21core__funwind_protectEN7gctools9smart_ptrINS_3T_OEEES
 257: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 258: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 259: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 260: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 261: COMPILER::COMPILE-STREAM-TO-MODULE
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:165
 262: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 263: (LAMBDA ())
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:290
 264: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 265: COMPILER::DO-COMPILER-TIMER
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:38
 266: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 267: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 268: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 269: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 270: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 271: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 272: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 273: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 274: COMPILER::DO-COMPILER-TIMER
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:38
 275: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 276: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 277: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 278: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 279: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 280: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 281: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 282: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 283: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 284: COMPILER::COMPILE-STREAM/SERIAL
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:290
 285: _ZN4core17apply2_inner_listEN7gctools9smart_ptrINS_10Function_O
 286: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 287: (LAMBDA ())
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:214
 288: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 289: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 290: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 291: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 292: COMPILER::CALL-WITH-COMPILATION-RESULTS
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compiler-conditions.lisp:344
 293: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 294: UNWIND-PROTECTED-LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:214
 295: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJEEEN7gc
 296: <unknown libunwind error>
 297: _ZN4core21core__funwind_protectEN7gctools9smart_ptrINS_3T_OEEES
 298: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 299: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 300: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 301: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 302: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 303: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 304: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 305: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 306: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 307: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 308: (LAMBDA ())
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:214
 309: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 310: UNWIND-PROTECTED-LAMBDA
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compiler-conditions.lisp:357
 311: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJEEEN7gc
 312: <unknown libunwind error>
 313: _ZN4core21core__funwind_protectEN7gctools9smart_ptrINS_3T_OEEES
 314: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 315: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 316: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 317: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 318: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 319: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 320: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 321: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 322: COMPILER::DO-COMPILATION-UNIT
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compiler-conditions.lisp:357
 323: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 324: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 325: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 326: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 327: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 328: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 329: COMPILE-FILE
    |---> /home/paul/external/clasp/src/lisp/kernel/cmp/compile-file.lisp:214
 330: _ZN4core16apply_inner_listEN7gctools9smart_ptrINS_10Function_OE
 331: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 332: APPLY
    |---> SYS:SRC;CORE;EVALUATOR.CC:500
 333: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 334: COMPILE-KERNEL-FILE
    |---> /home/paul/external/clasp/src/lisp/kernel/clasp-builder.lisp:82
 335: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 336: (LAMBDA (&OPTIONAL FAIL ERRNO &REST #:G35))
    |---> /home/paul/external/clasp/src/lisp/kernel/clasp-builder.lisp:129
 337: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 338: (LAMBDA (&OPTIONAL MAYBE-ERROR PID CHILD-STREAM &REST #:G34))
    |---> /home/paul/external/clasp/src/lisp/kernel/clasp-builder.lisp:129
 339: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 340: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 341: COMPILE-SYSTEM-PARALLEL
    |---> /home/paul/external/clasp/src/lisp/kernel/clasp-builder.lisp:129
 342: _ZN4core16apply_inner_listEN7gctools9smart_ptrINS_10Function_OE
 343: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 344: APPLY
    |---> SYS:SRC;CORE;EVALUATOR.CC:500
 345: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 346: COMPILE-SYSTEM
    |---> /home/paul/external/clasp/src/lisp/kernel/clasp-builder.lisp:219
 347: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 348: COMPILE-CLASP
    |---> /home/paul/external/clasp/src/lisp/kernel/clasp-builder.lisp:417
 349: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 350: LOAD-AND-COMPILE-CLASP
    |---> /home/paul/external/clasp/src/lisp/kernel/clasp-builder.lisp:434
 351: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 352: (LAMBDA ())
    |---> /home/paul/external/clasp/build/compile-clasp.lisp:4
 353: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJEEEN7gc
 354: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 355: COMPILER:BYTECODE-TOPLEVEL-EVAL
    |---> SYS:SRC;CORE;BYTECODE-COMPILER.CC:2825
 356: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJPNS_3T_
 357: core::load_stream(gctools::smart_ptr<core::T_O>, bool)
 358: core::core__load_source(gctools::smart_ptr<core::T_O>, bool, bool, gctools::smart_ptr<core::T_O>)
 359: _ZN6clbind24WRAPPER_VariadicFunctionIPFN7gctools9smart_ptrIN4co
 360: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 361: LOAD-SOURCE
    |---> SYS:SRC;CORE;LOAD.CC:77
 362: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJPNS_3T_
 363: _ZN4core25core__load_no_package_setEN7gctools9smart_ptrINS_3T_O
 364: core::cl__load(gctools::smart_ptr<core::T_O>, gctools::smart_ptr<core::T_O>, gctools::smart_ptr<core::T_O>, gctools::smart_ptr<core::T_O>, gctools::smart_ptr<core::T_O>, gctools::smart_ptr<core::T_O>)
 365: _ZN6clbind24WRAPPER_VariadicFunctionIPFN7gctools9smart_ptrIN4co
 366: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 367: LOAD
    |---> SYS:SRC;CORE;LOAD.CC:254
 368: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 369: (LAMBDA (ENTRY))
    |---> /home/paul/external/clasp/src/lisp/kernel/init.lisp:865
 370: _ZN4core10cl__mapcarEN7gctools9smart_ptrINS_3T_OEEENS1_INS_6Lis
 371: _ZN6clbind24WRAPPER_VariadicFunctionIPFN7gctools9smart_ptrIN4co
 372: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 373: MAPCAR
    |---> SYS:SRC;CORE;PRIMITIVES.CC:1314
 374: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 375: PROCESS-COMMAND-LINE-LOAD-EVAL-SEQUENCE
    |---> /home/paul/external/clasp/src/lisp/kernel/init.lisp:865
 376: _ZN4core11bytecode_vmERNS_14VirtualMachineEPPNS_3T_OES4_PNS_9Cl
 377: INIT-TOPLEVEL
    |---> /home/paul/external/clasp/src/lisp/kernel/init.lisp:921
 378: _ZN4core25BytecodeClosureEntryPoint17entry_point_fixedIJEEEN7gc
 379: core::Lisp::run()
 380: run_clasp
 381: main
Unhandled condition with debugger disabled, quitting
;
; compilation unit aborted
;   caught 1 ERROR condition
;
The child with wpid 18712 exited with status 1.
```