### PR TITLE
koga enhancements: defines, *.cxx and *.hpp as sources.

### DIFF
--- a/src/koga/configure.lisp
+++ b/src/koga/configure.lisp
@@ -952,6 +952,10 @@ the function to the overall configuration."
                    (format nil "~{-I~a~^ ~}" (mapcar (lambda (source)
                                                        (normalize-directory (resolve-source source)))
                                                      paths)))))
+(defun defines (&rest define-strings)
+  "Add -DXXX=YYY defines to the current configuration."
+  (append-cflags *configuration*
+                 (format nil "~{-D~a~^ ~}" define-strings)))
 
 (defun systems (&rest rest)
   (loop for system in rest

--- a/src/koga/packages.lisp
+++ b/src/koga/packages.lisp
@@ -8,6 +8,7 @@
            #:framework
            #:help
            #:includes
+           #:defines
            #:library
            #:make-source
            #:make-source-output

--- a/src/koga/setup.lisp
+++ b/src/koga/setup.lisp
@@ -203,10 +203,10 @@ accumulated plists from each PRINT-VARIANT-TARGET-SOURCE is passed as keys."))
                                      (eql name (getf source :name))))
                               sources)
         if source
-          do (message :info "Found repo definition for extension ~a. Using that to location extension directory." name)
+          do (message :info "Found repo definition for extension ~a. Using that to locate extension directory." name)
              (recurse (getf source :directory))
         else
-          do (message :info "Did not find repo definition for extension ~a. Assuming extension is in ~a" name directory)
+          do (message :info "Did not find repo definition for extension ~a. Assuming extension is in directory \"~a\"." name directory)
              (recurse directory))
   (loop for script = (pop (scripts *configuration*))
         for *script-path* = (when script (uiop:pathname-directory-pathname script))

--- a/src/koga/source.lisp
+++ b/src/koga/source.lisp
@@ -50,7 +50,9 @@
 (defparameter *source-classes*
   '((#P"*.c" . c-source)
     (#P"*.cc" . cc-source)
+    (#P"*.cxx" . cc-source)
     (#P"*.h" . h-source)
+    (#P"*.hpp" . h-source)
     (#P"*.lsp" . lisp-source)
     (#P"*.lisp" . lisp-source)
     (#P"*.ninja" . ninja-source)


### PR DESCRIPTION
This PR brings the following enhancements to koga:

1. Add source files with endings .cxx and .hpp as valid C++ source and header files.
2. Allow for #define statements being added in cscript files: `(koga:defines "XYZ=ABC") ` adds `-DXYZ=ABC` to cflags.

The PR also includes a minor correction for a debug message saying that the locaton of an extension is taken from its repo definiton.
