### PR TITLE
Fix single value catch in bytecode

### DIFF
--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -781,7 +781,10 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
         return result;
       });
       if (thrown) pc = target;
-      else pc = vm._pc;
+      else {
+        pc = vm._pc;
+        sp = vm._stackPointer;
+      }
       break;
     }
     case vm_catch_16: {
@@ -798,7 +801,10 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
         return result;
       });
       if (thrown) pc = target;
-      else pc = vm._pc;
+      else {
+        pc = vm._pc;
+        sp = vm._stackPointer;
+      }
       break;
     }
     case vm_throw: {

--- a/src/lisp/regression-tests/misc.lisp
+++ b/src/lisp/regression-tests/misc.lisp
@@ -316,3 +316,8 @@
           (declare (ignorable #'macro-function-shadowing.f))
           (e (macro-function-shadowing.f))))
       ((macro-function-shadowing.f)))
+
+;;; This returned junk due to my VM mistake and caused me no end of grief.
+(test single-value-catch
+      (let ((c (catch 'foo 4))) c)
+      (4))


### PR DESCRIPTION
The stack pointer not being saved properly resulted in junk returns from stack underflow.