### PR TITLE
Update Eclector function name

### DIFF
--- a/src/lisp/kernel/cmp/activate-clasp-readtables-for-eclector.lisp
+++ b/src/lisp/kernel/cmp/activate-clasp-readtables-for-eclector.lisp
@@ -53,7 +53,7 @@
 
 (defclass clasp-tracking-elector-client (cmp:clasp-eclector-client-mixin eclector.parse-result:parse-result-client) ())
 
-(defmethod eclector.parse-result:source-position
+(defmethod eclector.base:source-position
     ((client clasp-tracking-elector-client) stream)
   (cmp:compile-file-source-pos-info stream))
 

--- a/src/lisp/kernel/cmp/eclector-client.lisp
+++ b/src/lisp/kernel/cmp/eclector-client.lisp
@@ -10,7 +10,7 @@
   (locally (declare (notinline make-instance))
     (make-instance 'clasp-cst-client)))
 
-(defmethod eclector.parse-result:source-position
+(defmethod eclector.base:source-position
     ((client clasp-cst-client) stream)
   (cmp:compile-file-source-pos-info stream))
 


### PR DESCRIPTION
`parse-result:source-position` is being replaced with `base:` in the next version. Get out ahead of that.