### PR TITLE
Fix handling of llvm::Triple in LLVM22

### DIFF
--- a/include/clasp/llvmo/llvmoExpose.h
+++ b/include/clasp/llvmo/llvmoExpose.h
@@ -440,6 +440,9 @@ class Triple_O : public core::ExternalObject_O {
 protected:
   PointerToExternalType _ptr;
 
+private:
+  bool _PtrIsOwned = false;
+
 public:
   static Triple_sp make(const string& triple);
 
@@ -449,12 +452,15 @@ public:
 
 public:
   void set_wrapped(PointerToExternalType ptr) {
-    delete this->_ptr;
+    if (_PtrIsOwned)
+      delete this->_ptr;
     this->_ptr = ptr;
   }
-  Triple_O() : Base(), _ptr(NULL){};
+  void set_ptrIsOwned(bool b) { _PtrIsOwned = b; }
+  Triple_O(bool ownedp = false)
+    : Base(), _ptr(NULL), _PtrIsOwned(ownedp){};
   ~Triple_O() {
-    if (_ptr != NULL) {
+    if (_ptr != NULL && _PtrIsOwned) {
       auto ptr = this->_ptr;
       //      printf("%s:%d:%s registering dtor\n", __FILE__, __LINE__, __FUNCTION__ );
       core::thread_local_register_cleanup([ptr](void) {
@@ -490,7 +496,23 @@ template <> struct from_object<llvm::Triple&> {
 
 namespace translate {
 template <> struct to_object<llvm::Triple*> {
-  static core::T_sp convert(llvm::Triple* ptr) { return ((core::RP_Create_wrapped<llvmo::Triple_O, llvm::Triple*>(ptr))); }
+  static core::T_sp convert(llvm::Triple* ptr) {
+    llvmo::Triple_sp trip = core::RP_Create_wrapped<llvmo::Triple_O, llvm::Triple*>(ptr);
+    trip->set_ptrIsOwned(true);
+    return trip;
+  }
+};
+
+template <> struct to_object<llvm::Triple&> {
+  static core::T_sp convert(llvm::Triple& val) {
+    return core::RP_Create_wrapped<llvmo::Triple_O, llvm::Triple*>(&val);
+  }
+};
+template <> struct to_object<const llvm::Triple&> {
+  static core::T_sp convert(const llvm::Triple& val) {
+    // this const_cast is Dubious FIXME KLUDGE
+    return core::RP_Create_wrapped<llvmo::Triple_O, llvm::Triple*>(const_cast<llvm::Triple*>(&val));
+  }
 };
 }; // namespace translate
     ;

--- a/src/lisp/kernel/cleavir/compile-file.lisp
+++ b/src/lisp/kernel/cleavir/compile-file.lisp
@@ -2,24 +2,29 @@
 
 (defun generate-obj-asm-stream (module output-stream file-type reloc-model &key)
   (with-track-llvm-time
-      (let* ((triple-string (llvm-sys:get-target-triple module))
-             (normalized-triple-string (llvm-sys:triple-normalize triple-string))
-             (triple (llvm-sys:make-triple normalized-triple-string))
-             (target-options (llvm-sys:make-target-options)))
-        (multiple-value-bind (target msg)
-            (llvm-sys:target-registry-lookup-target "" triple)
-          (unless target
-            (error msg))
-          (llvm-sys:emit-module (llvm-sys:create-target-machine target
-                                                                #+(or llvm15 llvm16 llvm17 llvm18 llvm19 llvm20) (llvm-sys:get-triple triple)
-                                                                #-(or llvm16 llvm16 llvm17 llvm18 llvm19 llvm20) triple
-                                                                ""
-                                                                ""
-                                                                target-options
-                                                                reloc-model
-                                                                (code-model :jit nil)
-                                                                'llvm-sys:code-gen-opt-default
-                                                                nil)
-                                output-stream
-                                nil ; dwo-stream for dwarf objects
-                                file-type module)))))
+    (let* (#+(or llvm15 llvm16 llvm17 llvm18 llvm19 llvm20)
+           (triple-string (llvm-sys:get-target-triple module))
+           #+(or llvm15 llvm16 llvm17 llvm18 llvm19 llvm20)
+           (normalized-triple-string (llvm-sys:triple-normalize triple-string))
+           #+(or llvm15 llvm16 llvm17 llvm18 llvm19 llvm20)
+           (triple (llvm-sys:make-triple normalized-triple-string))
+           #-(or llvm15 llvm16 llvm17 llvm18 llvm19 llvm20)
+           (triple (llvm-sys:get-target-triple module))
+           (target-options (llvm-sys:make-target-options)))
+      (multiple-value-bind (target msg)
+          (llvm-sys:target-registry-lookup-target "" triple)
+        (unless target
+          (error msg))
+        (llvm-sys:emit-module (llvm-sys:create-target-machine target
+                                                              #+(or llvm15 llvm16 llvm17 llvm18 llvm19 llvm20) (llvm-sys:get-triple triple)
+                                                              #-(or llvm16 llvm16 llvm17 llvm18 llvm19 llvm20) triple
+                                                              ""
+                                                              ""
+                                                              target-options
+                                                              reloc-model
+                                                              (code-model :jit nil)
+                                                              'llvm-sys:code-gen-opt-default
+                                                              nil)
+                              output-stream
+                              nil ; dwo-stream for dwarf objects
+                              file-type module)))))

--- a/src/llvmo/llvmoExpose.cc
+++ b/src/llvmo/llvmoExpose.cc
@@ -758,7 +758,7 @@ CL_DOCSTRING(R"dx()dx");
 CL_PKG_NAME(LlvmoPkg,"make-triple");
 DOCGROUP(clasp);
 CL_DEFUN Triple_sp Triple_O::make(const string& triple) {
-  auto self = gctools::GC<Triple_O>::allocate();
+  auto self = gctools::GC<Triple_O>::allocate(true);
   self->_ptr = new llvm::Triple(triple);
   return self;
 };


### PR DESCRIPTION
compile-file was silently failing because we didn't have a Triple to_object translator.

LLVM now uses Triple objects more - it used to use the strings instead. Using the objects directly makes more sense and all, but is a little more awkward in terms of our management since we're used to owning Triples and deleting them ourselves. If we do that for a Triple LLVM owns we get a double free. So add a flag for that. We assume we don't own triples if we got a reference type, which I _think_ is correct, but it's possible we're disclaiming ownership of something we do actually own, which would be a small memory leak.