### PR TITLE
Quit other thread

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -7,6 +7,12 @@
 
 ## Fixed
 * Weak pointers and weak hash tables survive snapshot save/load.
+* `ext:quit` can be used from any thread, not just the initial thread.
+
+## Removed
+* `-z`/`--snapshot-symbols-save` command line option, occasionally used
+  for snapshot debugging. You can call `core:mangled-symbol-names` if the
+  effect is still needed.
 
 # Version 2.7.0 (LLVM15-19) 2025-01-21
 

--- a/include/clasp/core/commandLineOptions.h
+++ b/include/clasp/core/commandLineOptions.h
@@ -66,8 +66,6 @@ struct CommandLineOptions {
   std::string _DescribeFile;
   long _RandomNumberSeed;
   bool _ExportedSymbolsCheck;
-  bool _ExportedSymbolsSave;
-  std::string _ExportedSymbolsFilename;
   bool _NoInform;
   bool _NoPrint;
   bool _DebuggerDisabled;

--- a/include/clasp/core/exceptions.h
+++ b/include/clasp/core/exceptions.h
@@ -198,19 +198,6 @@ namespace core {
 
 class DebugStream;
 
-/*! To exit the program throw this exception
- */
-class TerminateProgramIfBatch {
-private:
-  int _ExitResult;
-  string _Message;
-
-public:
-  TerminateProgramIfBatch(int result, string const& message) : _ExitResult(result), _Message(message){};
-  string message() const { return this->_Message; };
-  int getExitResult() { return this->_ExitResult; };
-};
-
 #pragma GCC visibility push(default)
 class ATTR_WEAK CatchThrow {
   virtual void keyFunctionForVtable() ATTR_WEAK;

--- a/include/clasp/core/exceptions.h
+++ b/include/clasp/core/exceptions.h
@@ -200,17 +200,6 @@ class DebugStream;
 
 /*! To exit the program throw this exception
  */
-class ExitProgramException : public std::exception {
-private:
-  int _ExitResult;
-
-public:
-  ExitProgramException(int result) : _ExitResult(result){};
-  int getExitResult() { return this->_ExitResult; };
-};
-
-/*! To exit the program throw this exception
- */
 class TerminateProgramIfBatch {
 private:
   int _ExitResult;

--- a/include/clasp/core/exceptions.h
+++ b/include/clasp/core/exceptions.h
@@ -199,7 +199,7 @@ namespace core {
 class DebugStream;
 
 #pragma GCC visibility push(default)
-class ATTR_WEAK CatchThrow {
+class ATTR_WEAK CatchThrow : public std::exception {
   virtual void keyFunctionForVtable() ATTR_WEAK;
 
 private:
@@ -208,9 +208,10 @@ private:
 public:
   CatchThrow(T_sp tag) : _Tag(tag){};
   T_sp getTag() { return this->_Tag; };
+  const char* what() const noexcept override { return "Lisp Throw exception"; }
 };
 
-class ATTR_WEAK Unwind {
+class ATTR_WEAK Unwind : public std::exception {
   virtual void keyFunctionForVtable() ATTR_WEAK;
 
 private:
@@ -218,9 +219,11 @@ private:
   size_t _Index;
 
 public:
-  ATTR_WEAK Unwind(void* frame, size_t index) : _Frame(frame), _Index(index){};
+  ATTR_WEAK Unwind(void* frame, size_t index)
+    : _Frame(frame), _Index(index){};
   void* getFrame() const { return this->_Frame; };
   size_t index() const { return this->_Index; };
+  const char* what() const noexcept override { return "Lisp Unwind exception"; }
 };
 
 #pragma GCC visibility pop

--- a/include/clasp/core/lisp.h
+++ b/include/clasp/core/lisp.h
@@ -874,4 +874,6 @@ extern bool global_Started;
 void dumpDebuggingLayouts();
 T_mv cl__intern(String_sp symbol_name, T_sp package_desig);
 
+[[noreturn]] void core__exit(int);
+
 }; // namespace core

--- a/src/core/commandLineOptions.cc
+++ b/src/core/commandLineOptions.cc
@@ -88,11 +88,6 @@ Options:
       Check symbols while starting up and verify that snapshot save will
       work. The symbols can be recovered at runtime calling by
       (core:mangled-symbol-names <stream>).
-  -z, --snapshot-symbols-save <file>
-      Accumulate symbols while starting up and verify that snapshot save will
-      work. The symbols can be recovered at runtime calling by
-      (core:mangled-symbol-names <stream>). They are written out to the <file>
-      on exit.
   -f, --feature <feature>
       Add the feature to *features*
   -e, --eval <form>
@@ -334,10 +329,6 @@ void process_clasp_arguments(CommandLineOptions* options) {
       options->_PauseForDebugger = true;
     } else if (*arg == "-y" || *arg == "--snapshot-symbols") {
       options->_ExportedSymbolsCheck = true;
-    } else if (*arg == "-z" || *arg == "--snapshot-symbols-save") {
-      options->_ExportedSymbolsCheck = true;
-      options->_ExportedSymbolsSave = true;
-      options->_ExportedSymbolsFilename = *++arg;
     } else if (*arg == "-m" || *arg == "--disable-mpi") {
       options->_DisableMpi = true;
     } else if (*arg == "-v" || *arg == "--version") {
@@ -440,7 +431,7 @@ void process_clasp_arguments(CommandLineOptions* options) {
 CommandLineOptions::CommandLineOptions(int argc, const char* argv[])
     : _ProcessArguments(process_clasp_arguments), _DisableMpi(false), _AddressesP(false), _StartupType(DEFAULT_STARTUP_TYPE),
       _FreezeStartupType(false), _HasDescribeFile(false), _StartupFile(""), _ExportedSymbolsCheck(false),
-      _ExportedSymbolsSave(false), _RandomNumberSeed(0), _NoInform(false), _NoPrint(false), _DebuggerDisabled(false),
+      _RandomNumberSeed(0), _NoInform(false), _NoPrint(false), _DebuggerDisabled(false),
       _Interactive(true), _Version(false), _SilentStartup(true), _GenerateTrampolines(false),
       _RCFileName(std::string(getenv("HOME")) + "/.clasprc"), _NoRc(false), _PauseForDebugger(false) {
   if (argc == 0) {

--- a/src/core/debugger2.cc
+++ b/src/core/debugger2.cc
@@ -155,7 +155,7 @@ T_mv early_debug_inner(DebuggerFrame_sp bot, bool can_continue) {
     line = myReadLine(sprompt.str(), end_of_transmission);
     if (end_of_transmission) {
       printf("%s:%d Exiting debugger\n", __FILE__, __LINE__);
-      throw ExitProgramException(0);
+      core__exit(0);
     }
     char cmd;
     string eline;

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -2274,11 +2274,6 @@ int Lisp::run() {
   } catch (core::ExitProgramException& ee) {
     exitCode = ee.getExitResult();
   }
-  if (global_options->_ExportedSymbolsSave) {
-    T_sp stream = core::cl__open(core::SimpleBaseString_O::make(global_options->_ExportedSymbolsFilename), StreamDirection::output);
-    core::core__mangledSymbols(stream);
-    cl__close(stream);
-  }
 
   return exitCode;
 };

--- a/src/gctools/startRunStop.cc
+++ b/src/gctools/startRunStop.cc
@@ -105,10 +105,6 @@ int handleFatalCondition() {
   int exitCode = 0;
   try {
     throw;
-  } catch (core::ExitProgramException& ee) {
-    // Do nothing
-    //            printf("Caught ExitProgram in %s:%d\n", __FILE__, __LINE__);
-    exitCode = ee.getExitResult();
   } catch (core::TerminateProgramIfBatch& ee) {
     // Do nothing
     printf("Caught TerminateProgramIfBatch in %s:%d\n", __FILE__, __LINE__);

--- a/src/gctools/startRunStop.cc
+++ b/src/gctools/startRunStop.cc
@@ -105,9 +105,6 @@ int handleFatalCondition() {
   int exitCode = 0;
   try {
     throw;
-  } catch (core::TerminateProgramIfBatch& ee) {
-    // Do nothing
-    printf("Caught TerminateProgramIfBatch in %s:%d\n", __FILE__, __LINE__);
   } catch (core::CatchThrow& ee) {
     core::clasp_write_string(fmt::format("{}:{} Uncaught THROW tag[{}] - this should NEVER happen - the stack should never be "
                                          "unwound unless there is a CATCH clause that matches the THROW",


### PR DESCRIPTION
Allows `quit` and friends to be called from threads other than the main one without causing one of those stupid "unknown exception" errors. While I was at it I fixed up our exceptions to actually be `std::exception`s, so uncaught exception bugs should be a little more scrutable.