### PR TITLE
Numlib compiler macros

### DIFF
--- a/include/clasp/llvmo/code.h
+++ b/include/clasp/llvmo/code.h
@@ -389,19 +389,20 @@ namespace llvmo {
 template <typename Stage> inline void allocateInCodeBlock(BasicLayout& BL, CodeBlock_sp& codeBlock) {
   WITH_READ_WRITE_LOCK(globals_->_CodeBlocksMutex);
   size_t PageSize = getpagesize();
-  auto SegsSizes = BL.getContiguousPageBasedLayoutSizes(PageSize);
+  llvm::ExitOnError ExitOnErr;
+  auto SegsSizes = ExitOnErr(BL.getContiguousPageBasedLayoutSizes(PageSize));
   if (_lisp->_Roots._AllCodeBlocks.load().consp()) {
     core::Cons_sp ll = gc::As_unsafe<core::Cons_sp>(_lisp->_Roots._AllCodeBlocks.load());
     codeBlock = gc::As<CodeBlock_sp>(CONS_CAR(ll));
   } else {
-    size_t size = std::max((size_t)CodeBlock_O::DefaultSize, (size_t)SegsSizes->total());
+    size_t size = std::max((size_t)CodeBlock_O::DefaultSize, (size_t)SegsSizes.total());
     codeBlock = CodeBlock_O::make<Stage>(size);
     DEBUG_OBJECT_FILES_PRINT(("%s:%d:%s Created first CodeBlock size: %lu\n", __FILE__, __LINE__, __FUNCTION__, size));
     _lisp->_Roots._AllCodeBlocks.store(core::Cons_O::createAtStage<Stage>(codeBlock, _lisp->_Roots._AllCodeBlocks.load()));
   }
   bool fits = codeBlock->calculate(BL);
   if (!fits) {
-    size_t size = std::max((size_t)CodeBlock_O::DefaultSize, (size_t)SegsSizes->total());
+    size_t size = std::max((size_t)CodeBlock_O::DefaultSize, (size_t)SegsSizes.total());
     codeBlock = CodeBlock_O::make<Stage>(size);
     DEBUG_OBJECT_FILES_PRINT(("%s:%d:%s Created a fresh CodeBlock size: %lu\n", __FILE__, __LINE__, __FUNCTION__, size));
     _lisp->_Roots._AllCodeBlocks.store(core::Cons_O::createAtStage<Stage>(codeBlock, _lisp->_Roots._AllCodeBlocks.load()));

--- a/src/cross-clasp/base.lisp
+++ b/src/cross-clasp/base.lisp
@@ -453,6 +453,8 @@
                        cmp::warn-undefined-type
                        cmp::warn-cannot-coerce
                        #+clasp si:backquote-append
+                       core:expand-associative core:proper-list-p
+                       core:expand-compare core:expand-uncompare
                        alexandria:make-gensym-list
                        alexandria:ensure-car
                        alexandria:ensure-list
@@ -483,6 +485,7 @@
                        core::once-only
                        core::defconstant-eqx core::defconstant-equal
                        core::while core::until
+                       core:the-single
                        clos::with-early-accessors
                        clos::define-method-combination
                        clos::define-simple-method-combination

--- a/src/cross-clasp/macrology.lisp
+++ b/src/cross-clasp/macrology.lisp
@@ -292,3 +292,116 @@ Example:
               (setf ,keyplace
                     (ctypecase-error ',keyplace ,key
                                      ',(mapcar #'car clauses))))))
