### PR TITLE
fixed typo preventing clbind header files from being installed.

### DIFF
--- a/include/cscript.lisp
+++ b/include/cscript.lisp
@@ -3,7 +3,7 @@
 (k:sources :install-code
            #~"clasp/asttooling/"
            #~"clasp/cffi-old/"
-           #~"clasp/clbin/"
+           #~"clasp/clbind/"
            #~"clasp/cffi-old/"
            #~"clasp/core/"
            #~"clasp/external/"
@@ -18,7 +18,7 @@
 (k:sources :etags
            #~"clasp/asttooling/"
            #~"clasp/cffi-old/"
-           #~"clasp/clbin/"
+           #~"clasp/clbind/"
            #~"clasp/cffi-old/"
            #~"clasp/core/"
            #~"clasp/external/"


### PR DESCRIPTION
Found a typo in file` include/cscript.lisp` ... See also [issue 1638](https://github.com/clasp-developers/clasp/issues/1638)