### PR TITLE
Clear EOF if we hit it in a C file stream

### DIFF
--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -4974,9 +4974,12 @@ cl_index CFileStream_O::read_byte8(unsigned char* c, cl_index n) {
       out = fread(c, sizeof(char), n, _file);
     } while (out < 0 && ferror(_file) && errno == EINTR);
   } END_PARK;
-  // note: EOF we leave to the caller to figure out
-  if (out < n && ferror(_file)) io_error("fread");
-
+  // note: EOF we leave to the caller to figure out,
+  // though we do clear it in case there's more reading to do later.
+  if (out < n) {
+    if (ferror(_file)) io_error("fread");
+    else clearerr(_file);
+  }
   return out;
 }
 


### PR DESCRIPTION
Reading again will just hit another EOF, which is fine. Unless it's an interactive stream or pipe or whatever, in which case there might be more input to read and we definitely don't want EOF.

Fixes #1678