### PR TITLE
Reform from object

### DIFF
--- a/include/clasp/asttooling/clangTooling.h
+++ b/include/clasp/asttooling/clangTooling.h
@@ -74,9 +74,7 @@ public:
     core::T_sp obj = core::eval::funcall(_sym_CreateASTConsumer, this->asSmartPtr(),
                                          translate::to_object<clang::CompilerInstance&>::convert(Compiler),
                                          translate::to_object<llvm::StringRef>::convert(InFile));
-    // translate::from_object<std::unique_ptr<clang::ASTConsumer>> result(obj);
-    // return result._v;
-    return translate::from_object<std::unique_ptr<clang::ASTConsumer>>(obj)._v;
+    return translate::make_from_object<std::unique_ptr<clang::ASTConsumer>>(obj);
   }
 
   std::unique_ptr<clang::ASTConsumer> default_CreateASTConsumer(clang::CompilerInstance& Compiler, llvm::StringRef InFile) {
@@ -98,7 +96,7 @@ public:
     core::T_sp obj = core::eval::funcall(_sym_CreateASTConsumer, this->asSmartPtr(),
                                          translate::to_object<clang::CompilerInstance&>::convert(Compiler),
                                          translate::to_object<llvm::StringRef>::convert(InFile));
-    return translate::from_object<std::unique_ptr<clang::ASTConsumer>>(obj)._v;
+    return translate::make_from_object<std::unique_ptr<clang::ASTConsumer>>(obj);
   }
 
   std::unique_ptr<clang::ASTConsumer> default_CreateASTConsumer(clang::CompilerInstance& Compiler, llvm::StringRef InFile) {
@@ -118,8 +116,8 @@ class DerivableFrontendActionFactory : public clbind::Derivable<clang::tooling::
 public:
   virtual std::unique_ptr<clang::FrontendAction> create() {
     core::T_sp obj = core::eval::funcall(_sym_create, this->asSmartPtr());
-    translate::from_object<clang::FrontendAction*> result(obj);
-    std::unique_ptr<clang::FrontendAction> ret(result._v);
+    auto result = translate::make_from_object<clang::FrontendAction*>(obj);
+    std::unique_ptr<clang::FrontendAction> ret(result);
     return ret;
   }
 

--- a/include/clasp/asttooling/translators.h
+++ b/include/clasp/asttooling/translators.h
@@ -130,7 +130,7 @@ template <> struct to_object<std::map<std::string, clang::tooling::Replacements>
   }
 };
 
