### PR TITLE
Package reform

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,6 +2,7 @@
 
 ## Fixed
 * Pathnames and filesystem operations support Unicode (#1595).
+* Package names support Unicode (#1596).
 
 # Version 2.6.0 (LLVM15-18) 2024-06-03
 

--- a/include/clasp/core/designators.h
+++ b/include/clasp/core/designators.h
@@ -60,7 +60,7 @@ extern Package_sp packageDesignator(T_sp obj);
 extern T_sp packageDesignatorNoError(T_sp obj);
 
 /*! Return the name of a Package by interpreting a package or a string as a name */
-extern string packageNameDesignator(T_sp obj);
+extern SimpleString_sp packageNameDesignator(T_sp obj);
 
 /*! Return a List of packages by interpreting as a list of package designators */
 extern List_sp listOfPackageDesignators(T_sp obj);

--- a/include/clasp/core/lisp.h
+++ b/include/clasp/core/lisp.h
@@ -746,6 +746,7 @@ public:
   Package_sp getCurrentPackage() const;
   void mapNameToPackage(const string& name, Package_sp pkg);
   void unmapNameToPackage(const string& name);
+  void unmapNameToPackage(String_sp packageName);
   void finishPackageSetup(const string& packageName, list<string> const& nicknames, list<string> const& usePackages,
                           list<string> const& shadow = {});
   Package_sp makePackage(const string& packageName, list<string> const& nicknames, list<string> const& usePackages,

--- a/include/clasp/core/lisp.h
+++ b/include/clasp/core/lisp.h
@@ -735,11 +735,13 @@ public:
   /*! Return true if classSymbol is the id for a class that has the baseClassSymbol
    */
   //	bool subClassOrder(Symbol_sp baseClassSymbol,Symbol_sp classSymbol);
-
+private:
+  T_sp findPackage_no_lock(String_sp packageName) const;
+  T_sp findPackage_no_lock(const string& packageName) const;
+  
+public:
   bool recognizesPackage(const string& packageName) const;
-  T_sp findPackage_no_lock(const string& packageName, bool errorp = false) const;
   T_sp findPackage(const string& packageName, bool errorp = false) const;
-  T_sp findPackage_no_lock(String_sp packageName, bool errorp = false) const;
   T_sp findPackage(String_sp packageName, bool errorp = false) const;
   void inPackage(const string& packageName);
   void selectPackage(Package_sp pack);

--- a/include/clasp/core/lisp.h
+++ b/include/clasp/core/lisp.h
@@ -751,7 +751,7 @@ public:
                           list<string> const& shadow = {});
   Package_sp makePackage(const string& packageName, list<string> const& nicknames, list<string> const& usePackages,
                          list<string> const& shadow = {});
-  void remove_package(const string& package_name);
+  void remove_package(String_sp package_name);
   bool usePackage(const string& packageName);
 
   List_sp getBackTrace() const;

--- a/include/clasp/core/lisp.h
+++ b/include/clasp/core/lisp.h
@@ -745,7 +745,7 @@ public:
   void selectPackage(Package_sp pack);
   Package_sp getCurrentPackage() const;
   void mapNameToPackage(const string& name, Package_sp pkg);
-  void unmapNameToPackage(const string& name);
+  void mapNameToPackage(String_sp packageName, Package_sp pkg);
   void unmapNameToPackage(String_sp packageName);
   void finishPackageSetup(const string& packageName, list<string> const& nicknames, list<string> const& usePackages,
                           list<string> const& shadow = {});

--- a/include/clasp/core/lisp.h
+++ b/include/clasp/core/lisp.h
@@ -753,6 +753,7 @@ public:
                           list<string> const& shadow = {});
   Package_sp makePackage(const string& packageName, list<string> const& nicknames, list<string> const& usePackages,
                          list<string> const& shadow = {});
+  Package_sp makePackage(SimpleString_sp packageName, List_sp nicknames, List_sp use);
   void remove_package(String_sp package_name);
   bool usePackage(const string& packageName);
 

--- a/include/clasp/core/package.h
+++ b/include/clasp/core/package.h
@@ -120,7 +120,6 @@ public:
   /*! support for CLHS::unexport */
   void unexport(Symbol_sp sym);
 
-  string getName() const;
   void setName(const string& n);
 
   bool isExported(Symbol_sp sym);

--- a/include/clasp/core/package.h
+++ b/include/clasp/core/package.h
@@ -88,6 +88,7 @@ private:
 
 public:
   string packageName() const;
+  SimpleString_sp name() const { return this->_Name; }
 
   T_mv packageHashTables() const;
 
@@ -120,7 +121,7 @@ public:
   /*! support for CLHS::unexport */
   void unexport(Symbol_sp sym);
 
-  void setName(const string& n);
+  void setName(SimpleString_sp newName);
 
   bool isExported(Symbol_sp sym);
 

--- a/include/clasp/core/package.h
+++ b/include/clasp/core/package.h
@@ -74,6 +74,7 @@ public: // instance variables
 
 public: // Creation class functions
   static Package_sp create(const string& p);
+  static Package_sp create(SimpleString_sp name);
 
 public:
   /*! Very low level - add to internal symbols unless keyword

--- a/include/clasp/core/package.h
+++ b/include/clasp/core/package.h
@@ -50,7 +50,7 @@ class Package_O : public General_O {
 public: // virtual functions inherited from Object
   void initialize() override;
   string __repr__() const override;
-  void __write__(T_sp stream) const override;
+  void __write__(T_sp stream) const override; // in write_ugly.cc
 
 public: // instance variables
   HashTableEqual_sp _InternalSymbols;

--- a/src/core/designators.cc
+++ b/src/core/designators.cc
@@ -144,12 +144,11 @@ CL_DEFUN core::Package_sp coerce_to_package(core::T_sp obj) { return coerce::pac
 
 namespace core {
 namespace coerce {
-string packageNameDesignator(T_sp obj) {
+SimpleString_sp packageNameDesignator(T_sp obj) {
   if (cl__packagep(obj)) {
-    return gc::As<Package_sp>(obj)->packageName();
-  }
-  String_sp packageName = stringDesignator(obj);
-  return packageName->get_std_string();
+    return gc::As<Package_sp>(obj)->name();
+  } else
+    return simple_string(obj);
 }
 
 List_sp listOfPackageDesignators(T_sp obj) {

--- a/src/core/designators.cc
+++ b/src/core/designators.cc
@@ -120,7 +120,7 @@ core::T_sp packageDesignatorInternal(core::T_sp obj, bool errorp) {
   }
   TYPE_ERROR(obj, Cons_O::createList(cl::_sym_or, cl::_sym_string, cl::_sym_Symbol_O, cl::_sym_character));
 PACKAGE_NAME:
-  T_sp tpkg = _lisp->findPackage(packageName->get_std_string(), false);
+  T_sp tpkg = _lisp->findPackage(packageName, false);
   if (tpkg.notnilp()) {
     Package_sp pkg = gc::As<Package_sp>(tpkg);
     return pkg;

--- a/src/core/designators.cc
+++ b/src/core/designators.cc
@@ -146,7 +146,7 @@ namespace core {
 namespace coerce {
 string packageNameDesignator(T_sp obj) {
   if (cl__packagep(obj)) {
-    return gc::As<Package_sp>(obj)->getName();
+    return gc::As<Package_sp>(obj)->packageName();
   }
   String_sp packageName = stringDesignator(obj);
   return packageName->get_std_string();

--- a/src/core/foundation.cc
+++ b/src/core/foundation.cc
@@ -964,7 +964,7 @@ void lisp_defineSingleDispatchMethod(T_sp name, Symbol_sp classSymbol,
   string arguments = fix_method_lambda(classSymbol, raw_arguments);
   Instance_sp receiver_class = gc::As<Instance_sp>(eval::funcall(cl::_sym_findClass, classSymbol, _lisp->_true()));
   Symbol_sp className = receiver_class->_className();
-  List_sp ldeclares = lisp_parse_declares(gc::As<Package_sp>(className->getPackage())->getName(), declares);
+  List_sp ldeclares = lisp_parse_declares(gc::As<Package_sp>(className->getPackage())->packageName(), declares);
   // NOTE: We are compiling the llhandler in the package of the class - not the package of the
   // method name  -- sometimes the method name will belong to another class (ie: core:--init--)
   List_sp lambda_list;
@@ -972,10 +972,10 @@ void lisp_defineSingleDispatchMethod(T_sp name, Symbol_sp classSymbol,
   if (useTemplateDispatchOn)
     single_dispatch_argument_index = TemplateDispatchOn;
   if (arguments == "" && number_of_required_arguments >= 0) {
-    lambda_list = lisp_parse_arguments(gc::As<Package_sp>(className->getPackage())->getName(), arguments,
+    lambda_list = lisp_parse_arguments(gc::As<Package_sp>(className->getPackage())->packageName(), arguments,
                                        number_of_required_arguments, pureOutIndices);
   } else if (arguments != "") {
-    List_sp llraw = lisp_parse_arguments(gc::As<Package_sp>(className->getPackage())->getName(), arguments);
+    List_sp llraw = lisp_parse_arguments(gc::As<Package_sp>(className->getPackage())->packageName(), arguments);
     T_mv mv_llprocessed = process_single_dispatch_lambda_list(llraw, true);
     T_sp tllproc = coerce_to_list(mv_llprocessed); // slice
     lambda_list = coerce_to_list(tllproc);

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -746,20 +746,22 @@ void Lisp::addClassSymbol(Symbol_sp classSymbol, Creator_sp alloc, Symbol_sp bas
   cc->CLASS_set_creator(alloc);
 }
 
-void Lisp::mapNameToPackage(const string& name, Package_sp pkg) {
-  // TODO Support package names with as regular strings
+void Lisp::mapNameToPackage(String_sp sname, Package_sp pkg) {
   int packageIndex;
   {
     WITH_READ_WRITE_LOCK(globals_->_PackagesMutex);
     for (packageIndex = 0; packageIndex < this->_Roots._Packages.size(); ++packageIndex) {
       if (this->_Roots._Packages[packageIndex] == pkg) {
-        SimpleBaseString_sp sname = SimpleBaseString_O::make(name);
         this->_Roots._PackageNameIndexMap->setf_gethash(sname, make_fixnum(packageIndex));
         return;
       }
     }
   }
   SIMPLE_ERROR("Could not find package with (nick)name: {}", pkg->packageName());
+}
+
+void Lisp::mapNameToPackage(const string& name, Package_sp pkg) {
+  mapNameToPackage(SimpleBaseString_O::make(name), pkg);
 }
 
 void Lisp::unmapNameToPackage(String_sp sname) {
@@ -774,10 +776,6 @@ void Lisp::unmapNameToPackage(String_sp sname) {
   }
 package_unfound:
   SIMPLE_ERROR("Could not find package with (nick)name: {}", _rep_(sname));
-}
-
-void Lisp::unmapNameToPackage(const string& name) {
-  unmapNameToPackage(SimpleBaseString_O::make(name));
 }
 
 void Lisp::finishPackageSetup(const string& pkgname, list<string> const& nicknames, list<string> const& usePackages,

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -941,7 +941,7 @@ Package_sp Lisp::makePackage(SimpleString_sp name, List_sp nicknames, List_sp us
       this->_Roots._Packages.push_back(newPackage);
     }
     // Assign nicknames.
-    for (auto nc : nicknames) {
+    for (auto nc : cnicknames) {
       this->_Roots._PackageNameIndexMap->setf_gethash(oCar(nc), packageIndex);
     }
     newPackage->setNicknames(cnicknames);

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -708,7 +708,7 @@ void Lisp::defconstant(Symbol_sp sym, T_sp obj) {
 }
 
 void Lisp::installPackage(const Exposer_O* pkg) {
-  LOG("Installing package[{}]", pkg->packageName());
+  LOG("Installing package[{}]", _rep_(pkg->name()));
   int firstNewGlobalCallback = globals_->_GlobalInitializationCallbacks.end() - globals_->_GlobalInitializationCallbacks.begin();
   ChangePackage change(gc::As<Package_sp>(_lisp->findPackage(pkg->packageName())));
   { pkg->expose(_lisp, Exposer_O::candoClasses); }
@@ -757,7 +757,7 @@ void Lisp::mapNameToPackage(String_sp sname, Package_sp pkg) {
       }
     }
   }
-  SIMPLE_ERROR("Could not find package with (nick)name: {}", pkg->packageName());
+  SIMPLE_ERROR("Could not find package with (nick)name: {}", _rep_(pkg->name()));
 }
 
 void Lisp::mapNameToPackage(const string& name, Package_sp pkg) {
@@ -876,7 +876,7 @@ start:
     }
     for (list<string>::const_iterator jit = usePackages.begin(); jit != usePackages.end(); jit++) {
       Package_sp usePkg = gc::As<Package_sp>(this->findPackage_no_lock(*jit, true));
-      LOG("Using package[{}]", usePkg->packageName());
+      LOG("Using package[{}]", _rep_(usePkg->name()));
       newPackage->usePackage(usePkg);
     }
     if (globals_->_MakePackageCallback != NULL) {
@@ -1163,8 +1163,7 @@ T_mv Lisp::readEvalPrint(T_sp stream, T_sp environ, bool printResults, bool prom
         Symbol_sp pkgSym = cl::_sym_STARpackageSTAR;
         T_sp pkgVal = pkgSym->symbolValue();
         Package_sp curPackage = gc::As<Package_sp>(pkgVal);
-        std::string name = curPackage->packageName();
-        prompts << name << "> ";
+        prompts << _rep_(curPackage->name()) << "> ";
         clasp_write_string(prompts.str(), stream);
       }
       T_sp expression = cl__read(stream, nil<T_O>(), unbound<T_O>(), nil<T_O>());
@@ -2066,7 +2065,7 @@ void Lisp::parseStringIntoPackageAndSymbolName(const string& name, bool& package
   }
   package = gc::As<Package_sp>(this->findPackage(name.substr(0, colonPos), true));
   symbolName = name.substr(secondPart, 99999);
-  LOG("It's a packaged symbol ({} :: {})", package->packageName(), symbolName);
+  LOG("It's a packaged symbol ({} :: {})", _rep_(package->name()), symbolName);
   return;
 }
 

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -961,15 +961,13 @@ T_sp Lisp::findPackage(String_sp name, bool errorp) const {
   return this->findPackage_no_lock(name, errorp);
 }
 
-void Lisp::remove_package(const string& name) {
+void Lisp::remove_package(String_sp name) {
   WITH_READ_WRITE_LOCK(globals_->_PackagesMutex);
-  //        printf("%s:%d Lisp::findPackage name: %s\n", __FILE__, __LINE__, name.c_str());
-  SimpleBaseString_sp sname = SimpleBaseString_O::make(name);
-  T_sp fi = this->_Roots._PackageNameIndexMap->gethash(sname);
+  T_sp fi = this->_Roots._PackageNameIndexMap->gethash(name);
   if (fi.nilp()) {
-    PACKAGE_ERROR(sname);
+    PACKAGE_ERROR(name);
   }
-  this->_Roots._PackageNameIndexMap->remhash(sname);
+  this->_Roots._PackageNameIndexMap->remhash(name);
   this->_Roots._Packages[fi.unsafe_fixnum()]->setZombieP(true);
 }
 

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -903,45 +903,22 @@ nickname_exists:
 }
 
 T_sp Lisp::findPackage_no_lock(const string& name, bool errorp) const {
-  // Check local nicknames first.
-  // FIXME: This conses!
-  if (_lisp->_Roots._TheSystemIsUp) {
-    T_sp local = this->getCurrentPackage()->findPackageByLocalNickname(SimpleBaseString_O::make(name));
-    if (local.notnilp())
-      return local;
-  }
-
-  //        printf("%s:%d Lisp::findPackage name: %s\n", __FILE__, __LINE__, name.c_str());
-  SimpleBaseString_sp sname = SimpleBaseString_O::make(name);
-  T_sp fi = this->_Roots._PackageNameIndexMap->gethash(sname);
-  if (fi.nilp()) {
-    if (errorp) {
-      PACKAGE_ERROR(SimpleBaseString_O::make(name));
-    }
-    return nil<Package_O>(); // return nil if no package found
-  }
-  //        printf("%s:%d Lisp::findPackage index: %d\n", __FILE__, __LINE__, fi->second );
-  ASSERT(fi.fixnump());
-  Package_sp getPackage = this->_Roots._Packages[fi.unsafe_fixnum()];
-  //        printf("%s:%d Lisp::findPackage pkg@%p\n", __FILE__, __LINE__, getPackage.raw_());
-  return getPackage;
+  return this->findPackage_no_lock(SimpleBaseString_O::make(name), errorp);
 }
 
 T_sp Lisp::findPackage(const string& name, bool errorp) const {
   WITH_READ_LOCK(globals_->_PackagesMutex);
-  return this->findPackage_no_lock(name, errorp);
+  return this->findPackage_no_lock(SimpleBaseString_O::make(name), errorp);
 }
 
 T_sp Lisp::findPackage_no_lock(String_sp name, bool errorp) const {
   // Check local nicknames first.
-  // FIXME: This conses!
   if (_lisp->_Roots._TheSystemIsUp) {
     T_sp local = this->getCurrentPackage()->findPackageByLocalNickname(name);
     if (local.notnilp())
       return local;
   }
-
-  //        printf("%s:%d Lisp::findPackage name: %s\n", __FILE__, __LINE__, name.c_str());
+  // OK, now global names.
   T_sp fi = this->_Roots._PackageNameIndexMap->gethash(name);
   if (fi.nilp()) {
     if (errorp) {
@@ -949,10 +926,8 @@ T_sp Lisp::findPackage_no_lock(String_sp name, bool errorp) const {
     }
     return nil<Package_O>(); // return nil if no package found
   }
-  //        printf("%s:%d Lisp::findPackage index: %d\n", __FILE__, __LINE__, fi->second );
   ASSERT(fi.fixnump());
   Package_sp getPackage = this->_Roots._Packages[fi.unsafe_fixnum()];
-  //        printf("%s:%d Lisp::findPackage pkg@%p\n", __FILE__, __LINE__, getPackage.raw_());
   return getPackage;
 }
 

--- a/src/core/lispReader.cc
+++ b/src/core/lispReader.cc
@@ -758,7 +758,7 @@ T_sp interpret_token_or_throw_reader_error(T_sp sin, Token& token, bool only_dot
         return nil<T_O>();
       SimpleString_sp sym_name = symbolTokenStr(sin, token, name_marker - token.data(), token.size(), only_dots_ok);
       Symbol_sp sym = _lisp->getCurrentPackage()->intern(sym_name);
-      LOG_READ(BF("sym_name = |%s| sym->symbolNameAsString() = |%s|") % sym_name->get_std_string() % sym->symbolNameAsString());
+      LOG_READ(BF("sym_name = |%s| sym->symbolNameAsString() = |%s|") % _rep_(sym_name) % sym->symbolNameAsString());
       return sym;
     }
     break;
@@ -783,10 +783,8 @@ T_sp interpret_token_or_throw_reader_error(T_sp sin, Token& token, bool only_dot
     // TODO Handle proper string names
     SimpleString_sp symbol_name_str = symbolTokenStr(sin, token, name_marker - token.data(), token.size(), only_dots_ok);
     LOG_READ(BF("Interpreting token as packageName[%s] and symbol-name[%s]") % _rep_(packageSin.string()) %
-             symbol_name_str->get_std_string());
-    // TODO Deal with proper string package names
-    string packageName = packageSin.string()->get_std_string();
-    Package_sp pkg = gc::As<Package_sp>(_lisp->findPackage(packageName, true));
+             _rep_(symbol_name_str));
+    Package_sp pkg = gc::As<Package_sp>(_lisp->findPackage(packageSin.string(), true));
     Symbol_sp sym;
     MultipleValues& mvn = core::lisp_multipleValues();
     if (separator == 1) { // Asking for external symbol

--- a/src/core/loadltv.cc
+++ b/src/core/loadltv.cc
@@ -552,7 +552,7 @@ struct loadltv {
   void op_package() {
     size_t index = next_index();
     String_sp name = gc::As<String_sp>(get_ltv(read_index()));
-    set_ltv(_lisp->findPackage(name->get_std_string(), true), index);
+    set_ltv(_lisp->findPackage(name, true), index);
   }
 
   void op_bignum() {

--- a/src/core/package.cc
+++ b/src/core/package.cc
@@ -187,20 +187,12 @@ CL_LAMBDA("package-name &key nicknames (use (list \"CL\"))");
 CL_DECLARE();
 CL_DOCSTRING(R"dx(make_package)dx");
 DOCGROUP(clasp);
-CL_DEFUN T_mv cl__make_package(T_sp package_name_desig, List_sp nick_names, List_sp use_packages) {
-  String_sp package_name = coerce::stringDesignator(package_name_desig);
-  list<string> lnn;
-  for (auto nc : nick_names) {
-    String_sp nickstr = coerce::stringDesignator(oCar(nc));
-    // TODO Support proper strings
-    lnn.push_front(nickstr->get_std_string());
+CL_DEFUN Package_sp cl__make_package(T_sp package_name_desig, List_sp nick_names, List_sp use_packages) {
+  ql::list use;
+  for (auto u : use_packages) {
+    use << coerce::packageDesignator(oCar(u));
   }
-  list<string> lup;
-  for (auto uc : use_packages) {
-    Package_sp pkg = coerce::packageDesignator(oCar(uc));
-    lup.push_front(pkg->packageName());
-  }
-  return Values(_lisp->makePackage(package_name->get_std_string(), lnn, lup));
+  return _lisp->makePackage(coerce::simple_string(package_name_desig), nick_names, use.cons());
 }
 
 /*
@@ -475,6 +467,11 @@ SYMBOL_EXPORT_SC_(CorePkg, package_lock_violation);
 Package_sp Package_O::create(const string& name) {
   Package_sp p = Package_O::create();
   p->setName(SimpleBaseString_O::make(name));
+  return p;
+}
+Package_sp Package_O::create(SimpleString_sp name) {
+  Package_sp p = Package_O::create();
+  p->setName(name);
   return p;
 }
 

--- a/src/core/package.cc
+++ b/src/core/package.cc
@@ -67,9 +67,9 @@ CL_DEFUN Package_sp cl__rename_package(T_sp pkg, T_sp newNameDesig, T_sp nickNam
   string newName = coerce::packageNameDesignator(newNameDesig);
   List_sp nickNames = coerce::listOfStringDesignators(nickNameDesigs);
   // Remove the old names from the Lisp system
-  _lisp->unmapNameToPackage(package->getName());
+  _lisp->unmapNameToPackage(package->packageName());
   for (auto cur : package->getNicknames()) {
-    _lisp->unmapNameToPackage(gc::As<String_sp>(oCar(cur))->get_std_string());
+    _lisp->unmapNameToPackage(gc::As<String_sp>(oCar(cur)));
   }
   // Set up the new names
   package->setName(newName);
@@ -103,7 +103,7 @@ CL_DEFUN T_sp ext__package_add_nickname(T_sp pkg, T_sp nick) {
   if (packageUsingNickName.notnilp()) {
     if (Package_sp pkg = packageUsingNickName.asOrNull<Package_O>())
       SIMPLE_PACKAGE_ERROR_2_args("Package nickname[~a] is already being used by package[~a]", nickname->get_std_string(),
-                                  pkg->getName());
+                                  pkg->packageName());
     else
       SIMPLE_PACKAGE_ERROR("Package nickname[~a] is already being used", nickname->get_std_string());
   } else {
@@ -500,8 +500,6 @@ void Package_O::initialize() {
 
 string Package_O::packageName() const { return this->_Name->get_std_string(); }
 
-string Package_O::getName() const { return this->packageName(); };
-
 void Package_O::setName(const string& n) {
   WITH_PACKAGE_READ_WRITE_LOCK(this);
   this->_Name = SimpleBaseString_O::make(n);
@@ -694,7 +692,7 @@ bool FindConflicts::mapKeyValue(T_sp key, T_sp value) {
 }
 
 bool Package_O::usePackage(Package_sp usePackage) {
-  LOG("In usePackage this[{}]  using package[{}]", this->getName(), usePackage->getName());
+  LOG("In usePackage this[{}]  using package[{}]", this->packageName(), usePackage->packageName());
   while (true) {
     FindConflicts findConflicts(this->asSmartPtr());
     {
@@ -735,7 +733,7 @@ bool Package_O::unusePackage_no_outer_lock(Package_sp usePackage) {
           return true;
         }
       }
-      SIMPLE_ERROR("The unusePackage argument {} is not used by my package {}", usePackage->getName(), this->getName());
+      SIMPLE_ERROR("The unusePackage argument {} is not used by my package {}", usePackage->packageName(), this->packageName());
     }
   }
   return true;
@@ -754,7 +752,7 @@ bool Package_O::unusePackage_no_inner_lock(Package_sp usePackage) {
           return true;
         }
       }
-      SIMPLE_ERROR("The unusePackage argument {} is not used by my package {}", usePackage->getName(), this->getName());
+      SIMPLE_ERROR("The unusePackage argument {} is not used by my package {}", usePackage->packageName(), this->packageName());
     }
   }
   return true;

--- a/src/core/package.cc
+++ b/src/core/package.cc
@@ -319,7 +319,7 @@ CL_DEFUN T_sp cl__delete_package(T_sp pobj) {
   });
   pkg->_ExternalSymbols->clrhash();
   pkg->_Shadowing->clrhash();
-  string package_name = pkg->packageName();
+  String_sp package_name = pkg->_Name;
   pkg->_Name = SimpleBaseString_O::make("");
   _lisp->remove_package(package_name);
   return _lisp->_true();

--- a/src/core/package.cc
+++ b/src/core/package.cc
@@ -443,7 +443,9 @@ CL_DOCSTRING(R"dx(packageName)dx");
 DOCGROUP(clasp);
 CL_DEFUN T_sp cl__package_name(T_sp pkgDesig) {
   Package_sp pkg = coerce::packageDesignator(pkgDesig);
-  return pkg->name();
+  if (pkg->getZombieP()) // deleted
+    return nil<T_O>();
+  else return pkg->name();
 };
 
 SYMBOL_EXPORT_SC_(ClPkg, package_use_list);

--- a/src/core/package.cc
+++ b/src/core/package.cc
@@ -519,8 +519,6 @@ string Package_O::__repr__() const {
   return ss.str();
 }
 
-void Package_O::__write__(T_sp stream) const { clasp_write_string(this->__repr__(), stream); }
-
 class PackageMapper : public KeyValueMapper {
 public:
   stringstream* ssP;

--- a/src/core/symbol.cc
+++ b/src/core/symbol.cc
@@ -562,7 +562,7 @@ string Symbol_O::formattedName(bool prefixAlways) const { // no guard
       } else {
         Package_sp currentPackage = _lisp->getCurrentPackage();
         if (prefixAlways || myPackage != currentPackage) {
-          ss << myPackage->getName() << "::" << this->_Name->get_std_string();
+          ss << myPackage->packageName() << "::" << this->_Name->get_std_string();
         } else {
           ss << this->_Name->get_std_string();
         }

--- a/src/core/write_symbol.cc
+++ b/src/core/write_symbol.cc
@@ -222,7 +222,7 @@ void clasp_write_symbol(Symbol_sp x, T_sp stream) {
         print_package = true;
     }
     if (print_package) {
-      SimpleBaseString_sp name = SimpleBaseString_O::make(gc::As<Package_sp>(package)->packageName());
+      SimpleString_sp name = gc::As<Package_sp>(package)->name();
       write_symbol_string(name, cl__readtable_case(readtable), print_case, stream,
                           needs_to_be_escaped(gc::As<Array_sp>(name), readtable));
       if (!x.nilp()) {

--- a/src/core/write_ugly.cc
+++ b/src/core/write_ugly.cc
@@ -56,6 +56,7 @@ THE SOFTWARE.
 #include <clasp/core/array.h>
 #include <clasp/core/evaluator.h>
 #include <clasp/core/pathname.h>
+#include <clasp/core/package.h>
 #include <clasp/core/lispStream.h>
 #include <clasp/core/instance.h>
 #include <clasp/core/funcallableInstance.h>
@@ -111,6 +112,19 @@ void FileStream_O::__write__(T_sp stream) const {
   stream_write_char(stream, ' ');
   write_ugly_object(this->pathname(), stream);
   stream_write_char(stream, '>');
+}
+
+void Package_O::__write__(T_sp stream) const {
+  if (clasp_print_readably()) {
+    clasp_write_string("#.(FIND-PACKAGE ", stream);
+    write_ugly_object(this->name(), stream);
+    stream_write_char(stream, ')');
+  } else {
+    DynamicScopeManager escape(cl::_sym_STARprint_escapeSTAR, _lisp->_true());
+    clasp_write_string("#<PACKAGE ", stream);
+    write_ugly_object(this->name(), stream);
+    stream_write_char(stream, '>');
+  }
 }
 
 void Instance_O::__write__(T_sp stream) const { clasp_write_string(_rep_(this->asSmartPtr()), stream); }

--- a/src/llvmo/link_intrinsics.cc
+++ b/src/llvmo/link_intrinsics.cc
@@ -397,8 +397,8 @@ LtvcReturnVoid ltvc_ensure_vcell(gctools::GCRootsInModule* holder, char tag, siz
 
 LtvcReturnVoid ltvc_make_package(gctools::GCRootsInModule* holder, char tag, size_t index, core::T_O* package_name_t) {
   NO_UNWIND_BEGIN();
-  core::SimpleBaseString_sp package_name((gctools::Tagged)package_name_t);
-  core::T_sp tpkg = _lisp->findPackage(package_name->get_std_string(), false);
+  core::SimpleString_sp package_name((gctools::Tagged)package_name_t);
+  core::T_sp tpkg = _lisp->findPackage(package_name, false);
   if (tpkg.nilp()) {
     // If we don't find the package - just make it
     // a more comprehensive defpackage should be coming


### PR DESCRIPTION
Cleans some stuff up and, importantly, allows package names that aren't just base strings (#1596).

Unfortunately does **not** fix the way package objects are printed - which is relatively minor, but annoying. The problem is it goes through __repr__ and that returns a std::string.