### PR TITLE
Use brace initialization for KVPair

### DIFF
--- a/include/clasp/core/hashTable.h
+++ b/include/clasp/core/hashTable.h
@@ -163,7 +163,7 @@ public:
   virtual Mapping_sp realloc(size_t sz) const { return make(sz); }
   virtual gctools::KVPair get(size_t i) const {
     auto p = _Mapping.get(i);
-    return gctools::KVPair(p.value, p.key);
+    return gctools::KVPair{p.value, p.key};
   }
   virtual void setValue(size_t i, T_sp k, T_sp v) {
     // GC note: I think we don't have to go out of our way to keep the old

--- a/include/clasp/gctools/gcweak.h
+++ b/include/clasp/gctools/gcweak.h
@@ -232,8 +232,8 @@ struct WeakAnd {
   KVPair get() const {
     auto k = key.value();
     auto v = value.value();
-    if (k && v) return KVPair(*k, *v);
-    else return KVPair(deleted<core::T_O>(), deleted<core::T_O>());
+    if (k && v) return KVPair{*k, *v};
+    else return KVPair{deleted<core::T_O>(), deleted<core::T_O>()};
   }
   void setValue(core::T_sp v) { value.store(v); }
   void reinit(core::T_sp k, core::T_sp v) {
@@ -279,7 +279,7 @@ public:
 struct DoubleEphemeron {
   Ephemeron kv;
   Ephemeron vk;
-  DoubleEphemeron(core::T_sp k, core::T_sp v) : kv(k, v), vk(v, k) {}
+  DoubleEphemeron(core::T_sp k, core::T_sp v) : kv{k, v}, vk{v, k} {}
   KVPair get() const { return kv.get(); }
   void setValue(core::T_sp v) {
     auto r = get();

--- a/src/gctools/gcweak.cc
+++ b/src/gctools/gcweak.cc
@@ -153,7 +153,7 @@ KVPair Ephemeron::get() const {
 }
 
 KVPair Ephemeron::get_no_lock() const {
-  return KVPair(core::T_sp((Tagged)GC_REVEAL_POINTER(_key)), _value);
+  return KVPair{core::T_sp((Tagged)GC_REVEAL_POINTER(_key)), _value};
 }
 void Ephemeron::reinit_no_lock(core::T_sp k, core::T_sp v) {
   _key = GC_HIDE_POINTER(k.tagged_());
@@ -179,7 +179,7 @@ void Ephemeron::reinit(core::T_sp k, core::T_sp v) {
 }
 void Ephemeron::reinit_no_lock(core::T_sp k, core::T_sp v) { reinit(k, v); }
 
-KVPair Ephemeron::get() const { return KVPair(_key, _value); }
+KVPair Ephemeron::get() const { return KVPair{_key, _value}; }
 KVPair Ephemeron::get_no_lock() const { return get(); }
 void Ephemeron::fixupInternalsForSnapshotSaveLoad(snapshotSaveLoad::Fixup*) {}
 #endif


### PR DESCRIPTION
Using constructor initialization seems to be some kind of extension since we don't actually declare a two-argument constructor.