### PR TITLE
Add core:build-mode to report bytecode vs native build at runtime

### DIFF
--- a/src/core/primitives.cc
+++ b/src/core/primitives.cc
@@ -269,6 +269,18 @@ CL_DEFUN T_sp core__clasp_git_full_commit() {
 #endif
 };
 
+CL_LAMBDA();
+CL_DECLARE();
+CL_DOCSTRING(R"dx(build-mode - :bytecode or :native, the mode clasp's image was built with. Note: this reports the build-time configuration, not what COMPILE currently emits - a :native build still carries a bytecode compiler, and a :bytecode build can JIT to native via auto-compilation.)dx");
+DOCGROUP(clasp);
+CL_DEFUN T_sp core__build_mode() {
+#ifdef CLASP_BUILD_MODE_BYTECODE
+  return _lisp->internKeyword("BYTECODE");
+#else
+  return _lisp->internKeyword("NATIVE");
+#endif
+};
+
 CL_LAMBDA(obj);
 CL_DECLARE();
 CL_DOCSTRING(

--- a/src/koga/config-header.lisp
+++ b/src/koga/config-header.lisp
@@ -25,6 +25,7 @@
                  (if (eq (build-mode configuration) :bytecode)
                      "fasl"
                      "nfasl")
+                 "CLASP_BUILD_MODE_BYTECODE" (eq (build-mode configuration) :bytecode)
                  "USE_COMPILE_FILE_PARALLEL" (compile-file-parallel configuration)
                  "USE_DEFAULT_NATIVE" (default-native configuration)
                  "FORCE_STARTUP_EXTERNAL_LINKAGE" (force-startup-external-linkage configuration)


### PR DESCRIPTION
## Summary

Adds `core:build-mode`, a runtime introspection function returning `:bytecode` or `:native` — the koga `build-mode` the running image was compiled with.

Clasp already records the GC, debug/release, threads, float configs, etc. in `*features*`, but the bytecode-vs-native build mode was only known at build time (it sets `STARTUP_IMAGE_EXTENSION`); there was no way to query it at runtime. This adds that.

## Changes

- **`src/koga/config-header.lisp`**: emit a `CLASP_BUILD_MODE_BYTECODE` define in `config.h` for bytecode builds. Mirrors the existing `USE_BOEHM`/`USE_MMTK` idiom — `write-defines` omits it entirely for native builds, so `#ifdef` is the natural test.
- **`src/core/primitives.cc`**: add `core:build-mode` (`CL_DEFUN`) returning the interned keyword via `#ifdef`, next to the other `lisp-implementation-*` introspection functions. No symbol-table/export edits needed; the scraper handles interning/exposure like its siblings.

The docstring is explicit that this reports the **build-time configuration**, not what `compile` currently emits — a `:native` build still carries a bytecode compiler, and a `:bytecode` build can JIT to native via auto-compilation.

## Verification

Built and ran the `boehmprecise` variant in both modes (macOS/Apple Silicon, LLVM 22):

- native build → `(core:build-mode)` returns `:NATIVE`
- bytecode-configured build (`config.h` defines `CLASP_BUILD_MODE_BYTECODE`) → `(core:build-mode)` returns `:BYTECODE`

`(fboundp 'core:build-mode)` returns `T`, and the symbol reads as `core:build-mode` (exported from `CORE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
