### PR TITLE
Fix extended sequences in the type system

### DIFF
--- a/src/lisp/kernel/clos/boot.lisp
+++ b/src/lisp/kernel/clos/boot.lisp
@@ -175,6 +175,11 @@
   (setq +the-std-class+ (find-class 'std-class nil))
   (setq +the-funcallable-standard-class+
         (find-class 'funcallable-standard-class nil)))
+
+;; Undefine the SEQUENCE type expansion, which does not account
+;; for extended sequences. Redefining SEQUENCE like this is a KLUDGE.
+(setf (ext:type-expander 'sequence) nil)
+
 ;;
 ;; Finalize
 ;;

--- a/src/lisp/kernel/cmp/opt/opt-type.lisp
+++ b/src/lisp/kernel/cmp/opt/opt-type.lisp
@@ -361,7 +361,9 @@
                   et
                   (upgraded-array-element-type et env)))))
           ((sequence)
-           `(or (listp object) (vectorp object)))
+           `(or (listp object) (vectorp object)
+                (subclassp (class-of object)
+                           (load-time-value (find-class 'sequence)))))
           ((standard-char)
            `(and (characterp object) (standard-char-p object)))
           ;; NOTE: Probably won't actually occur, due to normalization.

--- a/src/lisp/kernel/lsp/predlib.lisp
+++ b/src/lisp/kernel/lsp/predlib.lisp
@@ -527,7 +527,9 @@ Returns T if X belongs to TYPE; NIL otherwise."
     ;; Note that if you decide to change this, you'll need to alter the
     ;; compiler macro (in cmp/opt-type.lisp) as well.
     (COMPLEX (complexp object))
-    (SEQUENCE (or (listp object) (vectorp object)))
+    (SEQUENCE (or (listp object) (vectorp object)
+                  (si:subclassp (class-of object)
+                                (find-class 'sequence))))
     (CONS (and (consp object)
 	       (or (endp i)
 		   (let ((car-type (first i)))
@@ -1222,8 +1224,6 @@ if not possible."
       (SIMPLE-BASE-STRING (SIMPLE-ARRAY BASE-CHAR (*)))
       (core:simple-character-string (SIMPLE-ARRAY CHARACTER (*)))
       (BIT-VECTOR (ARRAY BIT (*)))
-
-      (SEQUENCE (OR CONS (MEMBER NIL) (ARRAY * (*))))
 
       (HASH-TABLE)
       (PATHNAME)


### PR DESCRIPTION
Currently this fixes typep and not subtypep. and it breaks `(subtypep '(cons foo) 'sequence)`.

I think Baker's subtypep is kind of totally incompatible with extended sequences in any meaningful way, because `sequence` is effectively in all of the array, list, and class "type families".