### PR TITLE
Fix macOS Apple Silicon build (Homebrew paths, rpath quoting, JIT W^X SIGBUS)

### DIFF
--- a/src/core/compiler.cc
+++ b/src/core/compiler.cc
@@ -210,7 +210,12 @@ CL_DEFUN T_sp core__literals_vref(Pointer_sp lvec, size_t index) {
 CL_LISPIFY_NAME("core:literals_vref");
 CL_DEFUN_SETF T_sp core__literals_vset(T_sp val, Pointer_sp lvec, size_t index)
 {
+  // The literals vector lives in JIT (MAP_JIT) memory, which on Apple Silicon
+  // is write-protected (execute mode) by default; we must switch this thread to
+  // write mode around the store or it faults with a SIGBUS (KERN_PROTECTION_FAILURE).
+  llvmo::JITDataReadWriteMaybeExecute();
   ((T_sp*)(lvec->ptr()))[index] = val;
+  llvmo::JITDataReadExecute();
   return val;
 }
 

--- a/src/core/loadltv.cc
+++ b/src/core/loadltv.cc
@@ -900,7 +900,11 @@ struct loadltv {
     bool seen = false;
     for (size_t i = 0; i < nlits; ++i) {
       if (lits[i] == function.raw_()) {
+        // lits[] is in write-protected JIT (MAP_JIT) memory on Apple Silicon;
+        // switch this thread to write mode just for the store.
+        llvmo::JITDataReadWriteMaybeExecute();
         lits[i] = scf.raw_();
+        llvmo::JITDataReadExecute();
         seen = true;
       }
     }
@@ -1094,7 +1098,13 @@ struct loadltv {
     } else {
       T_O** lits = (T_O**)vlits;
       for (size_t i = 0; i < nlits; ++i) {
-        lits[i] = get_ltv(read_index()).raw_();
+        // Read the literal in execute mode (reads are fine), then switch this
+        // thread to write mode only for the store: lits[] is in write-protected
+        // JIT (MAP_JIT) memory on Apple Silicon and a bare store faults (SIGBUS).
+        T_O* value = get_ltv(read_index()).raw_();
+        llvmo::JITDataReadWriteMaybeExecute();
+        lits[i] = value;
+        llvmo::JITDataReadExecute();
       }
       /*
       uint16_t nfuns = read_u16();

--- a/src/gctools/snapshotSaveLoad.cc
+++ b/src/gctools/snapshotSaveLoad.cc
@@ -2598,7 +2598,11 @@ void snapshot_load(void* maybeStartOfSnapshot, void* maybeEndOfSnapshot, const s
         //
         if (oldCodeClient->literalsSize() != 0 &&
             (newCodeDataStart <= newCodeLiteralsStart && newCodeLiteralsEnd <= newCodeDataEnd)) {
+          // newCodeLiteralsStart is in write-protected JIT (MAP_JIT) memory on
+          // Apple Silicon; switch this thread to write mode around the copy.
+          llvmo::JITDataReadWriteMaybeExecute();
           memcpy((void*)newCodeLiteralsStart, (void*)oldCodeClient->literalsStart(), newCodeClient->literalsSize());
+          llvmo::JITDataReadExecute();
         }
         //
         // Now set the forwarding pointer from the oldCode object to the newCodeClient

--- a/src/koga/units.lisp
+++ b/src/koga/units.lisp
@@ -219,6 +219,11 @@
   (append-cflags configuration "-std=gnu++20" :type :cxxflags)
   #+darwin (append-cflags configuration "-stdlib=libc++" :type :cxxflags)
   #+darwin (append-cflags configuration "-I/usr/local/include")
+  ;; Apple Silicon Homebrew installs headers (e.g. boost, which ships no
+  ;; pkg-config file) under /opt/homebrew rather than the Intel /usr/local
+  ;; prefix.  Add it to the search path when present.
+  #+darwin (when (probe-file #P"/opt/homebrew/include/")
+             (append-cflags configuration "-I/opt/homebrew/include"))
   #+linux (append-cflags configuration "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fno-stack-protector -stdlib=libstdc++"
                                        :type :cxxflags)
   #+linux (append-cflags configuration "-fno-omit-frame-pointer -mno-omit-leaf-frame-pointer -fno-stack-protector"
@@ -317,7 +322,11 @@ has not been set."
          (message :emph "Configuring non-reproducible build")
          (loop for variant in (variants configuration)
                do (append-ldflags variant
-                                  (format nil "-Wl,-rpath,~a"
+                                  ;; Quote the path: the build directory may
+                                  ;; contain spaces, and ninja passes ldflags
+                                  ;; through /bin/sh which would otherwise split
+                                  ;; the rpath at the space.
+                                  (format nil "-Wl,-rpath,\"~a\""
                                           (normalize-directory
                                            (uiop:ensure-absolute-pathname
                                             (merge-pathnames

--- a/src/llvmo/code.cc
+++ b/src/llvmo/code.cc
@@ -235,7 +235,11 @@ CL_LISPIFY_NAME("CODE-LITERAL");
 CL_DEFUN_SETF core::T_sp code_literal_set(core::T_sp lit,
                                           ObjectFile_sp code, size_t idx) {
   core::T_O** literals = (core::T_O**)(code->literalsStart());
+  // The literals vector lives in write-protected JIT (MAP_JIT) memory on Apple
+  // Silicon; switch this thread to write mode around the store to avoid a SIGBUS.
+  JITDataReadWriteMaybeExecute();
   literals[idx] = lit.raw_();
+  JITDataReadExecute();
   return lit;
 }
 


### PR DESCRIPTION
## Summary

Makes `ninja -C build` work on a macOS **Apple Silicon** machine with a Homebrew LLVM 22 toolchain. Three independent problems are fixed; the build now compiles, links, completes the native-image bootstrap, and produces a working clasp.

## 1. koga: Homebrew include path (Apple Silicon)

boost (pulled in by `clbind/config.h`) ships no pkg-config file, so it isn't declared as a koga `library`; clasp relies on it being on the default include path. `units.lisp` only added the **Intel** Homebrew prefix `/usr/local/include`, so on Apple Silicon `/opt/homebrew/include` was never searched and the build failed at the first compile with `'boost/config.hpp' file not found`. Now adds `/opt/homebrew/include` for darwin when present (probe-guarded — Intel and Linux unaffected).

## 2. koga: quote the rpath

The rpath was emitted as an unquoted `-Wl,-rpath,<abs path>`. When the build directory contains a space, ninja hands the flag to `/bin/sh`, which splits it at the space and the link fails with `no such file or directory: '<tail>'`. The path is now quoted.

## 3. SIGBUS writing native-module literals on Apple Silicon (JIT W^X)

The substantive one. During the *Compiling Clasp native image* step, loading a freshly-compiled native FASL crashed with:

```
Condition of type: BUS-ERROR
Bus error. Attempted to access invalid memory address #x10721c830.
... core::loadltv::attr_clasp_module_native(unsigned int)
```

lldb pinned it to a `str` (store) into an `rwx` page that still faulted with `EXC_BAD_ACCESS code=2` (`KERN_PROTECTION_FAILURE`) — the signature of `MAP_JIT` memory under Apple Silicon hardware W^X. clasp writes Lisp pointers into each native module's literals vector, which lives in the LLVM ORC **JITLink** `MAP_JIT` slab; a thread must switch to write mode (`pthread_jit_write_protect_np(false)`) before writing. On x86-64/Linux the `rwx` page is genuinely writable, so the bug was latent there; LLVM 22's JITLink on macOS ARM64 exposes it.

The helpers `llvmo::JITDataReadWriteMaybeExecute()` / `JITDataReadExecute()` already existed for exactly this purpose but **had no callers**. This wires them around every write into JIT-resident literals memory:

- `core::core__literals_vset` (`compiler.cc`)
- `llvmo::code_literal_set` (`code.cc`)
- `loadltv::attr_clasp_module_native` (`loadltv.cc`)
- `loadltv::attr_clasp_function_native_estranged` (`loadltv.cc`)
- snapshot-load literal relocation `memcpy` (`snapshotSaveLoad.cc`)

Reads are left untouched (MAP_JIT memory is readable in execute mode; only writes fault), and each write-mode window is kept to the bare store so no JIT code runs while the thread is in write mode. Each fix made the crash advance to the next write site, confirming a single root cause across these locations rather than guesswork.

## Testing

- `ninja -C build` → exit 0; re-run reports `no work to do`; zero `FAILED:`/`Bus error`/`Condition of type` lines in the log.
- Smoke test on the resulting native image: `(defun fib …)` → `(compile 'fib)` → `(fib 20)` = `6765` (exercises Cleavir → native codegen → JIT → literals writes), `(require :asdf)` loads, clean exit.

## Notes for reviewers

- #1 and #2 are general Apple-Silicon / spaces-in-path koga fixes, not machine-specific.
- For #3, the write-mode windows are deliberately minimal (per-store). If you'd prefer a broader single write-mode window around FASL load / snapshot relocation instead of per-site toggling, that's worth deciding here — but a broad window risks faulting if any JIT code executes during load, which is why this takes the conservative per-write approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
