### PR TITLE
Remove MPS from preciseprep builds

### DIFF
--- a/include/clasp/core/core.h
+++ b/include/clasp/core/core.h
@@ -46,11 +46,11 @@ THE SOFTWARE.
 // Checkif we are running the static analyzer
 // Modify the preprocessor settings for the static analyzer
 // Turn on USE_MPS and turn off USE_BOEHM
-#ifdef RUNNING_PRECISEPREP
-#undef USE_BOEHM
-#undef USE_MMTK
-#define USE_MPS
-#endif
+//#ifdef RUNNING_PRECISEPREP
+//#undef USE_BOEHM
+//#undef USE_MMTK
+//#define USE_MPS
+//#endif
 
 /*! Old way of doing #= and ## used alists which are slow
   Switch to hash-tables to speed things up */

--- a/repos.sexp
+++ b/repos.sexp
@@ -204,10 +204,6 @@
   :repository "https://github.com/clasp-developers/asdf.git"
   :directory "src/lisp/modules/asdf/"
   :branch "add-clasp-bytecode-support")
- (:name :mps
-  :repository "https://github.com/Ravenbrook/mps.git"
-  :directory "src/mps/"
-  :commit "b8a05a3846430bc36c8200f24d248c8293801503")
  (:name :bdwgc
   :repository "https://github.com/ivmai/bdwgc.git"
   :directory "src/bdwgc/"

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -241,7 +241,7 @@ CL_DEFUN T_sp cl__lisp_implementation_version() {
 #endif
 #endif
 #ifdef RUNNING_PRECISEPREP
-  ss << "mpsprep-";
+  ss << "prep-";
 #endif
   ss << CLASP_VERSION;
   if (cst.notnilp())

--- a/src/gctools/cscript.lisp
+++ b/src/gctools/cscript.lisp
@@ -10,7 +10,6 @@
            #~"exposeClasses3.cc"
            #~"boehmGarbageCollection.cc"
            #~"mmtkGarbageCollection.cc"
-           #~"mpsGarbageCollection.cc"
            #~"hardErrors.cc"
            #~"source_info.cc"
            #~"threadlocal.cc"

--- a/src/koga/compile-commands.lisp
+++ b/src/koga/compile-commands.lisp
@@ -2,7 +2,7 @@
 
 ;; This method creates a JSON Compilation Database that is compatible with
 ;; https://clang.llvm.org/docs/JSONCompilationDatabase.html
-;; This file is used by preciseprep to create an AST and sif file to enable
+;; This file is used by boehm to create an AST and sif file to enable
 ;; the precise variants.
 (defmethod print-variant-target-sources
     (configuration (name (eql :compile-commands)) output-stream (target (eql :iclasp)) sources

--- a/src/koga/configure.lisp
+++ b/src/koga/configure.lisp
@@ -720,8 +720,8 @@ is not compatible with snapshots.")
                              (make-instance 'variant :gc :boehm :precise t)
                              (make-instance 'variant :gc :boehm :debug t)
                              (make-instance 'variant :gc :boehm :precise t :debug t)
-                             (make-instance 'variant :gc :mps :prep t)
-                             (make-instance 'variant :gc :mps :debug t :prep t))
+                             (make-instance 'variant :gc :boehm :prep t)
+                             (make-instance 'variant :gc :boehm :debug t :prep t))
              :type list
              :documentation "A list of the variants")
    (scripts :accessor scripts
@@ -882,7 +882,7 @@ the function to the overall configuration."
   (:documentation "Configure a specific unit"))
 
 (defun variant-name (variant)
-  "Return the variant name, i.e. boehm, boehmprecise, preciseprep, etc"
+  "Return the variant name, i.e. boehm, boehmprecise, etc"
   (format nil "~:[~(~a~)~:[~;precise~]~;preciseprep~]"
           (variant-prep variant)
           (variant-gc variant)

--- a/src/koga/help.lisp
+++ b/src/koga/help.lisp
@@ -21,8 +21,7 @@ OPTIONS:")
 TARGETS:
 If no target is given to ninja then the default is cclasp-boehmprecise.
 
-  analyze: Run the static analyzer on the boehm variant. Builds preciseprep as
-    needed.
+  analyze: Run the static analyzer on the boehm variant.
 
   test: Run the regression tests on the boehmprecise variant.
 
@@ -44,7 +43,6 @@ If no target is given to ninja then the default is cclasp-boehmprecise.
     Unless you are developing clasp the \"c\" stage is generally what you want.
     The -d suffix will enable debug mode.
 
-  analyze-boehm[-d]: Run the static analyzer on the specified variant. Builds
-    preciseprep as needed.
+  analyze-boehm[-d]: Run the static analyzer on the specified variant
 
   test-boehm[precise][-d]: Run the regression tests on the specified variant."))

--- a/src/koga/ninja.lisp
+++ b/src/koga/ninja.lisp
@@ -768,7 +768,7 @@
     (configuration (name (eql :ninja)) output-stream (target (eql :analyze))
      (source c-source)
      &aux (output (make-source-output source :type "sa"))
-          (database (make-source (format nil "preciseprep~:[~;-d~]/compile_commands.json"
+          (database (make-source (format nil "boehm~:[~;-d~]/compile_commands.json"
                                          *variant-debug*)
                                  :build)))
   (declare (ignore configuration name target))
@@ -777,7 +777,7 @@
                        :clasp (make-source "iclasp" :variant)
                        :inputs (list source)
                        :implicit-inputs (list (build-name "cclasp")
-                                              (build-name "generated" :prep t :gc :mps)
+                                              (build-name "generated" :gc :boehm)
                                               database
                                               (make-source "analyzer.stub" :variant-lib))                                    
                        :database database
@@ -797,7 +797,7 @@
                        :clasp (make-source "iclasp" :variant)
                        :inputs outputs
                        :implicit-inputs (list (build-name "cclasp")
-                                              (build-name "generated" :prep t :gc :mps)
+                                              (build-name "generated" :gc :boehm)
                                               (make-source "analyzer.stub" :variant-lib))                                    
                        :sif sif
                        :outputs (list (build-name "analyze")))


### PR DESCRIPTION
Leave the defines in for reference during MMTK integration.