### PR TITLE
Bytecode compiler strictness

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -9,6 +9,7 @@
 * Weak pointers and weak hash tables survive snapshot save/load.
 * `ext:quit` can be used from any thread, not just the initial thread.
 * Quasiquoted vectors are read correctly (#1666).
+* The bytecode compiler detects malformed bindings.
 
 ## Removed
 * `-z`/`--snapshot-symbols-save` command line option, occasionally used

--- a/include/clasp/core/exceptions.h
+++ b/include/clasp/core/exceptions.h
@@ -108,12 +108,9 @@ namespace core {
 #define TYPE_ERROR(_datum_, _expectedType_)                                                                                        \
   ERROR(::cl::_sym_type_error, core::lisp_createList(kw::_sym_datum, _datum_, kw::_sym_expected_type, _expectedType_))
 #define PROGRAM_ERROR() ERROR(cl::_sym_programError, (nil<T_O>()))
-#define SIMPLE_PROGRAM_ERROR(message, datum)                                                                                       \
+#define SIMPLE_PROGRAM_ERROR(message, ...)                                                                                         \
   ERROR(core::_sym_simpleProgramError, core::lisp_createList(kw::_sym_format_control, core::lisp_createStr(message),               \
-                                                             kw::_sym_format_arguments, core::lisp_createList(datum)))
-#define SIMPLE_PROGRAM_ERROR_2_ARGS(message, datum1, datum2)                                                                       \
-  ERROR(core::_sym_simpleProgramError, core::lisp_createList(kw::_sym_format_control, core::lisp_createStr(message),               \
-                                                             kw::_sym_format_arguments, core::lisp_createList(datum1, datum2)))
+                                                             kw::_sym_format_arguments, core::lisp_createList(__VA_ARGS__)))
 
 #define FILE_ERROR(_file_) ERROR(cl::_sym_fileError, core::lisp_createList(kw::_sym_pathname, _file_))
 #define CANNOT_OPEN_FILE_ERROR(_file_) FILE_ERROR(_file_)

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -1413,7 +1413,7 @@ CL_DEFUN void cmp__warn_set_unused_variable(T_sp name, T_sp sourceloc) {
 [[noreturn]] CL_DEFUN void cmp__malformed_binding(T_sp op, T_sp binding,
                                                   T_sp source) {
   (void)source;
-  SIMPLE_PROGRAM_ERROR_2_ARGS("Malformed ~s binding: ~s", op, binding);
+  SIMPLE_PROGRAM_ERROR("Malformed ~s binding: ~s", op, binding);
 }
 
 // Emit warnings for unused variables etc.

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -1496,6 +1496,23 @@ static List_sp decls_for_fun(T_sp funname, List_sp decls) {
   return result.cons();
 }
 
+void destructure_let_binding(T_sp binding, Symbol_sp& var, T_sp& valf) {
+  // TODO: Source info
+  if (binding.consp()) {
+    if (oCdr(binding).consp() && oCddr(binding).nilp()) {
+      var = gc::As<Symbol_sp>(oCar(binding));
+      valf = oCadr(binding);
+    } else if (oCdr(binding).nilp()) {
+      var = gc::As<Symbol_sp>(oCar(binding));
+      valf = nil<T_O>();
+    } else
+      SIMPLE_PROGRAM_ERROR("Malformed LET/LET* binding: ~s", binding);
+  } else {
+    var = gc::As<Symbol_sp>(binding);
+    valf = nil<T_O>();
+  }
+}
+
 void compile_let(List_sp bindings, List_sp body, Lexenv_sp env, const Context ctxt) {
   List_sp declares = nil<T_O>();
   gc::Nilable<String_sp> docstring;
@@ -1515,13 +1532,7 @@ void compile_let(List_sp bindings, List_sp body, Lexenv_sp env, const Context ct
     T_sp binding = oCar(cur);
     Symbol_sp var;
     T_sp valf;
-    if (binding.consp()) {
-      var = gc::As<Symbol_sp>(oCar(binding));
-      valf = oCadr(binding);
-    } else {
-      var = gc::As<Symbol_sp>(binding);
-      valf = nil<T_O>();
-    }
+    destructure_let_binding(binding, var, valf);
     compile_form(valf, env, ctxt.sub_receiving(1));
     if (special_binding_p(var, specials, env)) {
       ++special_binding_count;
@@ -1614,13 +1625,7 @@ void compile_letSTAR(List_sp bindings, List_sp body, Lexenv_sp env, const Contex
     T_sp binding = oCar(cur);
     Symbol_sp var;
     T_sp valf;
-    if (binding.consp()) {
-      var = gc::As<Symbol_sp>(oCar(binding));
-      valf = oCadr(binding);
-    } else {
-      var = gc::As<Symbol_sp>(binding);
-      valf = nil<T_O>();
-    }
+    destructure_let_binding(binding, var, valf);
     compile_form(valf, new_env, ctxt.sub_receiving(1));
     if (special_binding_p(var, specials, env)) {
       ++special_binding_count;
@@ -1973,6 +1978,16 @@ void compile_fdesignator(T_sp fform, Lexenv_sp env, const Context ctxt) {
   ctxt.assemble1(vm_code::fdesignator, ctxt.env_index());
 }
 
+void destructure_flet_binding(T_sp binding, T_sp& name, T_sp& lambda_list,
+                              T_sp& body) {
+  if (binding.consp() && oCdr(binding).consp()) {
+    name = oCar(binding);
+    lambda_list = oCadr(binding);
+    body = oCddr(binding);
+  } else
+    SIMPLE_PROGRAM_ERROR("Malformed FLET/LABELS binding: ~s", binding);
+}
+
 void compile_flet(List_sp definitions, List_sp body, Lexenv_sp env, const Context ctxt) {
   gc::Nilable<String_sp> docstring;
   List_sp code, specials, declares = nil<T_O>();
@@ -1980,19 +1995,19 @@ void compile_flet(List_sp definitions, List_sp body, Lexenv_sp env, const Contex
   ql::list fun_vars;
   size_t fun_count = 0;
   for (auto cur : definitions) {
-    Cons_sp definition = gc::As<Cons_sp>(oCar(cur));
-    T_sp name = oCar(definition);
+    T_sp name, lambda_list, body;
+    destructure_flet_binding(oCar(cur), name, lambda_list, body);
     List_sp declares = nil<T_O>();
     gc::Nilable<String_sp> docstring;
     List_sp code;
     List_sp specials;
-    eval::extract_declares_docstring_code_specials(oCddr(definition), declares, false, docstring, code, specials);
+    eval::extract_declares_docstring_code_specials(body, declares, false, docstring, code, specials);
     // If the function does not have a declared name, name it (flet whatever).
     if (extract_lambda_name_from_declares(declares).nilp())
       declares = Cons_O::create(Cons_O::createList(core::_sym_lambdaName, Cons_O::createList(cl::_sym_flet, name)), declares);
     // Compile the function.
     T_sp block = Cons_O::create(cl::_sym_block, Cons_O::create(core__function_block_name(name), code));
-    T_sp lambda = Cons_O::createList(cl::_sym_lambda, oCadr(definition), Cons_O::create(cl::_sym_declare, declares), block);
+    T_sp lambda = Cons_O::createList(cl::_sym_lambda, lambda_list, Cons_O::create(cl::_sym_declare, declares), block);
     compile_function(lambda, env, ctxt.sub_receiving(1));
     fun_vars << name;
     ++fun_count;
@@ -2041,19 +2056,21 @@ void compile_labels(List_sp definitions, List_sp body, Lexenv_sp env, const Cont
   }
   Lexenv_sp new_env = env->bind_funs(fun_vars.cons(), ctxt);
   for (auto cur : definitions) {
-    Cons_sp definition = gc::As_unsafe<Cons_sp>(oCar(cur));
-    T_sp name = oCar(definition);
+    T_sp definition = oCar(cur);
+    T_sp source = source_location_for(definition, ctxt.source_info());
+    T_sp name, lambda_list, body;
+    destructure_flet_binding(oCar(cur), name, lambda_list, body);
     List_sp declares = nil<T_O>();
     gc::Nilable<String_sp> docstring;
     List_sp code;
     List_sp specials;
-    eval::extract_declares_docstring_code_specials(oCddr(definition), declares, false, docstring, code, specials);
+    eval::extract_declares_docstring_code_specials(body, declares, false, docstring, code, specials);
     if (extract_lambda_name_from_declares(declares).nilp())
       declares = Cons_O::create(Cons_O::createList(core::_sym_lambdaName, Cons_O::createList(cl::_sym_labels, name)), declares);
     T_sp block = Cons_O::create(cl::_sym_block, Cons_O::create(core__function_block_name(name), code));
     T_sp fun_body = Cons_O::createList(Cons_O::create(cl::_sym_declare, declares), block);
     Cfunction_sp fun =
-        compile_lambda(oCadr(definition), fun_body, new_env, ctxt.module(), source_location_for(definition, ctxt.source_info()));
+      compile_lambda(lambda_list, fun_body, new_env, ctxt.module(), source);
     size_t literal_index = ctxt.cfunction_index(fun);
     LocalFunInfo_sp lfi = gc::As_assert<LocalFunInfo_sp>(fun_info(name, new_env));
     if (fun->closed()->length() == 0) // not a closure- easy
@@ -2067,7 +2084,7 @@ void compile_labels(List_sp definitions, List_sp body, Lexenv_sp env, const Cont
     lex->setIgnore(binding_ignore(fname, body_declares));
     lex->setDecls(decls_for_fun(name, body_declares));
     debugbindings << Cons_O::create(fname, lex);
-    ibindings << Cons_O::createList(fname, lex, source_location_for(definition, ctxt.source_info()));
+    ibindings << Cons_O::createList(fname, lex, source);
   }
   ctxt.emit_bind(fun_count, env->frameEnd());
   T_sp dbindings = debugbindings.cons();

--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -1497,7 +1497,7 @@ CL_DEFUN T_mv core__sequence_start_end(T_sp sequence, Fixnum_sp start, T_sp end)
     TYPE_ERROR_INDEX_VARIABLE("end[~a] must be <= length of sequence[~a]", sequence, end, len);
   }
   if (unbox_fixnum(fnend) < unbox_fixnum(start)) {
-    SIMPLE_PROGRAM_ERROR_2_ARGS("end[~d] is less than start[~d]", end, start);
+    SIMPLE_PROGRAM_ERROR("end[~d] is less than start[~d]", end, start);
   }
   return (Values(start, fnend, make_fixnum(len)));
 };

--- a/src/lisp/kernel/cmp/compiler-conditions.lisp
+++ b/src/lisp/kernel/cmp/compiler-conditions.lisp
@@ -156,6 +156,14 @@
                (if (symbolp name) name (second name))
                'ignore)))))
 
+(define-condition cmp:malformed-binding (program-error compiler-condition)
+  ((%operator :initarg :operator :reader operator)
+   (%binding :initarg :binding :reader binding))
+  (:report
+   (lambda (condition stream)
+     (format stream "The ~s binding ~s is malformed."
+             (operator condition) (binding condition)))))
+
 ;;; redefined from bytecode_compiler.cc.
 (defun cmp:warn-unused-variable (name &optional (origin (ext:current-source-location)))
   (warn 'cmp:unused-variable :origin origin :name name :setp nil))
@@ -163,6 +171,9 @@
   (warn 'cmp:used-variable :origin origin :name name))
 (defun cmp:warn-set-unused-variable (name &optional (origin (ext:current-source-location)))
   (warn 'cmp:unused-variable :origin origin :name name :setp t))
+(defun cmp:malformed-binding (operator binding &optional (origin (ext:current-source-location)))
+  (error 'cmp:malformed-binding :origin origin
+                                :operator operator :binding binding))
 
 ;; This condition is signaled when an attempt at constant folding fails
 ;; due to the function being called signaling an error.


### PR DESCRIPTION
Makes the bytecode compiler complain about malformed bindings.