+
+;; proper-list-p code from Robert Strandh's Cleavir code
+(defun proper-list-p (object)
+  (cond  ((null object) t)
+         ((atom object) nil)
+         (t (let ((slow object)
+                  (fast (cdr object)))
+              (declare (type cons slow))
+              (tagbody
+               again
+                 (unless (consp fast)
+                   (return-from proper-list-p
+                     (if (null fast) t nil)))
+                 (when (eq fast slow)
+                   (return-from proper-list-p nil))
+                 (setq fast (cdr fast))
+                 (unless (consp fast)
+                   (return-from proper-list-p
+                     (if (null fast) t nil)))
+                 (setq fast (cdr fast))
+                 (setq slow (cdr slow))
+                 (go again))))))
+
+  ;;; Some operators "should signal a type error", meaning that in safe code
+  ;;; they _must_ signal a type error, and otherwise the behavior is undefined.
+  ;;; The bytecode compiler is not smart enough to do this in a nuanced way,
+  ;;; in that it just ignores THE rather than type checking (which is allowed),
+  ;;; but Cleavir's is. So to implement this behavior we use
+  ;;; this THE-SINGLE macro.
+  ;;; The bytecode will have an actual call to a %the-single function,
+  ;;; defined below, which just does a type test. So in safe and unsafe code
+  ;;; there is a test.
+  ;;; When compiling with Cleavir, this call will be transformed into a THE,
+  ;;; so there's no actual call and the compiler can do its usual processing
+  ;;; on THE forms based to the safety level.
+  ;;; This setup also means we extract only the primary value, so e.g.
+  ;;; (+ (values 1 2)) => 1 and not 1 2 as we want. Additionally it properly
+  ;;; removes toplevelness.
+(defmacro the-single (type form &optional (return nil returnp))
+  (if returnp
+      `(%the-single-return ',type (values ,form) ,return)
+      `(%the-single ',type (values ,form))))
+
+(defun %the-single (type value)
+  (unless (typep value type)
+    (error 'type-error :datum value :expected-type type))
+  value)
+
+(defun %the-single-return (type value return)
+  (unless (typep value type)
+    (error 'type-error :datum value :expected-type type))
+  return)
+
+(defun simple-associate-args (fun first-arg more-args)
+  (or more-args (error "more-args cannot be nil"))
+  (let ((next (rest more-args))
+        (arg (first more-args)))
+    (if (null next)
+        `(,fun ,first-arg ,arg)
+        (simple-associate-args fun `(,fun ,first-arg ,arg) next))))
+
+(defun expand-associative (fun two-arg-fun args identity
+                           &optional (one-arg-result-type 'number))
+  (declare (ignore fun))
+  (case (length args)
+    (0 identity)
+    ;; Note that we only use the type information in the one argument
+    ;; case because we need that check. With more arguments, the two-arg-fun
+    ;; will do checks. This also applies to EXPAND-COMPARE below.
+    (1 `(the-single ,one-arg-result-type ,(first args)))
+    (2 (values `(,two-arg-fun ,@args) t))
+    (t (simple-associate-args two-arg-fun (first args) (rest args)))))
+
+(defun simple-compare-args (fun first-arg more-args)
+  (let ((next (rest more-args))
+        (arg (first more-args)))
+    (if (null next)
+        `(,fun ,first-arg ,arg)
+        `(if (,fun ,first-arg ,arg)
+             ,(simple-compare-args fun arg next)
+             nil))))
+
+(defun expand-compare (form fun args &optional (arg-type 't))
+  (if (proper-list-p args)
+      (case (length args)
+        ((0)
+         ;; need at least one argument. FIXME: warn?
+         form)
+        ((1)
+         ;; preserve nontoplevelness and side effects
+         `(the-single ,arg-type ,(first args) t))
+        ((2)
+         `(,fun ,(first args) ,(second args)))
+        (otherwise
+         ;; Evaluate arguments only once
+         (let ((syms (mapcar (lambda (a) (declare (ignore a)) (gensym)) args)))
+           `(let (,@(mapcar #'list syms args))
+              ,(simple-compare-args fun (first syms) (rest syms))))))
+      ;; bad syntax. warn?
+      form))
+
+;; /=, char/=, and so on have to compare every pair.
+;; In general this results in order n^2 comparisons, requiring a loop etc.
+;; For now we don't do that, and only inline the 1 and 2 arg cases.
+(defun expand-uncompare (form fun args &optional (arg-type 't))
+  (if (proper-list-p args)
+      (case (length args)
+        ((1)
+         ;; preserve nontoplevelness and side effects.
+         `(the-single ,arg-type ,(first args) t))
+        ((2) `(not (,fun ,(first args) ,(second args))))
+        (otherwise form))
+      form))

--- a/src/cross-clasp/packages.lisp
+++ b/src/cross-clasp/packages.lisp
@@ -17,6 +17,8 @@
            #:odd-keywords #:unrecognized-keyword-argument-error
            #:simple-parse-error #:simple-reader-error)
   (:export #:defconstant-equal)
+  (:export #:expand-associative #:expand-compare #:expand-uncompare
+           #:proper-list-p #:the-single)
   (:export #:check-pending-interrupts #:terminal-interrupt
            #:signal-code-alist)
   ;; Clasp usually only defines these if the underlying OS has the given signal.

--- a/src/lisp/kernel/lsp/numlib.lisp
+++ b/src/lisp/kernel/lsp/numlib.lisp
@@ -36,6 +36,13 @@
 (defun 1- (num) (- num 1))
 (defun 1+ (num) (+ num 1))
 
+;;; KLUDGE: (setf compiler-macro-function) is defined later in compiler-macro.lisp
+;;; but we want these compiler macros as early as possible during build, so that they
+;;; can be applied for e.g. DO-SUBSEQUENCE. So do it at compile time.
+(eval-when (:compile-toplevel)
+  (define-compiler-macro 1+ (x) `(core:two-arg-+ ,x 1))
+  (define-compiler-macro 1- (x) `(core:two-arg-- ,x 1)))
+
 (defun isqrt (i)
   "Args: (integer)
 Returns the integer square root of INTEGER."

--- a/src/lisp/kernel/lsp/numlib.lisp
+++ b/src/lisp/kernel/lsp/numlib.lisp
@@ -39,9 +39,7 @@
 ;;; KLUDGE: (setf compiler-macro-function) is defined later in compiler-macro.lisp
 ;;; but we want these compiler macros as early as possible during build, so that they
 ;;; can be applied for e.g. DO-SUBSEQUENCE. So do it at compile time.
-(eval-when (:compile-toplevel)
-  (define-compiler-macro 1+ (x) `(core:two-arg-+ ,x 1))
-  (define-compiler-macro 1- (x) `(core:two-arg-- ,x 1)))
+(eval-when (:compile-toplevel))
 
 (defun isqrt (i)
   "Args: (integer)
@@ -169,6 +167,100 @@ Same as ROUND, but returns a float as the first value."
 Equivalent to (NOT (ZEROP (LOGAND INTEGER1 INTEGER2)))."
   (not (zerop (logand x y))))
 
+;;; Some compiler macros we want to be available as early as possible.
+;;; (setf compiler-macro-function) is not yet defined during load, but the build
+;;; can use it no problem.
+;;; Load-time definitions are in cmp/opt/opt-number.lisp.
+(eval-when (:compile-toplevel)
+(define-compiler-macro min (&whole form &rest args)
+  (if (null args) ; invalid
+      form
+      (let ((arg0 (first args)) (args (rest args)))
+        (if (null args)
+            ;; preserve nontoplevelness and eliminate extra values
+            `(core::the-single real ,arg0)
+            (let ((s (gensym)))
+              `(let ((,s ,arg0)
+                     (minrest (min ,@args)))
+                 (if (<= ,s minrest) ,s minrest)))))))
+(define-compiler-macro max (&whole form &rest args)
+  (if (null args) ; invalid
+      form
+      (let ((arg0 (first args)) (args (rest args)))
+        (if (null args)
+            `(core::the-single real ,arg0) ; preserve nontoplevelness
+            (let ((s (gensym)))
+              `(let ((,s ,arg0)
+                     (maxrest (max ,@args)))
+                 (if (>= ,s maxrest) ,s maxrest)))))))
+
+(define-compiler-macro + (&rest numbers)
+  (core:expand-associative '+ 'core:two-arg-+ numbers 0))
+
+(define-compiler-macro * (&rest numbers)
+  (core:expand-associative '* 'core:two-arg-* numbers 1))
+
+(define-compiler-macro - (minuend &rest subtrahends)
+  (if (proper-list-p subtrahends)
+      (if subtrahends
+          `(core:two-arg-- ,minuend (+ ,@subtrahends))
+          `(core:negate ,minuend))
+      (error "The - operator can not be part of a form that is a dotted list.")))
+
+(define-compiler-macro / (dividend &rest divisors)
+  (if (proper-list-p divisors)
+      (if divisors
+          `(core:two-arg-/ ,dividend (* ,@divisors))
+          `(core:reciprocal ,dividend))
+      (error "The / operator can not be part of a form that is a dotted list.")))
+
+(define-compiler-macro < (&whole form &rest numbers)
+  (core:expand-compare form 'core:two-arg-< numbers 'real))
+
+(define-compiler-macro <= (&whole form &rest numbers)
+  (core:expand-compare form 'core:two-arg-<= numbers 'real))
+
+(define-compiler-macro > (&whole form &rest numbers)
+  (core:expand-compare form 'core:two-arg-> numbers 'real))
+
+(define-compiler-macro >= (&whole form &rest numbers)
+  (core:expand-compare form 'core:two-arg->= numbers 'real))
+
+(define-compiler-macro = (&whole form &rest numbers)
+  (core:expand-compare form 'core:two-arg-= numbers 'number))
+
+(define-compiler-macro /= (&whole form &rest numbers)
+  (core:expand-uncompare form 'core:two-arg-= numbers 'number))
+
+(define-compiler-macro plusp (number) `(> ,number 0))
+(define-compiler-macro minusp (number) `(< ,number 0))
+
+(define-compiler-macro 1+ (x)
+  `(core:two-arg-+ ,x 1))
+
+(define-compiler-macro 1- (x)
+  `(core:two-arg-- ,x 1))
+
+;;; TODO: With integers it might be easier to do log base 2; rewriting as such
+;;; would need a more sophisticated transformation.
+(define-compiler-macro log (&whole form number &optional (base nil base-p))
+  (if base-p
+      `(/ (log ,number) (log ,base))
+      form))
+
+;;; log* operations
+(define-compiler-macro logand (&rest numbers)
+  (core:expand-associative 'logand 'core:logand-2op numbers -1))
+
+(define-compiler-macro logxor (&rest numbers)
+  (core:expand-associative 'logxor 'core:logxor-2op numbers 0))
+
+(define-compiler-macro logior (&rest numbers)
+  (core:expand-associative 'logior 'core:logior-2op numbers 0))
+
+(define-compiler-macro logeqv (&rest numbers)
+  (core:expand-associative 'logeqv 'core:logeqv-2op numbers -1))
+) ; eval-when
 
 (defun byte (size position)
   "Args: (size position)
@@ -241,3 +333,39 @@ the result."
 Returns an integer represented by the bit sequence obtained by replacing the
 specified bits of INTEGER2 with the specified bits of INTEGER1."
   (%deposit-field newbyte (byte-size bytespec) (byte-position bytespec) integer))
+
+;;; Look for an explicit (byte ...) form as is usually used in ldb etc.
+;;; return NIL if it's not a (byte ...) form.
+(eval-when (:compile-toplevel :load-toplevel :execute)
+(defun parse-bytespec (bytespec)
+  (when (and (consp bytespec)
+             (eql (car bytespec) 'byte)
+             (consp (cdr bytespec))
+             (consp (cddr bytespec))
+             (null (cdddr bytespec)))
+    (values (cadr bytespec) (caddr bytespec)))))
+
+(eval-when (:compile-toplevel)
+(define-compiler-macro ldb-test (&whole whole bytespec integer)
+  (multiple-value-bind (size position) (parse-bytespec bytespec)
+    (if size
+        `(%ldb-test ,size ,position ,integer)
+        whole)))
+
+(define-compiler-macro mask-field (&whole whole bytespec integer)
+  (multiple-value-bind (size position) (parse-bytespec bytespec)
+    (if size
+        `(%mask-field ,size ,position ,integer)
+        whole)))
+
+(define-compiler-macro dpb (&whole whole newbyte bytespec integer)
+  (multiple-value-bind (size position) (parse-bytespec bytespec)
+    (if size
+        `(%dpb ,newbyte ,size ,position ,integer)
+        whole)))
+
+(define-compiler-macro deposit-field (&whole whole newbyte bytespec integer)
+  (multiple-value-bind (size position) (parse-bytespec bytespec)
+    (if size
+        `(%deposit-field ,newbyte ,size ,position ,integer)
+        whole))))

--- a/src/llvmo/runtimeJit.cc
+++ b/src/llvmo/runtimeJit.cc
@@ -158,10 +158,11 @@ core::SimpleBaseString_sp createSimpleBaseStringForStage(const std::string& snam
 }
 
 uint64_t getModuleSectionIndexForText(llvm::object::ObjectFile& objf) {
+  llvm::ExitOnError ExitOnErr;
   for (llvm::object::SectionRef Sec : objf.sections()) {
     if (!Sec.isText() || Sec.isVirtual())
       continue;
-    if (Sec.getName()->str() == TEXT_NAME) {
+    if (ExitOnErr(Sec.getName()).str() == TEXT_NAME) {
       return Sec.getIndex();
     }
   }
@@ -660,7 +661,6 @@ void ClaspJIT_O::adjustMainJITDylib(JITDylib_sp mainJITDylib) {
 }
 
 [[nodiscard]] bool ClaspJIT_O::do_lookup(JITDylib_sp dylibsp, const std::string& Name, void*& ptr) {
-  llvm::ExitOnError ExitOnErr;
   JITDylib& dylib = *dylibsp->wrappedPtr();
   std::string mangledName = Name;
   auto symbol = this->_LLJIT->lookup(dylib, mangledName);
@@ -804,10 +804,9 @@ void ClaspReturnObjectBuffer(std::unique_ptr<llvm::MemoryBuffer> buffer) {
 
   ObjectFile_sp code = lookupObjectFile(buffer->getBufferIdentifier().str());
   code->_MemoryBuffer = std::move(buffer);
-  //  printf("%s:%d:%s loadedObjectFile %p  _MemoryBuffer = %p\n", __FILE__, __LINE__, __FUNCTION__, (void*)&*code,
-  //  (void*)code->_MemoryBuffer.get() );
-  auto objf = code->getObjectFile();
-  llvm::object::ObjectFile& of = *objf->get();
+  llvm::ExitOnError ExitOnErr;
+  auto ofp = ExitOnErr(code->getObjectFile());
+  llvm::object::ObjectFile& of = *ofp;
 #if defined(_TARGET_OS_LINUX)
   uint64_t secId = getModuleSectionIndexForText(of);
   code->_TextSectionId = secId;


### PR DESCRIPTION
Define numlib compiler macros earlier so they can be used in the build itself. Helps e.g. `position` that uses `1+` through `do-subsequence`, and which we don't want to have call `+` with a consed &rest list.

Also incidentally fix some failures when using an llvm build with assertions.