-template <> struct from_object<clang::QualType, std::true_type> {
+template <> struct from_object<clang::QualType> {
   typedef clang::QualType DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(gc::As<asttooling::QualType_sp>(o)->_Value._value) {
@@ -160,7 +160,7 @@ template <> struct to_object<clang::QualType, translate::adopt_pointer> {
   }
 };
 
-template <> struct from_object<clang::PresumedLoc, std::true_type> {
+template <> struct from_object<clang::PresumedLoc> {
   typedef clang::PresumedLoc DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(gc::As<asttooling::PresumedLoc_sp>(o)->_Value._value) {
@@ -168,7 +168,7 @@ template <> struct from_object<clang::PresumedLoc, std::true_type> {
   }
 };
 
-template <> struct from_object<const clang::PresumedLoc&, std::true_type> {
+template <> struct from_object<const clang::PresumedLoc&> {
   typedef clang::PresumedLoc DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(gc::As<asttooling::PresumedLoc_sp>(o)->_Value._value) {
@@ -198,7 +198,7 @@ template <> struct to_object<clang::PresumedLoc, translate::adopt_pointer> {
   }
 };
 
-template <> struct from_object<clang::SourceLocation, std::true_type> {
+template <> struct from_object<clang::SourceLocation> {
   typedef clang::SourceLocation DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(gc::As<asttooling::SourceLocation_sp>(o)->_Value._value) {
@@ -206,7 +206,7 @@ template <> struct from_object<clang::SourceLocation, std::true_type> {
   }
 };
 
-template <> struct from_object<const clang::SourceLocation&, std::true_type> {
+template <> struct from_object<const clang::SourceLocation&> {
   typedef clang::SourceLocation DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(gc::As<asttooling::SourceLocation_sp>(o)->_Value._value) {

--- a/include/clasp/clbind/apply_impl.h
+++ b/include/clasp/clbind/apply_impl.h
@@ -279,16 +279,15 @@ template <int Index, typename Type> struct prepare_argument<std::integral_consta
   }
 };
 
-template <typename Type> struct prepare_argument<std::integral_constant<int, 32767>, Type> {
-  using type = translate::from_object<Type, std::false_type>;
+template <typename Type> struct prepare_argument<std::integral_constant<int, 32767>, Type&> {
+  using type = translate::from_object<Type&, std::false_type>;
   static type goFrame(gctools::Frame::ElementType* frame) {
-    // Return an initialized from_object for the argument
-    return type(nil<core::T_O>());
+    // Return an uninitialized from_object for the argument.
+    return type();
   }
   template <typename... Targs>
   static type goArg(const std::tuple<Targs...>&& args) {
-    // Return an initialized from_object for the argument
-    return type(nil<core::T_O>());
+    return type();
   }
 };
 

--- a/include/clasp/clbind/clbind_wrappers.h
+++ b/include/clasp/clbind/clbind_wrappers.h
@@ -623,7 +623,7 @@ template <typename T> struct from_object<const T*&> {
 template <typename T> struct from_object<const T&> {
   typedef const T& DeclareType;
   DeclareType _v;
-  from_object(core::T_sp o) : _v(*(from_object<T*>(o)._v)){};
+  from_object(core::T_sp o) : _v(*(make_from_object<T*>(o))){};
 };
 
 template <typename T> T& safe_deref(T* ptr) {
@@ -637,7 +637,7 @@ template <typename T> T& safe_deref(T* ptr) {
 template <typename T> struct from_object<T&> {
   typedef T& DeclareType;
   DeclareType _v;
-  from_object(core::T_sp o) : _v(safe_deref<T>((from_object<T*>(o)._v))){};
+  from_object(core::T_sp o) : _v(safe_deref<T>((make_from_object<T*>(o)))){};
   ~from_object(){/*non trivial*/};
 };
 
@@ -645,7 +645,7 @@ template <typename T> struct from_object {
   typedef T DeclareType;
   DeclareType _v;
   from_object(core::T_sp o)
-      : _v(*(from_object<T*>(o)._v)){
+      : _v(*(make_from_object<T*>(o))){
             /*!!!!!!!! Did a EXC_BAD_ACCESS happen here???
               !!!!!!!! If it did - maybe this isn't the right from_object translator
               !!!!!!!! and you need to implement a more specialized one.
@@ -686,10 +686,6 @@ template <> struct from_object<const char*> {
     this->_v = (char*)malloc(len + 1);
     strncpy(this->_v, strng->get_std_string().data(), len);
     this->_v[len] = '\0';
-  }
-  from_object(const from_object<const char*>& other) {
-    this->_v = other._v;
-    other._v = NULL;
   }
   ~from_object() {
     if (this->_v) {

--- a/include/clasp/clbind/clbind_wrappers.h
+++ b/include/clasp/clbind/clbind_wrappers.h
@@ -514,7 +514,7 @@ public:
       been deleted!   Has a function that consumes a std::unique_ptr not been wrapped yet
     by Clasp?    How does this work???
     */
-template <typename T> struct from_object<std::unique_ptr<T>, std::true_type> {
+template <typename T> struct from_object<std::unique_ptr<T>> {
   typedef std::unique_ptr<T> DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) {
@@ -560,7 +560,7 @@ template <typename T> struct from_object<std::unique_ptr<T>, std::true_type> {
   }
 };
 
-template <typename T> struct from_object<T*, std::true_type> {
+template <typename T> struct from_object<T*> {
   typedef T* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) {
@@ -600,7 +600,7 @@ template <typename T> struct from_object<T*, std::true_type> {
   }
 };
 
-template <typename T> struct from_object<const T*&, std::true_type> {
+template <typename T> struct from_object<const T*&> {
   typedef const T* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) {
@@ -641,14 +641,7 @@ template <typename T> struct from_object<T&> {
   ~from_object(){/*non trivial*/};
 };
 
-template <typename T> struct from_object<T&, std::false_type> {
-  typedef T& DeclareType;
-  T _v;
-  from_object(){};
-  ~from_object(){/*non trivial*/};
-};
-
-template <typename T> struct from_object<T> {
+template <typename T> struct from_object {
   typedef T DeclareType;
   DeclareType _v;
   from_object(core::T_sp o)
@@ -658,7 +651,7 @@ template <typename T> struct from_object<T> {
               !!!!!!!! and you need to implement a more specialized one.
               !!!!!!!! And you need to make sure it's visible when the function that
               !!!!!!!! uses it is exposed.
-              !!!!!!!! See from_object<llvm::DIFile::ChecksumKind,std::true_type>
+              !!!!!!!! See from_object<llvm::DIFile::ChecksumKind>
               !!!!!!!! for an example where a specific translator was implemented
             */
         };
@@ -677,14 +670,14 @@ template <typename T> struct from_object<T> {
 
 namespace translate {
 
-template <> struct from_object<int&, std::true_type> {
+template <> struct from_object<int&> {
   typedef int DeclareType;
   int _v;
   from_object(gctools::smart_ptr<core::T_O> vv) : _v(core::clasp_to_int(vv)){};
   ~from_object(){/* Non-trivial */};
 };
 
-template <> struct from_object<const char*, std::true_type> {
+template <> struct from_object<const char*> {
   typedef const char* DeclareType;
   mutable char* _v;
   from_object(gctools::smart_ptr<core::T_O> vv) {
@@ -694,7 +687,7 @@ template <> struct from_object<const char*, std::true_type> {
     strncpy(this->_v, strng->get_std_string().data(), len);
     this->_v[len] = '\0';
   }
-  from_object(const from_object<const char*, std::true_type>& other) {
+  from_object(const from_object<const char*>& other) {
     this->_v = other._v;
     other._v = NULL;
   }

--- a/include/clasp/clbind/clbind_wrappers.h
+++ b/include/clasp/clbind/clbind_wrappers.h
@@ -620,13 +620,6 @@ template <typename T> struct from_object<const T*&, std::true_type> {
   }
 };
 
-/*! If the argument is a pure-out-value then don't use the passed to initialize _v */
-template <typename T> struct from_object<const T*&, std::false_type> {
-  typedef const T* DeclareType;
-  DeclareType _v;
-  from_object(const core::T_sp& o) : _v(NULL){};
-};
-
 template <typename T> struct from_object<const T&> {
   typedef const T& DeclareType;
   DeclareType _v;
@@ -651,7 +644,7 @@ template <typename T> struct from_object<T&> {
 template <typename T> struct from_object<T&, std::false_type> {
   typedef T& DeclareType;
   T _v;
-  from_object(core::T_sp o){};
+  from_object(){};
   ~from_object(){/*non trivial*/};
 };
 
@@ -689,24 +682,6 @@ template <> struct from_object<int&, std::true_type> {
   int _v;
   from_object(gctools::smart_ptr<core::T_O> vv) : _v(core::clasp_to_int(vv)){};
   ~from_object(){/* Non-trivial */};
-};
-
-template <> struct from_object<int&, std::false_type> {
-  typedef int DeclareType;
-  int _v;
-  from_object(gctools::smart_ptr<core::T_O> vv) { (void)vv; };
-  ~from_object(){
-      // non-trivial dtor to keep _v around
-  };
-};
-
-template <> struct from_object<int*, std::false_type> {
-  typedef int DeclareType;
-  int _v;
-  from_object(gctools::smart_ptr<core::T_O> vv) { (void)vv; };
-  ~from_object(){
-      // non-trivial dtor to keep _v around
-  };
 };
 
 template <> struct from_object<const char*, std::true_type> {

--- a/include/clasp/clbind/memberFunction.h
+++ b/include/clasp/clbind/memberFunction.h
@@ -70,10 +70,10 @@ public:
     if (lcc_nargs != NumParams)
       cc_wrong_number_of_arguments(lcc_closure, lcc_nargs, NumParams, NumParams);
     core::T_sp ootep((gctools::Tagged)lcc_args[0]);
-    translate::from_object<OT*> otep(ootep);
+    OT* otep = translate::make_from_object<OT*>(ootep);
     auto all_args = clbind::arg_tuple<1, Policies, ARGS...>::goFrame(lcc_args);
     return clbind::clbind_external_method_apply_and_return<Policies, RT, decltype(closure->mptr), OT*, decltype(all_args)>::go(
-        std::move(closure->mptr), otep._v, std::move(all_args));
+        std::move(closure->mptr), otep, std::move(all_args));
   }
 
   template <typename... Ts>
@@ -85,9 +85,9 @@ public:
     } else {
       MyType* closure = gctools::untag_general<MyType*>((MyType*)lcc_closure);
       core::T_sp ootep((gctools::Tagged)std::get<0>(std::make_tuple(args...)));
-      translate::from_object<OT*> otep(ootep);
+      OT* otep = translate::make_from_object<OT*>(ootep);
       auto all_args = clbind::arg_tuple<1, Policies, ARGS...>::goArgs(args...);
-      return clbind::clbind_external_method_apply_and_return<Policies, RT, decltype(closure->mptr), OT*, decltype(all_args)>::go(std::move(closure->mptr), otep._v, std::move(all_args));
+      return clbind::clbind_external_method_apply_and_return<Policies, RT, decltype(closure->mptr), OT*, decltype(all_args)>::go(std::move(closure->mptr), otep, std::move(all_args));
     }
   }
 };
@@ -129,10 +129,10 @@ public:
     if (lcc_nargs != NumParams)
       cc_wrong_number_of_arguments(lcc_closure, lcc_nargs, NumParams, NumParams);
     core::T_sp ootep((gctools::Tagged)lcc_args[0]);
-    translate::from_object<OT*> otep(ootep);
+    OT* otep = translate::make_from_object<OT*>(ootep);
     auto all_args = clbind::arg_tuple<1, Policies, ARGS...>::goFrame(lcc_args);
     return clbind::clbind_external_method_apply_and_return<Policies, RT, decltype(closure->mptr), OT*, decltype(all_args)>::go(
-        std::move(closure->mptr), otep._v, std::move(all_args));
+        std::move(closure->mptr), otep, std::move(all_args));
   }
 
   template <typename... Ts>
@@ -144,9 +144,9 @@ public:
     } else {
       MyType* closure = gctools::untag_general<MyType*>((MyType*)lcc_closure);
       core::T_sp ootep((gctools::Tagged)std::get<0>(std::make_tuple(args...)));
-      translate::from_object<OT*> otep(ootep);
+      OT* otep = translate::make_from_object<OT*>(ootep);
       auto all_args = clbind::arg_tuple<1, Policies, ARGS...>::goArgs(args...);
-      return clbind::clbind_external_method_apply_and_return<Policies, RT, decltype(closure->mptr), OT*, decltype(all_args)>::go(std::move(closure->mptr), otep._v, std::move(all_args));
+      return clbind::clbind_external_method_apply_and_return<Policies, RT, decltype(closure->mptr), OT*, decltype(all_args)>::go(std::move(closure->mptr), otep, std::move(all_args));
     }
   }
 };

--- a/include/clasp/clbind/setterBot.h
+++ b/include/clasp/clbind/setterBot.h
@@ -26,8 +26,7 @@ private:
     core::T_sp arg0((gctools::Tagged)a0);
     core::T_sp arg1((gctools::Tagged)a1);
     OT* objPtr = gc::As<core::WrappedPointer_sp>(arg1)->cast<OT>();
-    translate::from_object<MemberType> fvalue(arg0);
-    (*objPtr).*(this->mptr) = fvalue._v;
+    (*objPtr).*(this->mptr) = translate::make_from_object<MemberType>(arg0);
     typename gctools::return_type ret(arg0.raw_(), 1);
     return ret;
   }

--- a/include/clasp/clbind/setterTop.h
+++ b/include/clasp/clbind/setterTop.h
@@ -26,8 +26,7 @@ private:
     core::T_sp arg0((gctools::Tagged)a0);
     core::T_sp arg1((gctools::Tagged)a1);
     OT* objPtr = gc::As<core::WrappedPointer_sp>(arg1)->cast<OT>();
-    translate::from_object<MemberType> fvalue(arg0);
-    (*objPtr).*(this->mptr) = fvalue._v;
+    (*objPtr).*(this->mptr) = translate::make_from_object<MemberType>(arg0);
     gctools::return_type retv(arg0.raw_(), 1);
     return retv;
   }

--- a/include/clasp/core/bignum.h
+++ b/include/clasp/core/bignum.h
@@ -30,6 +30,7 @@ THE SOFTWARE.
 #include <clasp/core/object.h>
 #include <clasp/core/numbers.h>
 #include <clasp/core/bignum.fwd.h>
+#include <concepts> // integral
 
 namespace core {
 class Bignum_O;
@@ -132,7 +133,7 @@ public: // Functions here
   virtual bool evenp_() const override { return !((this->limbs())[0] & 1); }
   virtual bool oddp_() const override { return (this->limbs())[0] & 1; }
 
-  template <typename integral> integral to_integral() const {
+  template <std::integral integral> integral to_integral() const {
     integral mn = std::numeric_limits<integral>::min();
     integral mx = std::numeric_limits<integral>::max();
     // First, if integral can only hold fixnums, conversion will always fail.
@@ -184,8 +185,7 @@ Integer_sp core__next_fadd(Bignum_sp, Fixnum);
 Integer_sp core__next_fsub(Fixnum, Bignum_sp);
 int core__next_compare(Bignum_sp, Bignum_sp);
 
-template <typename integral> integral clasp_to_integral(T_sp obj) {
-  static_assert(std::is_integral<integral>::value, "clasp_to_integral needs an integral type");
+template <std::integral integral> integral clasp_to_integral(T_sp obj) {
   integral mn = std::numeric_limits<integral>::min();
   integral mx = std::numeric_limits<integral>::max();
   if (obj.fixnump()) {

--- a/include/clasp/core/character.h
+++ b/include/clasp/core/character.h
@@ -90,7 +90,7 @@ inline bool clasp_is_character_type(T_sp the_type) {
 
 namespace translate {
 
-template <> struct from_object<char, std::true_type> {
+template <> struct from_object<char> {
   typedef char DeclareType;
 
   DeclareType _v;

--- a/include/clasp/core/glue.h
+++ b/include/clasp/core/glue.h
@@ -71,14 +71,12 @@ template <> inline gctools::multiple_values<core::Symbol_O> safe_downcast(const 
 #define T_P const core::T_sp&
 
 namespace translate {
-/*! The second template argument can be std::true_type if the value passed to the from_object ctor should be used
-      to construct the value or std::false_type if a default initialization value should be used */
-template <class oClass, typename Doit = std::true_type> struct from_object;
+template <class oClass> struct from_object;
 
 // Shortcut operator when we just want a new object and don't care about
 // references etc.
 template <typename T> T make_from_object(core::T_sp o) {
-  return from_object<T, std::true_type>(o)._v;
+  return from_object<T>(o)._v;
 }
 
 struct dont_adopt_pointer {};
@@ -87,37 +85,37 @@ struct adopt_pointer {};
       that specifies if the pointer should be adopted or not adopted */
 template <class oClass, class AdoptPolicy = dont_adopt_pointer> struct to_object {};
 
-template <typename T> struct from_object<gctools::smart_ptr<T>, std::true_type> {
+template <typename T> struct from_object<gctools::smart_ptr<T>> {
   typedef gctools::smart_ptr<T> DeclareType;
   DeclareType _v;
-  from_object(const core::T_sp& o) : _v(gc::As<gctools::smart_ptr<T>>(o)) { ASSERT(gctools::IsA<gctools::smart_ptr<T>>(o)); };
+  from_object(const core::T_sp& o) : _v(gc::As<gctools::smart_ptr<T>>(o)) {};
 };
 
-template <typename T> struct from_object<gctools::smart_ptr<T>&, std::true_type> {
+template <typename T> struct from_object<gctools::smart_ptr<T>&> {
   typedef gctools::smart_ptr<T> DeclareType;
   DeclareType _v;
-  from_object(const core::T_sp& o) : _v(gc::As<gctools::smart_ptr<T>>(o)) { ASSERT(gctools::IsA<gctools::smart_ptr<T>>(o)); };
+  from_object(const core::T_sp& o) : _v(gc::As<gctools::smart_ptr<T>>(o)) {};
 };
 
-template <> struct from_object<gctools::smart_ptr<core::Character_I>&, std::true_type> {
+template <> struct from_object<gctools::smart_ptr<core::Character_I>&> {
   typedef gctools::smart_ptr<core::Character_I> DeclareType;
   DeclareType _v;
-  from_object(const core::T_sp& o) : _v(gc::As<gctools::smart_ptr<core::Character_I>>(o)) { ASSERT(o.characterp()); };
+  from_object(const core::T_sp& o) : _v(gc::As<gctools::smart_ptr<core::Character_I>>(o)) {};
 };
 
-template <> struct from_object<core::T_sp, std::true_type> {
+template <> struct from_object<core::T_sp> {
   typedef core::T_sp DeclareType;
   DeclareType _v;
   from_object(const core::T_sp& o) : _v(o){};
 };
 
-template <> struct from_object<gctools::smart_ptr<core::List_V>&, std::true_type> {
+template <> struct from_object<gctools::smart_ptr<core::List_V>&> {
   typedef core::List_sp DeclareType;
   DeclareType _v;
-  from_object(const core::T_sp& o) : _v(gc::As<core::List_sp>(o)) { ASSERT(gc::IsA<core::List_sp>(o)); };
+  from_object(const core::T_sp& o) : _v(gc::As<core::List_sp>(o)) {};
 };
 
-template <typename T> struct from_object<gc::Nilable<gc::smart_ptr<T>>, std::true_type> {
+template <typename T> struct from_object<gc::Nilable<gc::smart_ptr<T>>> {
   typedef gctools::Nilable<gc::smart_ptr<T>> DeclareType;
   DeclareType _v;
   from_object(const core::T_sp& o) : _v(o){};
@@ -134,7 +132,7 @@ template <class T> struct to_object<gc::Nilable<gctools::smart_ptr<T>>> {
 
 #define DECLARE_ENUM_SYMBOL_TRANSLATOR(enumType, psid)                                                                             \
   namespace translate {                                                                                                            \
-  template <> struct from_object<enumType, std::true_type> {                                                                       \
+  template <> struct from_object<enumType> {                                                                       \
     typedef enumType DeclareType;                                                                                                  \
     DeclareType _v;                                                                                                                \
     from_object(T_P o) : _v(static_cast<DeclareType>(core::lisp_lookupEnumForSymbol(psid, o.as<core::Symbol_O>()))){};             \

--- a/include/clasp/core/glue.h
+++ b/include/clasp/core/glue.h
@@ -75,6 +75,12 @@ namespace translate {
       to construct the value or std::false_type if a default initialization value should be used */
 template <class oClass, typename Doit = std::true_type> struct from_object;
 
+// Shortcut operator when we just want a new object and don't care about
+// references etc.
+template <typename T> T make_from_object(core::T_sp o) {
+  return from_object<T, std::true_type>(o)._v;
+}
+
 struct dont_adopt_pointer {};
 struct adopt_pointer {};
 /*! to_object takes a class to convert to an T_sp type and a template parameter

--- a/include/clasp/core/glue.h
+++ b/include/clasp/core/glue.h
@@ -138,27 +138,6 @@ template <class T> struct to_object<gc::Nilable<gctools::smart_ptr<T>>> {
 };
 }; // namespace translate
 
-#define __FROM_OBJECT_CONVERTER(oClass)                                                                                            \
-  namespace translate {                                                                                                            \
-  template <> struct from_object<gctools::smart_ptr<oClass>, std::true_type> {                                                     \
-    typedef gctools::smart_ptr<oClass> ExpectedType;                                                                               \
-    typedef gctools::smart_ptr<oClass> DeclareType;                                                                                \
-    DeclareType _v;                                                                                                                \
-    from_object(T_P o) : _v(o.as<oClass>()) {}                                                                                     \
-  };                                                                                                                               \
-  };
-
-#define __TO_OBJECT_CONVERTER(oClass)                                                                                              \
-  namespace translate {                                                                                                            \
-  template <> struct to_object<gctools::smart_ptr<oClass>> {                                                                       \
-    typedef gctools::smart_ptr<oClass> GivenType;                                                                                  \
-    static core::T_sp convert(GivenType o) {                                                                                       \
-      _G();                                                                                                                        \
-      return o;                                                                                                                    \
-    }                                                                                                                              \
-  };                                                                                                                               \
-  };
-
 #define DECLARE_ENUM_SYMBOL_TRANSLATOR(enumType, psid)                                                                             \
   namespace translate {                                                                                                            \
   template <> struct from_object<enumType, std::true_type> {                                                                       \
@@ -175,13 +154,3 @@ template <class T> struct to_object<gc::Nilable<gctools::smart_ptr<T>>> {
     }                                                                                                                              \
   };                                                                                                                               \
   };
-
-#define STREAMIO(classo)                                                                                                           \
-  std::ostream& operator<<(std::ostream& os, gctools::smart_ptr<classo> p) {                                                       \
-    THROW_HARD_ERROR("Illegal operator<<");                                                                                        \
-    return os;                                                                                                                     \
-  }
-
-#define TRANSLATE(classo)
-
-//    STREAMIO(classo);

--- a/include/clasp/core/glue.h
+++ b/include/clasp/core/glue.h
@@ -88,43 +88,37 @@ struct adopt_pointer {};
 template <class oClass, class AdoptPolicy = dont_adopt_pointer> struct to_object {};
 
 template <typename T> struct from_object<gctools::smart_ptr<T>, std::true_type> {
-  typedef gctools::smart_ptr<T> ExpectedType;
   typedef gctools::smart_ptr<T> DeclareType;
   DeclareType _v;
   from_object(const core::T_sp& o) : _v(gc::As<gctools::smart_ptr<T>>(o)) { ASSERT(gctools::IsA<gctools::smart_ptr<T>>(o)); };
 };
 
 template <typename T> struct from_object<gctools::smart_ptr<T>&, std::true_type> {
-  typedef gctools::smart_ptr<T> ExpectedType;
   typedef gctools::smart_ptr<T> DeclareType;
   DeclareType _v;
   from_object(const core::T_sp& o) : _v(gc::As<gctools::smart_ptr<T>>(o)) { ASSERT(gctools::IsA<gctools::smart_ptr<T>>(o)); };
 };
 
 template <> struct from_object<gctools::smart_ptr<core::Character_I>&, std::true_type> {
-  typedef gctools::smart_ptr<core::Character_I> ExpectedType;
   typedef gctools::smart_ptr<core::Character_I> DeclareType;
   DeclareType _v;
   from_object(const core::T_sp& o) : _v(gc::As<gctools::smart_ptr<core::Character_I>>(o)) { ASSERT(o.characterp()); };
 };
 
 template <> struct from_object<core::T_sp, std::true_type> {
-  typedef core::T_sp ExpectedType;
   typedef core::T_sp DeclareType;
   DeclareType _v;
   from_object(const core::T_sp& o) : _v(o){};
 };
 
 template <> struct from_object<gctools::smart_ptr<core::List_V>&, std::true_type> {
-  typedef core::List_sp ExpectedType;
   typedef core::List_sp DeclareType;
   DeclareType _v;
   from_object(const core::T_sp& o) : _v(gc::As<core::List_sp>(o)) { ASSERT(gc::IsA<core::List_sp>(o)); };
 };
 
 template <typename T> struct from_object<gc::Nilable<gc::smart_ptr<T>>, std::true_type> {
-  typedef gctools::Nilable<gc::smart_ptr<T>> ExpectedType;
-  typedef ExpectedType DeclareType;
+  typedef gctools::Nilable<gc::smart_ptr<T>> DeclareType;
   DeclareType _v;
   from_object(const core::T_sp& o) : _v(o){};
 };
@@ -141,7 +135,6 @@ template <class T> struct to_object<gc::Nilable<gctools::smart_ptr<T>>> {
 #define DECLARE_ENUM_SYMBOL_TRANSLATOR(enumType, psid)                                                                             \
   namespace translate {                                                                                                            \
   template <> struct from_object<enumType, std::true_type> {                                                                       \
-    typedef enumType ExpectedType;                                                                                                 \
     typedef enumType DeclareType;                                                                                                  \
     DeclareType _v;                                                                                                                \
     from_object(T_P o) : _v(static_cast<DeclareType>(core::lisp_lookupEnumForSymbol(psid, o.as<core::Symbol_O>()))){};             \

--- a/include/clasp/core/record.h
+++ b/include/clasp/core/record.h
@@ -90,7 +90,7 @@ public:
       List_sp find = core__alist_assoc_eq(this->_alist, name);
       if (find.consp()) {
         RECORD_LOG(("find apair %s\n"), _rep_(find));
-        value = translate::from_object<ST>(CONS_CDR(find))._v;
+        value = translate::make_from_object<ST>(CONS_CDR(find));
         if (this->stage() == initializing)
           this->flagSeen(gc::As_unsafe<Cons_sp>(find));
       } else {
@@ -274,7 +274,7 @@ public:
       for (size_t i(0), iEnd(cl__length(vec_value)); i < iEnd; ++i) {
         T_sp val = vec_value->rowMajorAref(i);
         RECORD_LOG(("Loading vec0[%d] new@%p: %s\n"), i, (void*)(val.raw_()), _rep_(val));
-        value[i] = translate::from_object<SC>(val)._v;
+        value[i] = translate::make_from_object<SC>(val);
       }
       if (this->stage() == initializing)
         this->flagSeen(apair);
@@ -287,7 +287,7 @@ public:
         if (patch != orig) {
           RECORD_LOG(("Patching vec0[%d] orig@%p: %s --> new@%p: %s\n"), i, _rep_(orig), (void*)(orig.raw_()), _rep_(patch),
                      (void*)(patch.raw_()));
-          value[i] = translate::from_object<SC>(patch)._v;
+          value[i] = translate::make_from_object<SC>(patch);
         }
       }
     } break;
@@ -368,7 +368,7 @@ public:
       for (size_t i(0), iEnd(cl__length(vec_value)); i < iEnd; ++i) {
         T_sp val = vec_value->rowMajorAref(i);
         RECORD_LOG(("Loading vec0[%d] new@%p: %s\n"), i, (void*)(val.raw_()), _rep_(val));
-        value.push_back(std::make_pair<K, gctools::smart_ptr<SV>>(translate::from_object<K>(oCar(val))._v,
+        value.push_back(std::make_pair<K, gctools::smart_ptr<SV>>(translate::make_from_object<K>(oCar(val)),
                                                                   gc::As_unsafe<gctools::smart_ptr<SV>>(oCdr(val))));
       }
       if (this->stage() == initializing)
@@ -748,7 +748,7 @@ public:
         value = default_value;
       } else {
         Cons_sp apair = gc::As_unsafe<Cons_sp>(find);
-        value = translate::from_object<T>(CONS_CDR(apair))._v;
+        value = translate::make_from_object<T>(CONS_CDR(apair));
         if (this->stage() == initializing)
           this->flagSeen(apair);
       }
@@ -778,7 +778,7 @@ public:
       } else {
         defined = true;
         Cons_sp apair = gc::As_unsafe<Cons_sp>(find);
-        value = translate::from_object<T>(CONS_CDR(apair))._v;
+        value = translate::make_from_object<T>(CONS_CDR(apair));
         if (this->stage() == initializing)
           this->flagSeen(apair);
       }

--- a/include/clasp/core/scrape.h
+++ b/include/clasp/core/scrape.h
@@ -112,25 +112,3 @@ DOCGROUP(clasp)
   static const char* /*std::string*/ CurrentPkg = z;                                                                               \
   }
 #endif
-
-// Define a translator for the enum
-#define CL_ENUM_TRANSLATOR(_sym_, _type_)                                                                                          \
-  namespace translate {                                                                                                            \
-  template <> struct to_object<_type_> {                                                                                           \
-    typedef _type_ GivenType;                                                                                                      \
-    static core::T_sp convert(const GivenType& val) {                                                                              \
-      _G();                                                                                                                        \
-      core::SymbolToEnumConverter_sp converter = _sym_->symbolValue().as<core::SymbolToEnumConverter_O>();                         \
-      return (converter->symbolForEnum(val));                                                                                      \
-    }                                                                                                                              \
-  };                                                                                                                               \
-  template <> struct from_object<_type_> {                                                                                         \
-    typedef _type_ ExpectedType;                                                                                                   \
-    typedef ExpectedType DeclareType;                                                                                              \
-    DeclareType _v;                                                                                                                \
-    from_object(gctools::smart_ptr<core::T_O> o) {                                                                                 \
-      core::SymbolToEnumConverter_sp converter = _sym_->symbolValue().as<core::SymbolToEnumConverter_O>();                         \
-      _v = converter->enumForSymbol<_type_>(o.as<core::Symbol_O>());                                                               \
-    }                                                                                                                              \
-  };                                                                                                                               \
-  };

--- a/include/clasp/core/symbolToEnumConverter.h
+++ b/include/clasp/core/symbolToEnumConverter.h
@@ -102,7 +102,7 @@ public:
 
 #define ENUM_FROM_OBJECT_TRANSLATOR(enumType, converterSymbol)                                                                     \
   namespace translate {                                                                                                            \
-  template <> struct from_object<enumType, std::true_type> {                                                                       \
+  template <> struct from_object<enumType> {                                                                       \
     typedef enumType DeclareType;                                                                                                  \
     DeclareType _v;                                                                                                                \
     from_object(core::T_sp o)                                                                                                      \

--- a/include/clasp/core/translators.h
+++ b/include/clasp/core/translators.h
@@ -26,20 +26,6 @@ THE SOFTWARE.
 */
 /* -^- */
 
-// PATTERN FOR from_object TRANSLATORS:
-//
-// Fixnum not_fixnum_error(core::T_sp o) {
-//     TYPE_ERROR(o,cl::_sym_fixnum);
-// }
-//
-// template <>
-// struct from_object<unsigned long, std::true_type> {
-//     typedef unsigned long DeclareType;
-//
-//     DeclareType _v;
-//     from_object() : _v( o.fixnump() ? o.unsafe_fixnum() : not_fixnum_error(o) ) {};
-// };
-
 //
 // Type translators
 //
@@ -62,60 +48,60 @@ namespace translate {
 
 // FROM_OBJECT TRANSLATORS
 
-template <std::integral I> struct from_object<I, std::true_type> {
+template <std::integral I> struct from_object<I> {
   typedef I DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(core::clasp_to_integral<I>(o)) {};
 };
 
-template <> struct from_object<float, std::true_type> {
+template <> struct from_object<float> {
   typedef float DeclareType;
 
   DeclareType _v;
   from_object(core::T_sp o) : _v(core::clasp_to_float(gc::As<core::Number_sp>(o))){};
 };
 
-template <> struct from_object<double, std::true_type> {
+template <> struct from_object<double> {
   typedef double DeclareType;
 
   DeclareType _v;
   from_object(core::T_sp o) : _v(core::clasp_to_double(gc::As<core::Number_sp>(o))){};
 };
 
-template <> struct from_object<long double, std::true_type> {
+template <> struct from_object<long double> {
   typedef long double DeclareType;
 
   DeclareType _v;
   from_object(core::T_sp o) : _v(core::clasp_to_long_double(gc::As<core::Number_sp>(o))){};
 };
 
-template <> struct from_object<bool, std::true_type> {
+template <> struct from_object<bool> {
   typedef bool DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(!o.nilp()){};
 };
 
-template <> struct from_object<bool&, std::true_type> {
+template <> struct from_object<bool&> {
   typedef bool DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(!o.nilp()){};
   ~from_object(){/*non trivial*/};
 };
 
-template <> struct from_object<core::T_O*, std::true_type> {
+template <> struct from_object<core::T_O*> {
   typedef core::T_O* DeclareType;
 
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.raw_()){};
 };
 
-template <> struct from_object<void*, std::true_type> {
+template <> struct from_object<void*> {
   typedef void* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(core::lisp_to_void_ptr(o)){};
 };
 
-template <> struct from_object<bool*, std::true_type> {
+template <> struct from_object<bool*> {
   typedef bool* DeclareType;
 
   DeclareType _v;
@@ -293,19 +279,19 @@ template <> struct to_object<const mpz_class&> {
 
 //  String translators
 
-template <> struct from_object<const std::string&, std::true_type> {
+template <> struct from_object<const std::string&> {
   typedef std::string DeclareType;
   DeclareType _v;
   from_object(T_P o) : _v(string_get_std_string(o)){};
 };
 
-template <> struct from_object<std::string, std::true_type> {
+template <> struct from_object<std::string> {
   typedef std::string DeclareType;
   DeclareType _v;
   from_object(T_P o) : _v(string_get_std_string(o)){};
 };
 
-template <> struct from_object<std::string&, std::true_type> {
+template <> struct from_object<std::string&> {
   typedef std::string DeclareType;
   DeclareType _v;
   from_object(T_P o) : _v(string_get_std_string(o)){};

--- a/include/clasp/core/translators.h
+++ b/include/clasp/core/translators.h
@@ -116,23 +116,6 @@ template <> struct from_object<void*, std::true_type> {
   from_object(core::T_sp o) : _v(core::lisp_to_void_ptr(o)){};
 };
 
-template <> struct from_object<bool*, std::false_type> {
-  typedef bool* DeclareType;
-
-  DeclareType _v;
-  bool _val;
-  from_object(T_P o) : _v(&_val), _val(false){};
-};
-
-template <> struct from_object<bool*&, std::false_type> {
-  typedef bool* DeclareType;
-
-  DeclareType _v;
-  bool _val;
-  from_object(T_P o) : _v(&_val), _val(false){};
-  ~from_object(){/*non trivial*/};
-};
-
 template <> struct from_object<bool*, std::true_type> {
   typedef bool* DeclareType;
 
@@ -327,13 +310,6 @@ template <> struct from_object<std::string&, std::true_type> {
   typedef std::string DeclareType;
   DeclareType _v;
   from_object(T_P o) : _v(string_get_std_string(o)){};
-  ~from_object(){/*non trivial*/};
-};
-
-template <> struct from_object<std::string&, std::false_type> {
-  typedef std::string DeclareType;
-  DeclareType _v;
-  from_object(T_P o){};
   ~from_object(){/*non trivial*/};
 };
 

--- a/include/clasp/core/translators.h
+++ b/include/clasp/core/translators.h
@@ -34,7 +34,6 @@ THE SOFTWARE.
 //
 // template <>
 // struct from_object<unsigned long, std::true_type> {
-//     typedef unsigned long ExpectedType;
 //     typedef unsigned long DeclareType;
 //
 //     DeclareType _v;

--- a/include/clasp/core/translators.h
+++ b/include/clasp/core/translators.h
@@ -49,142 +49,25 @@ THE SOFTWARE.
 
 #include <cstdint>
 #include <utility>
+#include <concepts> // std::integral
 
 #include <clasp/core/predicates.h>
 #include <clasp/core/clasp_gmpxx.h>
 #include <clasp/core/glue.h>
 #include <clasp/core/pointer.h>
 #include <clasp/core/numbers.h>
+#include <clasp/core/bignum.h> // clasp_to_integral
 #include <clasp/core/array.fwd.h>
 
 namespace translate {
 
 // FROM_OBJECT TRANSLATORS
 
-// template <>
-// struct from_object< short, std::true_type >
-// {
-//   typedef short DeclareType;
-
-//   DeclareType _v;
-// from_object( core::T_sp o ) : _v( o.fixnump() ? o.unsafe_fixnum() : not_fixnum_error(o) ) {};
-// };
-
-// template <>
-//   struct from_object< unsigned short, std::true_type >
-// {
-//   typedef unsigned short DeclareType;
-
-//   DeclareType _v;
-// from_object( core::T_sp o ) : _v( o.fixnump() ? o.unsafe_fixnum() : not_fixnum_error(o) ) {};
-// };
-
-// template <>
-//   struct from_object< int, std::true_type >
-// {
-//   typedef int DeclareType;
-
-//   DeclareType _v;
-// from_object( core::T_sp o ) : _v( o.fixnump() ? o.unsafe_fixnum() : not_fixnum_error(o) ) {};
-// };
-
-// template <>
-//   struct from_object< unsigned int, std::true_type >
-// {
-//   typedef unsigned int DeclareType;
-
-//   DeclareType _v;
-// from_object( core::T_sp o ) : _v( o.fixnump() ? o.unsafe_fixnum() : not_fixnum_error(o) ) {};
-// };
-
-#if defined(_TARGET_OS_DARWIN) || defined(_TARGET_OS_FREEBSD)
-// linux doesn't like these because they clash with int64_t and uint64_t
-template <> struct from_object<long, std::true_type> {
-  typedef int DeclareType;
+template <std::integral I> struct from_object<I, std::true_type> {
+  typedef I DeclareType;
   DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : clasp_to_long(o)){};
+  from_object(core::T_sp o) : _v(core::clasp_to_integral<I>(o)) {};
 };
-
-template <> struct from_object<unsigned long, std::true_type> {
-  typedef unsigned long DeclareType;
-  DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : clasp_to_ulong(o)){};
-};
-#endif
-
-template <> struct from_object<long long, std::true_type> {
-  typedef long long DeclareType;
-
-  DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : core::clasp_to_longlong(o)){};
-};
-
-template <> struct from_object<unsigned long long, std::true_type> {
-  typedef unsigned long long DeclareType;
-
-  DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : core::clasp_to_ulonglong(o)){};
-};
-
-template <> struct from_object<int8_t, std::true_type> {
-  typedef int8_t DeclareType;
-
-  DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : core::not_fixnum_error(o)){};
-};
-
-template <> struct from_object<uint8_t, std::true_type> {
-  typedef uint8_t DeclareType;
-
-  DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : core::not_fixnum_error(o)){};
-};
-
-template <> struct from_object<int16_t, std::true_type> {
-  typedef int16_t DeclareType;
-
-  DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : core::not_fixnum_error(o)){};
-};
-
-template <> struct from_object<uint16_t, std::true_type> {
-  typedef uint16_t DeclareType;
-
-  DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : core::not_fixnum_error(o)){};
-};
-
-template <> struct from_object<int32_t, std::true_type> {
-  typedef int32_t DeclareType;
-
-  DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : core::not_fixnum_error(o)){};
-};
-
-template <> struct from_object<uint32_t, std::true_type> {
-  typedef uint32_t DeclareType;
-
-  DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : core::not_fixnum_error(o)){};
-};
-
-#if defined(_TARGET_OS_LINUX)
-template <> struct from_object<int64_t, std::true_type> {
-  typedef int64_t DeclareType;
-
-  DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : clasp_to_int64_t(o)){};
-};
-#endif
-
-#if defined(_TARGET_OS_LINUX)
-template <> struct from_object<uint64_t, std::true_type> {
-  typedef uint64_t DeclareType;
-
-  DeclareType _v;
-  from_object(core::T_sp o) : _v(o.fixnump() ? o.unsafe_fixnum() : clasp_to_uint64_t(o)){};
-};
-#endif
 
 template <> struct from_object<float, std::true_type> {
   typedef float DeclareType;

--- a/include/clasp/llvmo/debugInfoExpose.h
+++ b/include/clasp/llvmo/debugInfoExpose.h
@@ -93,7 +93,6 @@ public:
   virtual ~DILocation_O(){};
 }; // DILocation_O
 }; // namespace llvmo
-TRANSLATE(llvmo::DILocation_O);
 
 namespace translate {
 template <> struct from_object<llvm::DILocation*, std::true_type> {
@@ -130,7 +129,6 @@ public:
   virtual ~DINode_O(){};
 }; // DINode_O
 }; // namespace llvmo
-TRANSLATE(llvmo::DINode_O);
 
 namespace translate {
 template <> struct from_object<llvm::DINode*, std::true_type> {
@@ -167,7 +165,6 @@ public:
   virtual ~DIExpression_O(){};
 }; // DIExpression_O
 }; // namespace llvmo
-TRANSLATE(llvmo::DIExpression_O);
 
 namespace translate {
 template <> struct from_object<llvm::DIExpression*, std::true_type> {
@@ -200,7 +197,6 @@ public:
   virtual ~DIScope_O() {}
 }; // DIScope_O
 }; // namespace llvmo
-TRANSLATE(llvmo::DIScope_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -233,7 +229,6 @@ public:
 
 }; // DINodeArray_O
 }; // namespace llvmo
-TRANSLATE(llvmo::DINodeArray_O);
 
 namespace translate {
 template <> struct to_object<llvm::DINodeArray> {
@@ -264,7 +259,6 @@ public:
   virtual ~DITypeRefArray_O() {}
 }; // DITypeRefArray_O
 }; // namespace llvmo
-TRANSLATE(llvmo::DITypeRefArray_O);
 
 namespace translate {
 template <> struct to_object<llvm::DITypeRefArray> {
@@ -300,7 +294,6 @@ public:
   virtual ~DIFile_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DIFile_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -335,7 +328,6 @@ public:
   virtual ~DILocalScope_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DILocalScope_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -372,7 +364,6 @@ public:
   virtual ~DISubprogram_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DISubprogram_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -407,7 +398,6 @@ public:
   virtual ~DIType_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DIType_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -442,7 +432,6 @@ public:
   virtual ~DIBasicType_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DIBasicType_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -477,7 +466,6 @@ public:
   virtual ~DIDerivedType_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DIDerivedType_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -512,7 +500,6 @@ public:
   virtual ~DICompositeType_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DICompositeType_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -547,7 +534,6 @@ public:
   virtual ~DISubroutineType_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DISubroutineType_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -582,7 +568,6 @@ public:
   virtual ~DILexicalBlockBase_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DILexicalBlockBase_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -618,7 +603,6 @@ public:
   virtual ~DILexicalBlock_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DILexicalBlock_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -653,7 +637,6 @@ public:
   virtual ~DICompileUnit_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DICompileUnit_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -717,7 +700,6 @@ public:
 
 }; // DIBuilder_O
 }; // namespace llvmo
-TRANSLATE(llvmo::DIBuilder_O);
 /* from_object translators */
 
 namespace translate {
@@ -747,7 +729,6 @@ public:
   virtual ~DIVariable_O() {}
 }; // DIVariable_O
 }; // namespace llvmo
-TRANSLATE(llvmo::DIVariable_O);
 /* from_object translators */
 /* to_object translators */
 
@@ -784,7 +765,6 @@ public:
   virtual ~DILocalVariable_O() {}
 };
 }; // namespace llvmo
-TRANSLATE(llvmo::DILocalVariable_O);
 /* from_object translators */
 /* to_object translators */
 

--- a/include/clasp/llvmo/debugInfoExpose.h
+++ b/include/clasp/llvmo/debugInfoExpose.h
@@ -95,7 +95,7 @@ public:
 }; // namespace llvmo
 
 namespace translate {
-template <> struct from_object<llvm::DILocation*, std::true_type> {
+template <> struct from_object<llvm::DILocation*> {
   typedef llvm::DILocation* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DILocation_sp>(o)->wrappedPtr()){};
@@ -131,7 +131,7 @@ public:
 }; // namespace llvmo
 
 namespace translate {
-template <> struct from_object<llvm::DINode*, std::true_type> {
+template <> struct from_object<llvm::DINode*> {
   typedef llvm::DINode* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DINode_sp>(o)->wrappedPtr()){};
@@ -167,7 +167,7 @@ public:
 }; // namespace llvmo
 
 namespace translate {
-template <> struct from_object<llvm::DIExpression*, std::true_type> {
+template <> struct from_object<llvm::DIExpression*> {
   typedef llvm::DIExpression* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DIExpression_sp>(o)->wrappedPtr()){};
@@ -201,7 +201,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DIScope*, std::true_type> {
+template <> struct from_object<llvm::DIScope*> {
   typedef llvm::DIScope* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DIScope_sp>(o)->wrappedPtr()){};
@@ -237,7 +237,7 @@ template <> struct to_object<llvm::DINodeArray> {
     return ((obj));
   };
 };
-template <> struct from_object<llvm::DINodeArray, std::true_type> {
+template <> struct from_object<llvm::DINodeArray> {
   typedef llvm::DINodeArray DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(object.nilp() ? nullptr : gc::As<llvmo::DINodeArray_sp>(object)->get()){};
@@ -267,7 +267,7 @@ template <> struct to_object<llvm::DITypeRefArray> {
     return ((obj));
   };
 };
-template <> struct from_object<llvm::DITypeRefArray, std::true_type> {
+template <> struct from_object<llvm::DITypeRefArray> {
   typedef llvm::DITypeRefArray& DeclareType;
   DeclareType _v;
   from_object(core::T_sp object) : _v(gc::As<llvmo::DITypeRefArray_sp>(object)->get()){};
@@ -298,7 +298,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DIFile*, std::true_type> {
+template <> struct from_object<llvm::DIFile*> {
   typedef llvm::DIFile* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DIFile_sp>(o)->wrappedPtr()){};
@@ -332,7 +332,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DILocalScope*, std::true_type> {
+template <> struct from_object<llvm::DILocalScope*> {
   typedef llvm::DILocalScope* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DILocalScope_sp>(o)->wrappedPtr()){};
@@ -368,7 +368,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DISubprogram*, std::true_type> {
+template <> struct from_object<llvm::DISubprogram*> {
   typedef llvm::DISubprogram* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DISubprogram_sp>(o)->wrappedPtr()){};
@@ -402,7 +402,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DIType*, std::true_type> {
+template <> struct from_object<llvm::DIType*> {
   typedef llvm::DIType* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DIType_sp>(o)->wrappedPtr()){};
@@ -436,7 +436,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DIBasicType*, std::true_type> {
+template <> struct from_object<llvm::DIBasicType*> {
   typedef llvm::DIBasicType* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DIBasicType_sp>(o)->wrappedPtr()){};
@@ -470,7 +470,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DIDerivedType*, std::true_type> {
+template <> struct from_object<llvm::DIDerivedType*> {
   typedef llvm::DIDerivedType* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DIDerivedType_sp>(o)->wrappedPtr()){};
@@ -504,7 +504,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DICompositeType*, std::true_type> {
+template <> struct from_object<llvm::DICompositeType*> {
   typedef llvm::DICompositeType* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DICompositeType_sp>(o)->wrappedPtr()){};
@@ -538,7 +538,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DISubroutineType*, std::true_type> {
+template <> struct from_object<llvm::DISubroutineType*> {
   typedef llvm::DISubroutineType* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DISubroutineType_sp>(o)->wrappedPtr()){};
@@ -572,7 +572,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DILexicalBlockBase*, std::true_type> {
+template <> struct from_object<llvm::DILexicalBlockBase*> {
   typedef llvm::DILexicalBlockBase* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DILexicalBlockBase_sp>(o)->wrappedPtr()){};
@@ -607,7 +607,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DILexicalBlock*, std::true_type> {
+template <> struct from_object<llvm::DILexicalBlock*> {
   typedef llvm::DILexicalBlock* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DILexicalBlock_sp>(o)->wrappedPtr()){};
@@ -641,7 +641,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DICompileUnit*, std::true_type> {
+template <> struct from_object<llvm::DICompileUnit*> {
   typedef llvm::DICompileUnit* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DICompileUnit_sp>(o)->wrappedPtr()){};
@@ -703,7 +703,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DIBuilder&, std::true_type> {
+template <> struct from_object<llvm::DIBuilder&> {
   typedef llvm::DIBuilder& DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(*gc::As<llvmo::DIBuilder_sp>(object)->wrappedPtr()){};
@@ -733,7 +733,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DIVariable*, std::true_type> {
+template <> struct from_object<llvm::DIVariable*> {
   typedef llvm::DIVariable* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DIVariable_sp>(o)->wrappedPtr()){};
@@ -769,7 +769,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DILocalVariable*, std::true_type> {
+template <> struct from_object<llvm::DILocalVariable*> {
   typedef llvm::DILocalVariable* DeclareType;
   DeclareType _v;
   from_object(core::T_sp o) : _v(o.nilp() ? NULL : gc::As<llvmo::DILocalVariable_sp>(o)->wrappedPtr()){};
@@ -783,7 +783,7 @@ template <> struct to_object<llvm::DILocalVariable*> {
 
 #if LLVM_VERSION_MAJOR < 16
 namespace translate {
-template <> struct from_object<llvm::Optional<llvm::DIFile::ChecksumInfo<llvm::StringRef>>, std::true_type> {
+template <> struct from_object<llvm::Optional<llvm::DIFile::ChecksumInfo<llvm::StringRef>>> {
   typedef llvm::Optional<llvm::DIFile::ChecksumInfo<llvm::StringRef>> DeclareType;
   DeclareType _v;
   std::string _Storage;
@@ -824,7 +824,7 @@ template <> struct from_object<llvm::Optional<llvm::DIFile::ChecksumInfo<llvm::S
 }; // namespace translate
 #else
 namespace translate {
-template <> struct from_object<std::optional<llvm::DIFile::ChecksumInfo<llvm::StringRef>>, std::true_type> {
+template <> struct from_object<std::optional<llvm::DIFile::ChecksumInfo<llvm::StringRef>>> {
   typedef std::optional<llvm::DIFile::ChecksumInfo<llvm::StringRef>> DeclareType;
   DeclareType _v;
   std::string _Storage;
@@ -867,7 +867,7 @@ template <> struct from_object<std::optional<llvm::DIFile::ChecksumInfo<llvm::St
 
 #if LLVM_VERSION_MAJOR < 16
 namespace translate {
-template <> struct from_object<llvm::Optional<llvm::StringRef>, std::true_type> {
+template <> struct from_object<llvm::Optional<llvm::StringRef>> {
   typedef llvm::Optional<llvm::StringRef> DeclareType;
   std::string _Storage;
   DeclareType _v;
@@ -891,7 +891,7 @@ template <> struct from_object<llvm::Optional<llvm::StringRef>, std::true_type> 
 }; // namespace translate
 #else
 namespace translate {
-template <> struct from_object<std::optional<llvm::StringRef>, std::true_type> {
+template <> struct from_object<std::optional<llvm::StringRef>> {
   typedef std::optional<llvm::StringRef> DeclareType;
   std::string _Storage;
   DeclareType _v;
@@ -945,7 +945,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DIContext*, std::true_type> {
+template <> struct from_object<llvm::DIContext*> {
   typedef llvm::DIContext* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::DIContext_sp>(object)->wrappedPtr()){};
@@ -999,7 +999,7 @@ llvm::Expected<std::vector<llvm::DWARFAddressRange>> getAddressRangesForAddressI
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::DWARFContext*, std::true_type> {
+template <> struct from_object<llvm::DWARFContext*> {
   typedef llvm::DWARFContext* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::DWARFContext_sp>(object)->wrappedPtr()){};
@@ -1047,7 +1047,7 @@ public:
 }; // namespace llvmo
 
 namespace translate {
-template <> struct from_object<llvm::DWARFUnit*, std::true_type> {
+template <> struct from_object<llvm::DWARFUnit*> {
   typedef llvm::DWARFUnit* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::DWARFUnit_sp>(object)->wrappedPtr()){};
@@ -1098,7 +1098,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<const llvm::DWARFDebugLine::LineTable*, std::true_type> {
+template <> struct from_object<const llvm::DWARFDebugLine::LineTable*> {
   typedef const llvm::DWARFDebugLine::LineTable* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::LineTable_sp>(object)->wrappedPtr()){};

--- a/include/clasp/llvmo/llvmoExpose.h
+++ b/include/clasp/llvmo/llvmoExpose.h
@@ -1517,9 +1517,9 @@ class GlobalVariable_O : public GlobalValue_O {
   typedef llvm::GlobalVariable* PointerToExternalType;
 
 public:
-  static GlobalVariable_sp make(Module_sp module, Type_sp type, bool isConstant, core::Symbol_sp linkage,
+  static GlobalVariable_sp make(Module_sp module, Type_sp type, bool isConstant, llvm::GlobalValue::LinkageTypes linkage,
                                 /*Constant_sp*/ core::T_sp initializer, core::String_sp name,
-                                /*GlobalVariable_sp*/ core::T_sp insertBefore, core::Symbol_sp threadLocalMode);
+                                /*GlobalVariable_sp*/ core::T_sp insertBefore, llvm::GlobalValue::ThreadLocalMode threadLocalMode);
 
 public:
   PointerToExternalType wrappedPtr() const { return llvm_cast<ExternalType>(this->_ptr); };
@@ -3315,7 +3315,7 @@ public:
   ~FunctionType_O() {}
 
 public: // static methods
-  static core::T_sp get(core::T_sp result_type, core::T_sp params, core::T_sp is_var_arg);
+  static core::T_sp get(llvm::Type* result_type, core::T_sp params, core::T_sp is_var_arg);
 }; // FunctionType_O
 }; // namespace llvmo
 /* from_object translators */
@@ -3390,7 +3390,7 @@ public:
 
 public: // static methods
   /*! Get a structure using llvm:StructType::create(LLVMContext& context, ArrayRef<Type*>Elements,StringRef name,bool isPacked) */
-  static StructType_sp make(LLVMContext_sp context, core::T_sp elements, core::String_sp name, core::T_sp isPacked);
+  static StructType_sp make(LLVMContext_sp context, core::T_sp elements, llvm::StringRef name, core::T_sp isPacked);
 
   static StructType_sp get(LLVMContext_sp context, core::T_sp elements, bool isPacked = false);
 

--- a/include/clasp/llvmo/llvmoExpose.h
+++ b/include/clasp/llvmo/llvmoExpose.h
@@ -128,7 +128,7 @@ public:
 }; // namespace llvmo
 
 namespace translate {
-template <> struct from_object<llvm::LLVMContext&, std::true_type> {
+template <> struct from_object<llvm::LLVMContext&> {
   typedef llvm::LLVMContext& DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(*(gc::As<llvmo::LLVMContext_sp>(object)->wrappedPtr())){};
@@ -195,7 +195,7 @@ public:
 }; // namespace llvmo
 
 namespace translate {
-template <> struct from_object<const llvm::FunctionCallee&, std::true_type> {
+template <> struct from_object<const llvm::FunctionCallee&> {
   typedef llvm::FunctionCallee DeclareType;
   DeclareType _v;
   from_object(llvmo::FunctionCallee_sp object) : _v(object->getFunctionType(), object->getCallee()){};
@@ -277,7 +277,7 @@ public:
 }; // namespace llvmo
 
 namespace translate {
-template <> struct from_object<llvm::Linker&, std::true_type> {
+template <> struct from_object<llvm::Linker&> {
   typedef llvm::Linker& DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(*(gc::As<llvmo::Linker_sp>(object)->wrappedPtr())){};
@@ -341,7 +341,7 @@ public:
 }; // namespace llvmo
 
 namespace translate {
-template <> struct from_object<llvm::orc::JITDylib*, std::true_type> {
+template <> struct from_object<llvm::orc::JITDylib*> {
   typedef llvm::orc::JITDylib* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::JITDylib_sp>(object)->wrappedPtr()){};
@@ -471,13 +471,13 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::Triple*, std::true_type> {
+template <> struct from_object<llvm::Triple*> {
   typedef llvm::Triple* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(object.nilp() ? NULL : gc::As<llvmo::Triple_sp>(object)->wrappedPtr()){};
 };
 
-template <> struct from_object<llvm::Triple&, std::true_type> {
+template <> struct from_object<llvm::Triple&> {
   typedef llvm::Triple& DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(*gc::As<llvmo::Triple_sp>(object)->wrappedPtr()){};
@@ -552,12 +552,12 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::TargetOptions*, std::true_type> {
+template <> struct from_object<llvm::TargetOptions*> {
   typedef llvm::TargetOptions* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(object.nilp() ? NULL : gc::As<llvmo::TargetOptions_sp>(object)->wrappedPtr()){};
 };
-template <> struct from_object<const llvm::TargetOptions&, std::true_type> {
+template <> struct from_object<const llvm::TargetOptions&> {
   typedef const llvm::TargetOptions& DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(*gc::As<llvmo::TargetOptions_sp>(object)->wrappedPtr()){};
@@ -605,7 +605,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::Target*, std::true_type> {
+template <> struct from_object<llvm::Target*> {
   typedef llvm::Target* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(object.nilp() ? NULL : gc::As<llvmo::Target_sp>(object)->wrappedPtr()){};
@@ -655,7 +655,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::MCSubtargetInfo*, std::true_type> {
+template <> struct from_object<llvm::MCSubtargetInfo*> {
   typedef llvm::MCSubtargetInfo* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(object.nilp() ? NULL : gc::As<llvmo::MCSubtargetInfo_sp>(object)->wrappedPtr()){};
@@ -698,7 +698,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::TargetSubtargetInfo*, std::true_type> {
+template <> struct from_object<llvm::TargetSubtargetInfo*> {
   typedef llvm::TargetSubtargetInfo* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<gc::smart_ptr<llvmo::TargetSubtargetInfo_O>>(object)->wrappedPtr()){};
@@ -712,7 +712,7 @@ template <> struct to_object<const llvm::TargetSubtargetInfo*> {
 }; // namespace translate
 
 namespace translate {
-template <> struct from_object<llvm::CodeGenOpt::Level, std::true_type> {
+template <> struct from_object<llvm::CodeGenOpt::Level> {
   typedef llvm::CodeGenOpt::Level DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(llvm::CodeGenOpt::Default) {
@@ -729,7 +729,7 @@ template <> struct from_object<llvm::CodeGenOpt::Level, std::true_type> {
 };
 
 #if LLVM_VERSION_MAJOR < 16
-template <> struct from_object<llvm::Optional<llvm::Reloc::Model>, std::true_type> {
+template <> struct from_object<llvm::Optional<llvm::Reloc::Model>> {
   typedef llvm::Optional<llvm::Reloc::Model> DeclareType;
   DeclareType _v;
   from_object(T_P object) {
@@ -749,7 +749,7 @@ template <> struct from_object<llvm::Optional<llvm::Reloc::Model>, std::true_typ
   }
 };
 #else
-template <> struct from_object<std::optional<llvm::Reloc::Model>, std::true_type> {
+template <> struct from_object<std::optional<llvm::Reloc::Model>> {
   typedef std::optional<llvm::Reloc::Model> DeclareType;
   DeclareType _v;
   from_object(T_P object) {
@@ -770,7 +770,7 @@ template <> struct from_object<std::optional<llvm::Reloc::Model>, std::true_type
 };
 #endif
 
-template <> struct from_object<llvm::CodeModel::Model, std::true_type> {
+template <> struct from_object<llvm::CodeModel::Model> {
   typedef llvm::CodeModel::Model DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(llvm::CodeModel::Small) {
@@ -785,7 +785,7 @@ template <> struct from_object<llvm::CodeModel::Model, std::true_type> {
     }
   }
 };
-template <> struct from_object<llvm::CodeGenFileType, std::true_type> {
+template <> struct from_object<llvm::CodeGenFileType> {
   typedef llvm::CodeGenFileType DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(llvm::CGFT_ObjectFile) {
@@ -848,7 +848,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::TargetMachine*, std::true_type> {
+template <> struct from_object<llvm::TargetMachine*> {
   typedef llvm::TargetMachine* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(object.nilp() ? NULL : gc::As<llvmo::TargetMachine_sp>(object)->wrappedPtr()){};
@@ -905,7 +905,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::LLVMTargetMachine*, std::true_type> {
+template <> struct from_object<llvm::LLVMTargetMachine*> {
   typedef llvm::LLVMTargetMachine* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::LLVMTargetMachine_sp>(object)->wrappedPtr()){};
@@ -959,7 +959,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::Value*, std::true_type> {
+template <> struct from_object<llvm::Value*> {
   typedef llvm::Value* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::Value_sp>(object)->wrappedPtr()){};
@@ -1037,7 +1037,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::Metadata*, std::true_type> {
+template <> struct from_object<llvm::Metadata*> {
   typedef llvm::Metadata* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::Metadata_sp>(object)->wrappedPtr()){};
@@ -1120,7 +1120,7 @@ public:
 /* to_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::MetadataAsValue*, std::true_type> {
+template <> struct from_object<llvm::MetadataAsValue*> {
   typedef llvm::MetadataAsValue* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::MetadataAsValue_sp>(object)->wrappedPtr()){};
@@ -1161,7 +1161,7 @@ public: // Functions here
 
 }; // namespace llvmo
 namespace translate {
-template <> struct from_object<llvm::Attribute::AttrKind, std::true_type> {
+template <> struct from_object<llvm::Attribute::AttrKind> {
   typedef llvm::Attribute::AttrKind DeclareType;
   DeclareType _v;
   from_object(core::T_sp object) {
@@ -1174,7 +1174,7 @@ template <> struct from_object<llvm::Attribute::AttrKind, std::true_type> {
   }
 };
 
-template <> struct from_object<llvm::Attribute, std::true_type> {
+template <> struct from_object<llvm::Attribute> {
   typedef llvm::Attribute DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::Attribute_sp>(object)->attributes()){};
@@ -1248,7 +1248,7 @@ namespace translate {
 // Since llvm3.8 there don't appear to be functions that
 // take or return llvm::DataLayout* pointers.  So I am commenting out
 // their converters and I changed the DataLayout_O class to store a llvm::DataLayout
-template <> struct from_object<llvm::DataLayout const&, std::true_type> {
+template <> struct from_object<llvm::DataLayout const&> {
   typedef llvm::DataLayout const& DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::DataLayout_sp>(object)->dataLayout()){};
@@ -1334,7 +1334,7 @@ namespace translate {
 template <> struct to_object<llvm::Constant*> {
   static core::T_sp convert(llvm::Constant* ptr) { return ((core::RP_Create_wrapped<llvmo::Constant_O, llvm::Constant*>(ptr))); };
 };
-template <> struct from_object<llvm::Constant*, std::true_type> {
+template <> struct from_object<llvm::Constant*> {
   typedef llvm::Constant* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::Constant_sp>(object)->wrappedPtr()){};
@@ -1535,7 +1535,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::GlobalVariable*, std::true_type> {
+template <> struct from_object<llvm::GlobalVariable*> {
   typedef llvm::GlobalVariable* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::GlobalVariable_sp>(object)->wrappedPtr()){};
@@ -1681,12 +1681,12 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::Module*, std::true_type> {
+template <> struct from_object<llvm::Module*> {
   typedef llvm::Module* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::Module_sp>(object)->wrappedPtr()){};
 };
-template <> struct from_object<llvm::Module&, std::true_type> {
+template <> struct from_object<llvm::Module&> {
   typedef llvm::Module& DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(*gc::As<llvmo::Module_sp>(object)->wrappedPtr()){};
@@ -1705,7 +1705,7 @@ template <> struct to_object<llvm::Module*> {
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::ExecutionEngine*, std::true_type> {
+template <> struct from_object<llvm::ExecutionEngine*> {
   typedef llvm::ExecutionEngine* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::ExecutionEngine_sp>(object)->wrappedPtr()){};
@@ -1773,7 +1773,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::EngineBuilder*, std::true_type> {
+template <> struct from_object<llvm::EngineBuilder*> {
   typedef llvm::EngineBuilder* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = (gc::As<llvmo::EngineBuilder_sp>(object)->wrappedPtr()); };
@@ -1800,7 +1800,7 @@ public:
 }; // APFloat_O
 }; // namespace llvmo
 namespace translate {
-template <> struct from_object<const llvm::APFloat&, std::true_type> {
+template <> struct from_object<const llvm::APFloat&> {
   typedef llvm::APFloat DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(*gc::As<llvmo::APFloat_sp>(object)->_valueP){};
@@ -1838,7 +1838,7 @@ public:
 }; // namespace llvmo
 /* from_object translators */
 namespace translate {
-template <> struct from_object<const llvm::APInt&, std::true_type> {
+template <> struct from_object<const llvm::APInt&> {
   typedef llvm::APInt DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::APInt_sp>(object)->_value._value){};
@@ -1910,7 +1910,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::IRBuilderBase*, std::true_type> {
+template <> struct from_object<llvm::IRBuilderBase*> {
   typedef llvm::IRBuilderBase* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::IRBuilderBase_sp>(object)->wrappedPtr(); };
@@ -1996,7 +1996,7 @@ public:
 }; // Instruction_O
 }; // namespace llvmo
 namespace translate {
-template <> struct from_object<llvm::Instruction*, std::true_type> {
+template <> struct from_object<llvm::Instruction*> {
   typedef llvm::Instruction* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::Instruction_sp>(object)->wrappedPtr(); };
@@ -2045,7 +2045,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::StoreInst*, std::true_type> {
+template <> struct from_object<llvm::StoreInst*> {
   typedef llvm::StoreInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::StoreInst_sp>(object)->wrappedPtr(); };
@@ -2082,7 +2082,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::FenceInst*, std::true_type> {
+template <> struct from_object<llvm::FenceInst*> {
   typedef llvm::FenceInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::FenceInst_sp>(object)->wrappedPtr(); };
@@ -2119,7 +2119,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::AtomicCmpXchgInst*, std::true_type> {
+template <> struct from_object<llvm::AtomicCmpXchgInst*> {
   typedef llvm::AtomicCmpXchgInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::AtomicCmpXchgInst_sp>(object)->wrappedPtr(); };
@@ -2158,7 +2158,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::AtomicRMWInst*, std::true_type> {
+template <> struct from_object<llvm::AtomicRMWInst*> {
   typedef llvm::AtomicRMWInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::AtomicRMWInst_sp>(object)->wrappedPtr(); };
@@ -2197,7 +2197,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::PHINode*, std::true_type> {
+template <> struct from_object<llvm::PHINode*> {
   typedef llvm::PHINode* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::PHINode_sp>(object)->wrappedPtr(); };
@@ -2272,7 +2272,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::CallInst*, std::true_type> {
+template <> struct from_object<llvm::CallInst*> {
   typedef llvm::CallInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::CallInst_sp>(object)->wrappedPtr(); };
@@ -2309,7 +2309,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::LandingPadInst*, std::true_type> {
+template <> struct from_object<llvm::LandingPadInst*> {
   typedef llvm::LandingPadInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::LandingPadInst_sp>(object)->wrappedPtr(); };
@@ -2370,7 +2370,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::AllocaInst*, std::true_type> {
+template <> struct from_object<llvm::AllocaInst*> {
   typedef llvm::AllocaInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::AllocaInst_sp>(object)->wrappedPtr(); };
@@ -2409,7 +2409,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::VAArgInst*, std::true_type> {
+template <> struct from_object<llvm::VAArgInst*> {
   typedef llvm::VAArgInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::VAArgInst_sp>(object)->wrappedPtr(); };
@@ -2447,7 +2447,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::LoadInst*, std::true_type> {
+template <> struct from_object<llvm::LoadInst*> {
   typedef llvm::LoadInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::LoadInst_sp>(object)->wrappedPtr(); };
@@ -2484,7 +2484,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::BranchInst*, std::true_type> {
+template <> struct from_object<llvm::BranchInst*> {
   typedef llvm::BranchInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::BranchInst_sp>(object)->wrappedPtr(); };
@@ -2525,7 +2525,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::SwitchInst*, std::true_type> {
+template <> struct from_object<llvm::SwitchInst*> {
   typedef llvm::SwitchInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::SwitchInst_sp>(object)->wrappedPtr(); };
@@ -2564,7 +2564,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::IndirectBrInst*, std::true_type> {
+template <> struct from_object<llvm::IndirectBrInst*> {
   typedef llvm::IndirectBrInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::IndirectBrInst_sp>(object)->wrappedPtr(); };
@@ -2604,7 +2604,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::InvokeInst*, std::true_type> {
+template <> struct from_object<llvm::InvokeInst*> {
   typedef llvm::InvokeInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::InvokeInst_sp>(object)->wrappedPtr(); };
@@ -2643,7 +2643,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::ResumeInst*, std::true_type> {
+template <> struct from_object<llvm::ResumeInst*> {
   typedef llvm::ResumeInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::ResumeInst_sp>(object)->wrappedPtr(); };
@@ -2682,7 +2682,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::UnreachableInst*, std::true_type> {
+template <> struct from_object<llvm::UnreachableInst*> {
   typedef llvm::UnreachableInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::UnreachableInst_sp>(object)->wrappedPtr(); };
@@ -2721,7 +2721,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::ReturnInst*, std::true_type> {
+template <> struct from_object<llvm::ReturnInst*> {
   typedef llvm::ReturnInst* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::ReturnInst_sp>(object)->wrappedPtr(); };
@@ -2903,7 +2903,7 @@ template <> struct to_object<llvm::ConstantPointerNull*> {
   static core::T_sp convert(llvm::ConstantPointerNull* ptr) { return ((llvmo::ConstantPointerNull_O::create(ptr))); }
 };
 
-template <> struct from_object<llvm::ConstantPointerNull*, std::true_type> {
+template <> struct from_object<llvm::ConstantPointerNull*> {
   typedef llvm::ConstantPointerNull* DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::ConstantPointerNull_sp>(object)->wrappedPtr()){};
@@ -2936,7 +2936,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::MDNode*, std::true_type> {
+template <> struct from_object<llvm::MDNode*> {
   typedef llvm::MDNode* DeclareType;
   DeclareType _v;
   from_object(T_P o) : _v(o.nilp() ? NULL : gc::As<llvmo::MDNode_sp>(o)->wrappedPtr()){};
@@ -2978,7 +2978,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::MDString*, std::true_type> {
+template <> struct from_object<llvm::MDString*> {
   typedef llvm::MDString* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::MDString_sp>(object)->wrappedPtr(); };
@@ -3018,7 +3018,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::ValueAsMetadata*, std::true_type> {
+template <> struct from_object<llvm::ValueAsMetadata*> {
   typedef llvm::ValueAsMetadata* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = gc::As<llvmo::ValueAsMetadata_sp>(object)->wrappedPtr(); };
@@ -3067,7 +3067,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::NamedMDNode*, std::true_type> {
+template <> struct from_object<llvm::NamedMDNode*> {
   typedef llvm::NamedMDNode* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = object.nilp() ? NULL : gc::As<llvmo::NamedMDNode_sp>(object)->wrappedPtr(); };
@@ -3134,7 +3134,7 @@ template <> struct to_object<const llvm::Function&> {
   };
 };
 
-template <> struct from_object<llvm::Function*, std::true_type> {
+template <> struct from_object<llvm::Function*> {
   typedef llvm::Function* DeclareType;
   DeclareType _v;
   from_object(T_P object) {
@@ -3145,12 +3145,12 @@ template <> struct from_object<llvm::Function*, std::true_type> {
     }
   }
 };
-template <> struct from_object<const llvm::Function&, std::true_type> {
+template <> struct from_object<const llvm::Function&> {
   typedef llvm::Function const& DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(*(static_cast<llvm::Function*>(gc::As<llvmo::Function_sp>(object)->wrappedPtr()))){};
 };
-template <> struct from_object<llvm::Function&, std::true_type> {
+template <> struct from_object<llvm::Function&> {
   typedef llvm::Function& DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(*(static_cast<llvm::Function*>(gc::As<llvmo::Function_sp>(object)->wrappedPtr()))){};
@@ -3195,7 +3195,7 @@ template <> struct to_object<llvm::BasicBlock*> {
     return ((nil<core::T_O>()));
   };
 };
-template <> struct from_object<llvm::BasicBlock*, std::true_type> {
+template <> struct from_object<llvm::BasicBlock*> {
   typedef llvm::BasicBlock* DeclareType;
   DeclareType _v;
   from_object(T_P object) {
@@ -3279,7 +3279,7 @@ public:
 /* from_object translators */
 
 namespace translate {
-template <> struct from_object<llvm::Type*, std::true_type> {
+template <> struct from_object<llvm::Type*> {
   typedef llvm::Type* DeclareType;
   DeclareType _v;
   from_object(T_P object) {
@@ -3327,7 +3327,7 @@ template <> struct to_object<llvm::FunctionType*> {
     return ((core::RP_Create_wrapped<llvmo::FunctionType_O, llvm::FunctionType*>(ptr)));
   };
 };
-template <> struct from_object<llvm::FunctionType*, std::true_type> {
+template <> struct from_object<llvm::FunctionType*> {
   typedef llvm::FunctionType* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = static_cast<llvm::FunctionType*>(gc::As<llvmo::FunctionType_sp>(object)->wrappedPtr()); }
@@ -3365,7 +3365,7 @@ template <> struct to_object<llvm::IntegerType*> {
     return ((core::RP_Create_wrapped<llvmo::IntegerType_O, llvm::IntegerType*>(ptr)));
   };
 };
-template <> struct from_object<llvm::IntegerType*, std::true_type> {
+template <> struct from_object<llvm::IntegerType*> {
   typedef llvm::IntegerType* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = static_cast<llvm::IntegerType*>(gc::As<llvmo::IntegerType_sp>(object)->wrappedPtr()); }
@@ -3408,7 +3408,7 @@ template <> struct to_object<llvm::StructType*> {
     return (Values(core::RP_Create_wrapped<llvmo::StructType_O, llvm::StructType*>(ptr)));
   };
 };
-template <> struct from_object<llvm::StructType*, std::true_type> {
+template <> struct from_object<llvm::StructType*> {
   typedef llvm::StructType* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = static_cast<llvm::StructType*>(gc::As<llvmo::StructType_sp>(object)->wrappedPtr()); }
@@ -3450,7 +3450,7 @@ template <> struct to_object<llvm::PointerType*> {
     return (Values(core::RP_Create_wrapped<llvmo::PointerType_O, llvm::PointerType*>(ptr)));
   };
 };
-template <> struct from_object<llvm::PointerType*, std::true_type> {
+template <> struct from_object<llvm::PointerType*> {
   typedef llvm::PointerType* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = static_cast<llvm::PointerType*>(gc::As<llvmo::PointerType_sp>(object)->wrappedPtr()); }
@@ -3489,7 +3489,7 @@ template <> struct to_object<llvm::ArrayType*> {
     return ((core::RP_Create_wrapped<llvmo::ArrayType_O, llvm::ArrayType*>(ptr)));
   };
 };
-template <> struct from_object<llvm::ArrayType*, std::true_type> {
+template <> struct from_object<llvm::ArrayType*> {
   typedef llvm::ArrayType* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = static_cast<llvm::ArrayType*>(gc::As<llvmo::ArrayType_sp>(object)->wrappedPtr()); }
@@ -3527,7 +3527,7 @@ template <> struct to_object<llvm::VectorType*> {
     return ((core::RP_Create_wrapped<llvmo::VectorType_O, llvm::VectorType*>(ptr)));
   };
 };
-template <> struct from_object<llvm::VectorType*, std::true_type> {
+template <> struct from_object<llvm::VectorType*> {
   typedef llvm::VectorType* DeclareType;
   DeclareType _v;
   from_object(T_P object) { this->_v = static_cast<llvm::VectorType*>(gc::As<llvmo::VectorType_sp>(object)->wrappedPtr()); }
@@ -3536,7 +3536,7 @@ template <> struct from_object<llvm::VectorType*, std::true_type> {
 
 namespace translate {
 
-template <> struct from_object<const llvm::StringRef, std::true_type> {
+template <> struct from_object<const llvm::StringRef> {
   typedef llvm::StringRef DeclareType;
   DeclareType _v;
   string _Storage;
@@ -3545,7 +3545,7 @@ template <> struct from_object<const llvm::StringRef, std::true_type> {
   from_object(from_object&& orig) : _v(_Storage), _Storage(std::move(orig._Storage)){};
 };
 
-template <> struct from_object<llvm::GlobalValue::LinkageTypes, std::true_type> {
+template <> struct from_object<llvm::GlobalValue::LinkageTypes> {
   typedef llvm::GlobalValue::LinkageTypes DeclareType;
   DeclareType _v;
   from_object(T_P object) {
@@ -3559,7 +3559,7 @@ template <> struct from_object<llvm::GlobalValue::LinkageTypes, std::true_type> 
   }
 };
 
-template <> struct from_object<llvm::GlobalValue::ThreadLocalMode, std::true_type> {
+template <> struct from_object<llvm::GlobalValue::ThreadLocalMode> {
   typedef llvm::GlobalValue::ThreadLocalMode DeclareType;
   DeclareType _v;
   from_object(T_P object) {
@@ -3575,7 +3575,7 @@ template <> struct from_object<llvm::GlobalValue::ThreadLocalMode, std::true_typ
   }
 };
 
-template <> struct from_object<llvm::AtomicOrdering, std::true_type> {
+template <> struct from_object<llvm::AtomicOrdering> {
   typedef llvm::AtomicOrdering DeclareType;
   DeclareType _v;
   from_object(core::T_sp object) {
@@ -3591,7 +3591,7 @@ template <> struct from_object<llvm::AtomicOrdering, std::true_type> {
   }
 };
 
-template <> struct from_object<llvm::AtomicRMWInst::BinOp, std::true_type> {
+template <> struct from_object<llvm::AtomicRMWInst::BinOp> {
   typedef llvm::AtomicRMWInst::BinOp DeclareType;
   DeclareType _v;
   from_object(T_P object) {
@@ -3605,7 +3605,7 @@ template <> struct from_object<llvm::AtomicRMWInst::BinOp, std::true_type> {
   }
 };
 
-template <> struct from_object<llvm::Instruction::CastOps, std::true_type> {
+template <> struct from_object<llvm::Instruction::CastOps> {
   typedef llvm::Instruction::CastOps DeclareType;
   DeclareType _v;
   from_object(T_P object) {
@@ -3619,7 +3619,7 @@ template <> struct from_object<llvm::Instruction::CastOps, std::true_type> {
   }
 };
 
-template <> struct from_object<llvm::Instruction::BinaryOps, std::true_type> {
+template <> struct from_object<llvm::Instruction::BinaryOps> {
   typedef llvm::Instruction::BinaryOps DeclareType;
   DeclareType _v;
   from_object(T_P object) {
@@ -3633,7 +3633,7 @@ template <> struct from_object<llvm::Instruction::BinaryOps, std::true_type> {
   }
 };
 
-template <> struct from_object<llvm::CmpInst::Predicate, std::true_type> {
+template <> struct from_object<llvm::CmpInst::Predicate> {
   typedef llvm::CmpInst::Predicate DeclareType;
   DeclareType _v;
   from_object(T_P object) {
@@ -3740,7 +3740,7 @@ public:
 }; // SectionedAddress_O
 }; // namespace llvmo
 namespace translate {
-template <> struct from_object<const llvm::object::SectionedAddress&, std::true_type> {
+template <> struct from_object<const llvm::object::SectionedAddress&> {
   typedef llvm::object::SectionedAddress DeclareType;
   DeclareType _v;
   from_object(T_P object) : _v(gc::As<llvmo::SectionedAddress_sp>(object)->_value){};

--- a/include/clasp/llvmo/llvmoExpose.h
+++ b/include/clasp/llvmo/llvmoExpose.h
@@ -3762,8 +3762,6 @@ template <typename T> struct from_object<llvm::Optional<T>> {
     this->_v = val;
     return;
   }
-  from_object(const from_object& orig) = delete;
-  from_object(from_object&& orig) : _v(std::move(orig._v)){};
 };
 } // namespace translate
 #else
@@ -3779,8 +3777,6 @@ template <typename T> struct from_object<std::optional<T>> {
     this->_v = val;
     return;
   }
-  from_object(const from_object& orig) = delete;
-  from_object(from_object&& orig) : _v(std::move(orig._v)){};
 };
 } // namespace translate
 #endif

--- a/include/clasp/llvmo/translators.h
+++ b/include/clasp/llvmo/translators.h
@@ -38,7 +38,7 @@ THE SOFTWARE.
 
 namespace translate {
 
-template <> struct from_object<llvm::StringRef, std::true_type> {
+template <> struct from_object<llvm::StringRef> {
   typedef llvm::StringRef DeclareType;
   string _Storage; // Store the string here so it won't get wiped out before its used by the callee
   DeclareType _v;
@@ -208,7 +208,7 @@ template <> struct from_object<std::function<bool(const llvm::Function&)>> {
   }
 };
 
-template <> struct from_object<llvm::MaybeAlign, std::true_type> {
+template <> struct from_object<llvm::MaybeAlign> {
   typedef llvm::MaybeAlign DeclareType;
   DeclareType _v;
   from_object(core::T_sp object) : _v((size_t)core::clasp_to_fixnum(object)){};

--- a/src/asttooling/clangTooling.cc
+++ b/src/asttooling/clangTooling.cc
@@ -783,7 +783,7 @@ CL_DEFUN clang::SourceLocation ast_tooling__getIncludeLoc(const clang::PresumedL
 namespace asttooling {
 DOCGROUP(clasp);
 CL_DEFUN core::T_mv ast_tooling__wrapped_JSONCompilationDatabase_loadFromFile(core::T_sp FilePath, core::Symbol_sp ssyntax) {
-  clang::tooling::JSONCommandLineSyntax syntax = translate::from_object<clang::tooling::JSONCommandLineSyntax>(ssyntax)._v;
+  clang::tooling::JSONCommandLineSyntax syntax = translate::make_from_object<clang::tooling::JSONCommandLineSyntax>(ssyntax);
   std::string ErrorMessage;
   std::unique_ptr<clang::tooling::JSONCompilationDatabase> result = clang::tooling::JSONCompilationDatabase::loadFromFile(
       gc::As<core::String_sp>(FilePath)->get_std_string(), ErrorMessage, syntax);

--- a/src/asttooling/clangTooling.cc
+++ b/src/asttooling/clangTooling.cc
@@ -124,8 +124,7 @@ template <> struct from_object<clang::tooling::ArgumentsAdjuster> {
         core::T_sp tfilename = translate::to_object<llvm::StringRef>::convert(filename);
         core::T_mv result = core::eval::funcall(func, targs, tfilename);
         ;
-        translate::from_object<const clang::tooling::CommandLineArguments&> cresult(result);
-        return cresult._v;
+        return translate::make_from_object<clang::tooling::CommandLineArguments>(result);
       };
       return;
     } else if (clang::tooling::ArgumentsAdjuster* argAdj =

--- a/src/core/fli.cc
+++ b/src/core/fli.cc
@@ -967,16 +967,6 @@ core::T_sp PERCENTmem_ref_unsigned_char(core::Integer_sp address) {
 
 // Lisp to C++ translation, used by mem_set()
 
-// inline ptrdiff_t clasp_to_ptrdiff( core::T_sp sp_lisp_value ) {
-//   translate::from_object< ptrdiff_t > v( sp_lisp_value );
-//   return v._v;
-// }
-
-// inline char clasp_to_char( core::T_sp sp_lisp_value ) {
-//   translate::from_object< char > v( sp_lisp_value );
-//   return v._v;
-// }
-
 void* clasp_to_void_pointer(ForeignData_sp sp_lisp_value) { return sp_lisp_value->ptr(); }
 
 // ---------------------------------------------------------------------------
@@ -991,194 +981,189 @@ template <typename T> inline T mem_set(uintptr_t address, T value) {
 
 core::T_sp PERCENTmem_set_short(core::Integer_sp address, core::T_sp value) {
   short tmp;
-  translate::from_object<short> v(value);
-  tmp = mem_set<short>(core::clasp_to_uintptr_t(address), v._v);
+  tmp = mem_set<short>(core::clasp_to_uintptr_t(address), translate::make_from_object<short>(value));
   return mk_fixnum_short(tmp);
 }
 
 core::T_sp PERCENTmem_set_unsigned_short(core::Integer_sp address, core::T_sp value) {
   unsigned short tmp;
-  translate::from_object<unsigned short> v(value);
-  tmp = mem_set<unsigned short>(core::clasp_to_uintptr_t(address), v._v);
+  tmp = mem_set<unsigned short>(core::clasp_to_uintptr_t(address), translate::make_from_object<unsigned short>(value));
   return mk_fixnum_ushort(tmp);
 }
 
 core::T_sp PERCENTmem_set_int(core::Integer_sp address, core::T_sp value) {
   int tmp;
-  translate::from_object<int> v(value);
-  tmp = mem_set<int>(core::clasp_to_uintptr_t(address), v._v);
+  tmp = mem_set<int>(core::clasp_to_uintptr_t(address), translate::make_from_object<int>(value));
   return mk_fixnum_int(tmp);
 }
 
 core::T_sp PERCENTmem_set_unsigned_int(core::Integer_sp address, core::T_sp value) {
   unsigned int tmp;
-  translate::from_object<unsigned int> v(value);
-  tmp = mem_set<unsigned int>(core::clasp_to_uintptr_t(address), v._v);
+  tmp = mem_set<unsigned int>(core::clasp_to_uintptr_t(address), translate::make_from_object<unsigned int>(value));
   return mk_fixnum_uint(tmp);
 }
 
 core::T_sp PERCENTmem_set_int8(core::Integer_sp address, core::T_sp value) {
   int8_t tmp;
-  translate::from_object<int8_t> v(value);
-  tmp = mem_set<int8_t>(core::clasp_to_uintptr_t(address), v._v);
+  tmp = mem_set<int8_t>(core::clasp_to_uintptr_t(address), translate::make_from_object<int8_t>(value));
   return mk_fixnum_int8(tmp);
 }
 
 core::T_sp PERCENTmem_set_uint8(core::Integer_sp address, core::T_sp value) {
   uint8_t tmp;
-  translate::from_object<uint8_t> v(value);
-  tmp = mem_set<uint8_t>(core::clasp_to_uintptr_t(address), v._v);
+  uint8_t v = translate::make_from_object<uint8_t>(value);
+  tmp = mem_set<uint8_t>(core::clasp_to_uintptr_t(address), v);
   return mk_fixnum_uint8(tmp);
 }
 
 core::T_sp PERCENTmem_set_int16(core::Integer_sp address, core::T_sp value) {
   int16_t tmp;
-  translate::from_object<int16_t> v(value);
-  tmp = mem_set<int16_t>(core::clasp_to_uintptr_t(address), v._v);
+  int16_t v = translate::make_from_object<int16_t>(value);
+  tmp = mem_set<int16_t>(core::clasp_to_uintptr_t(address), v);
   return mk_fixnum_int16(tmp);
 }
 
 core::T_sp PERCENTmem_set_uint16(core::Integer_sp address, core::T_sp value) {
   uint16_t tmp;
-  translate::from_object<uint16_t> v(value);
-  tmp = mem_set<uint16_t>(core::clasp_to_uintptr_t(address), v._v);
+  uint16_t v = translate::make_from_object<uint16_t>(value);
+  tmp = mem_set<uint16_t>(core::clasp_to_uintptr_t(address), v);
   return mk_fixnum_uint16(tmp);
 }
 
 core::T_sp PERCENTmem_set_int32(core::Integer_sp address, core::T_sp value) {
   int32_t tmp;
-  translate::from_object<int32_t> v(value);
-  tmp = mem_set<int32_t>(core::clasp_to_uintptr_t(address), v._v);
+  int32_t v = translate::make_from_object<int32_t>(value);
+  tmp = mem_set<int32_t>(core::clasp_to_uintptr_t(address), v);
   return mk_fixnum_int32(tmp);
 }
 
 core::T_sp PERCENTmem_set_uint32(core::Integer_sp address, core::T_sp value) {
   uint32_t tmp;
-  translate::from_object<uint32_t> v(value);
-  tmp = mem_set<uint32_t>(core::clasp_to_uintptr_t(address), v._v);
+  uint32_t v = translate::make_from_object<uint32_t>(value);
+  tmp = mem_set<uint32_t>(core::clasp_to_uintptr_t(address), v);
   return mk_fixnum_uint32(tmp);
 }
 
 core::T_sp PERCENTmem_set_int64(core::Integer_sp address, core::T_sp value) {
   int64_t tmp;
-  translate::from_object<int64_t> v(value);
-  tmp = mem_set<int64_t>(core::clasp_to_uintptr_t(address), v._v);
+  int64_t v = translate::make_from_object<int64_t>(value);
+  tmp = mem_set<int64_t>(core::clasp_to_uintptr_t(address), v);
   return mk_integer_int64(tmp);
 }
 
 core::T_sp PERCENTmem_set_uint64(core::Integer_sp address, core::T_sp value) {
   uint64_t tmp;
-  translate::from_object<uint64_t> v(value);
-  tmp = mem_set<uint64_t>(core::clasp_to_uintptr_t(address), v._v);
+  uint64_t v = translate::make_from_object<uint64_t>(value);
+  tmp = mem_set<uint64_t>(core::clasp_to_uintptr_t(address), v);
   return mk_integer_uint64(tmp);
 }
 
 core::T_sp PERCENTmem_set_long(core::Integer_sp address, core::T_sp value) {
   long tmp;
-  translate::from_object<long> v(value);
-  tmp = mem_set<long>(core::clasp_to_uintptr_t(address), v._v);
+  long v = translate::make_from_object<long>(value);
+  tmp = mem_set<long>(core::clasp_to_uintptr_t(address), v);
   return mk_integer_long(tmp);
 }
 
 core::T_sp PERCENTmem_set_unsigned_long(core::Integer_sp address, core::T_sp value) {
   unsigned long tmp;
-  translate::from_object<unsigned long> v(value);
-  tmp = mem_set<unsigned long>(core::clasp_to_uintptr_t(address), v._v);
+  unsigned long v = translate::make_from_object<unsigned long>(value);
+  tmp = mem_set<unsigned long>(core::clasp_to_uintptr_t(address), v);
   return mk_integer_ulong(tmp);
 }
 
 core::T_sp PERCENTmem_set_long_long(core::Integer_sp address, core::T_sp value) {
   long long tmp;
-  translate::from_object<long long> v(value);
-  tmp = mem_set<long long>(core::clasp_to_uintptr_t(address), v._v);
-  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v._v);
+  long long v = translate::make_from_object<long long>(value);
+  tmp = mem_set<long long>(core::clasp_to_uintptr_t(address), v);
+  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v);
   return mk_integer_longlong(tmp);
 }
 
 core::T_sp PERCENTmem_set_unsigned_long_long(core::Integer_sp address, core::T_sp value) {
   unsigned long long tmp;
-  translate::from_object<uint64_t /*unsigned long long*/> v(value);
-  tmp = mem_set<unsigned long long>(core::clasp_to_uintptr_t(address), v._v);
-  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v._v);
+  unsigned long long v = translate::make_from_object<uint64_t>(value);
+  tmp = mem_set<unsigned long long>(core::clasp_to_uintptr_t(address), v);
+  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v);
   return mk_integer_ulonglong(tmp);
 }
 
 core::T_sp PERCENTmem_set_double(core::Integer_sp address, core::T_sp value) {
   double tmp;
-  translate::from_object<double> v(value);
-  tmp = mem_set<double>(core::clasp_to_uintptr_t(address), v._v);
-  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v._v);
+  double v = translate::make_from_object<double>(value);
+  tmp = mem_set<double>(core::clasp_to_uintptr_t(address), v);
+  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v);
   return mk_double_float(tmp);
 }
 
 core::T_sp PERCENTmem_set_float(core::Integer_sp address, core::T_sp value) {
   float tmp;
-  translate::from_object<float> v(value);
-  tmp = mem_set<float>(core::clasp_to_uintptr_t(address), v._v);
-  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v._v);
+  float v = translate::make_from_object<float>(value);
+  tmp = mem_set<float>(core::clasp_to_uintptr_t(address), v);
+  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v);
   return mk_single_float(tmp);
 }
 
 core::T_sp PERCENTmem_set_long_double(core::Integer_sp address, core::T_sp value) {
   long double tmp;
-  translate::from_object<long double> v(value);
-  tmp = mem_set<long double>(core::clasp_to_uintptr_t(address), v._v);
+  long double v = translate::make_from_object<long double>(value);
+  tmp = mem_set<long double>(core::clasp_to_uintptr_t(address), v);
   return mk_long_double(tmp);
 }
 
 core::T_sp PERCENTmem_set_time(core::Integer_sp address, core::T_sp value) {
   time_t tmp;
-  translate::from_object<time_t> v(value);
-  tmp = mem_set<time_t>(core::clasp_to_uintptr_t(address), v._v);
-  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v._v);
+  time_t v = translate::make_from_object<time_t>(value);
+  tmp = mem_set<time_t>(core::clasp_to_uintptr_t(address), v);
+  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v);
   return mk_time(tmp);
 }
 
 core::T_sp PERCENTmem_set_pointer(core::Integer_sp address, core::T_sp value) {
   void* tmp;
-  translate::from_object<void*> v(value);
-  tmp = mem_set<void*>(core::clasp_to_uintptr_t(address), v._v);
-  DEBUG_PRINT(BF("%s (%s:%d) | v = %p\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v._v);
+  void* v = translate::make_from_object<void*>(value);
+  tmp = mem_set<void*>(core::clasp_to_uintptr_t(address), v);
+  DEBUG_PRINT(BF("%s (%s:%d) | v = %p\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v);
   return mk_pointer(tmp);
 }
 
 core::T_sp PERCENTmem_set_size(core::Integer_sp address, core::T_sp value) {
   size_t tmp;
-  translate::from_object<size_t> v(value);
-  tmp = mem_set<size_t>(core::clasp_to_uintptr_t(address), v._v);
-  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v._v);
+  size_t v = translate::make_from_object<size_t>(value);
+  tmp = mem_set<size_t>(core::clasp_to_uintptr_t(address), v);
+  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v);
   return mk_size(tmp);
 }
 
 core::T_sp PERCENTmem_set_ssize(core::Integer_sp address, core::T_sp value) {
   ssize_t tmp;
-  translate::from_object<ssize_t> v(value);
-  tmp = mem_set<ssize_t>(core::clasp_to_uintptr_t(address), v._v);
-  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v._v);
+  ssize_t v = translate::make_from_object<ssize_t>(value);
+  tmp = mem_set<ssize_t>(core::clasp_to_uintptr_t(address), v);
+  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v);
   return mk_ssize(tmp);
 }
 
 core::T_sp PERCENTmem_set_ptrdiff(core::Integer_sp address, core::T_sp value) {
   ptrdiff_t tmp;
-  translate::from_object<ptrdiff_t> v(value);
-  tmp = mem_set<ptrdiff_t>(core::clasp_to_uintptr_t(address), v._v);
-  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v._v);
+  ptrdiff_t v = translate::make_from_object<ptrdiff_t>(value);
+  tmp = mem_set<ptrdiff_t>(core::clasp_to_uintptr_t(address), v);
+  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v);
   return mk_ptrdiff(tmp);
 }
 
 core::T_sp PERCENTmem_set_char(core::Integer_sp address, core::T_sp value) {
   int8_t tmp;
-  translate::from_object<int8_t> v(value);
-  tmp = mem_set<int8_t>(core::clasp_to_uintptr_t(address), v._v);
-  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v._v);
+  int8_t v = translate::make_from_object<int8_t>(value);
+  tmp = mem_set<int8_t>(core::clasp_to_uintptr_t(address), v);
+  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v);
   return mk_fixnum_int8(tmp);
 }
 
 core::T_sp PERCENTmem_set_unsigned_char(core::Integer_sp address, core::T_sp value) {
   uint8_t tmp;
-  translate::from_object<uint8_t> v(value);
-  tmp = mem_set<uint8_t>(core::clasp_to_uintptr_t(address), v._v);
-  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v._v);
+  uint8_t v = translate::make_from_object<uint8_t>(value);
+  tmp = mem_set<uint8_t>(core::clasp_to_uintptr_t(address), v);
+  DEBUG_PRINT(BF("%s (%s:%d) | v = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % v);
   return mk_fixnum_uint8(tmp);
 }
 

--- a/src/gctools/memoryManagement.cc
+++ b/src/gctools/memoryManagement.cc
@@ -273,7 +273,7 @@ DOCGROUP(clasp);
 CL_DEFUN void gctools__register_roots(core::T_sp taddress, core::List_sp args) {
   size_t nargs = core::cl__length(args);
   // Get the address of the memory space in the llvm::Module
-  uintptr_t address = translate::from_object<uintptr_t>(taddress)._v;
+  uintptr_t address = translate::make_from_object<uintptr_t>(taddress);
   core::T_O** module_mem = reinterpret_cast<core::T_O**>(address);
   //  printf("%s:%d:%s address=%p nargs=%" PRu "\n", __FILE__, __LINE__, __FUNCTION__, (void*)address, nargs);
   //  printf("%s:%d:%s constants-table contents: vvvvv\n", __FILE__, __LINE__, __FUNCTION__ );

--- a/src/llvmo/intrinsics.cc
+++ b/src/llvmo/intrinsics.cc
@@ -290,7 +290,7 @@ ALWAYS_INLINE core::T_O* to_object_unsigned_int(unsigned int x) { return to_obje
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE long from_object_long(core::T_O* obj) {
-  long x = translate::from_object<long>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  long x = translate::make_from_object<long>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -301,7 +301,7 @@ ALWAYS_INLINE core::T_O* to_object_long(long x) { return translate::to_object<lo
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE unsigned long from_object_unsigned_long(core::T_O* obj) {
-  unsigned long x = translate::from_object<unsigned long>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  unsigned long x = translate::make_from_object<unsigned long>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -360,7 +360,7 @@ ALWAYS_INLINE core::T_O* to_object_uint32(uint32_t x) { return to_object_fixnum(
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE int64_t from_object_int64(core::T_O* obj) {
-  int64_t x = translate::from_object<int64_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  int64_t x = translate::make_from_object<int64_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -371,7 +371,7 @@ ALWAYS_INLINE core::T_O* to_object_int64(int64_t x) { return translate::to_objec
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE uint64_t from_object_uint64(core::T_O* obj) {
-  uint64_t x = translate::from_object<uint64_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  uint64_t x = translate::make_from_object<uint64_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -383,7 +383,7 @@ ALWAYS_INLINE core::T_O* to_object_uint64(uint64_t x) { return translate::to_obj
 
 ALWAYS_INLINE long long from_object_long_long(core::T_O* obj) {
   core::T_sp tobj((gctools::Tagged)obj);
-  long long x = translate::from_object<long long>(tobj)._v; // gctools::smart_ptr<core::T_O>((gctools::Tagged) obj ))._v;
+  long long x = translate::make_from_object<long long>(tobj);
   return x;
 }
 
@@ -394,7 +394,7 @@ ALWAYS_INLINE core::T_O* to_object_long_long(long long x) { return translate::to
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE unsigned long long from_object_unsigned_long_long(core::T_O* obj) {
-  unsigned long long x = translate::from_object<long long>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  unsigned long long x = translate::make_from_object<long long>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -407,7 +407,7 @@ ALWAYS_INLINE core::T_O* to_object_unsigned_long_long(unsigned long long x) {
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE size_t from_object_size(core::T_O* obj) {
-  size_t x = translate::from_object<size_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  size_t x = translate::make_from_object<size_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -418,7 +418,7 @@ ALWAYS_INLINE core::T_O* to_object_size(size_t x) { return translate::to_object<
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE size_t from_object_ssize(core::T_O* obj) {
-  ssize_t x = translate::from_object<ssize_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  ssize_t x = translate::make_from_object<ssize_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -429,7 +429,7 @@ ALWAYS_INLINE core::T_O* to_object_ssize(ssize_t x) { return translate::to_objec
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE ptrdiff_t from_object_ptrdiff(core::T_O* obj) {
-  ptrdiff_t x = translate::from_object<ptrdiff_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  ptrdiff_t x = translate::make_from_object<ptrdiff_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -440,7 +440,7 @@ ALWAYS_INLINE core::T_O* to_object_ptrdiff(ptrdiff_t x) { return translate::to_o
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE time_t from_object_time(core::T_O* obj) {
-  time_t x = translate::from_object<time_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  time_t x = translate::make_from_object<time_t>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -451,7 +451,7 @@ ALWAYS_INLINE core::T_O* to_object_time(time_t x) { return translate::to_object<
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE char from_object_char(core::T_O* obj) {
-  char x = translate::from_object<char>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  char x = translate::make_from_object<char>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -462,7 +462,7 @@ ALWAYS_INLINE core::T_O* to_object_char(char x) { return translate::to_object<ch
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE unsigned char from_object_unsigned_char(core::T_O* obj) {
-  unsigned char x = translate::from_object<unsigned char>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  unsigned char x = translate::make_from_object<unsigned char>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -515,7 +515,7 @@ ALWAYS_INLINE core::T_O* to_object_float(float x) { return translate::to_object<
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE double from_object_double(core::T_O* obj) {
-  double x = translate::from_object<double>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  double x = translate::make_from_object<double>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 
@@ -526,7 +526,7 @@ ALWAYS_INLINE core::T_O* to_object_double(double x) { return translate::to_objec
 // ----------------------------------------------------------------------------
 
 ALWAYS_INLINE long double from_object_long_double(core::T_O* obj) {
-  long double x = translate::from_object<long double>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj))._v;
+  long double x = translate::make_from_object<long double>(gctools::smart_ptr<core::T_O>((gctools::Tagged)obj));
   return x;
 }
 


### PR DESCRIPTION
Basic cleanup. Removes the second template parameter from `from_object` as well as a bunch of unnecessary specializations.