### PR TITLE
Fix clang errors on mac, hopefully

### DIFF
--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -26,6 +26,7 @@ THE SOFTWARE.
 */
 /* -^- */
 
+#include <ranges> // required on mac for range algorithms, maybe?
 #include <algorithm> // range algorithms
 #include <clasp/core/array.fwd.h>
 #include <clasp/core/clasp_gmpxx.h>

--- a/include/clasp/gctools/gcarray.h
+++ b/include/clasp/gctools/gcarray.h
@@ -27,6 +27,8 @@ THE SOFTWARE.
 */
 /* -^- */
 #include <atomic>
+#include <ranges>
+#include <algorithm>
 
 namespace gctools {
 

--- a/include/clasp/gctools/gcweak.h
+++ b/include/clasp/gctools/gcweak.h
@@ -232,8 +232,8 @@ struct WeakAnd {
   KVPair get() const {
     auto k = key.value();
     auto v = value.value();
-    if (k && v) return KVPair(*k, *v);
-    else return KVPair(deleted<core::T_O>(), deleted<core::T_O>());
+    if (k && v) return KVPair{*k, *v};
+    else return KVPair{deleted<core::T_O>(), deleted<core::T_O>()};
   }
   void setValue(core::T_sp v) { value.store(v); }
   void reinit(core::T_sp k, core::T_sp v) {


### PR DESCRIPTION
Errors mostly relating to `std::ranges`, seen here https://github.com/clasp-developers/clasp/actions/runs/14520823855