### PR TITLE
Fix dumping of arrays with fill pointers

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -10,6 +10,7 @@
 * `ext:quit` can be used from any thread, not just the initial thread.
 * Quasiquoted vectors are read correctly (#1666).
 * The bytecode compiler detects malformed bindings.
+* Literal arrays with fill pointers are not dumped with excess elements.
 
 ## Removed
 * `-z`/`--snapshot-symbols-save` command line option, occasionally used


### PR DESCRIPTION
Dumping a literal vector with fill pointer is pretty rare, but we need to handle it correctly. Doing it wrong caused a hard to understand issue due to cl-interpol reading out such vectors.