### PR TITLE
Fix executable save-lisp-and-die snapshot on aarch64 Linux

### DIFF
--- a/src/gctools/snapshotSaveLoad.cc
+++ b/src/gctools/snapshotSaveLoad.cc
@@ -1854,15 +1854,31 @@ void* snapshot_save_impl(void* data) {
         mangled_name.begin(), mangled_name.end(), [](unsigned char c) { return !std::isalnum(c); }, '_');
 
     std::cout << "Creating binary object from snapshot..." << std::endl << std::flush;
-    cmd = OBJCOPY_BINARY " --input-target binary --output-target elf64-x86-64"
-                         " --binary-architecture i386 " +
+    // objcopy's output target and binary architecture must match the build target;
+    // otherwise the binary-wrapped snapshot object is empty/rejected by the linker
+    // (e.g. on aarch64 the hardcoded x86-64/i386 values give "architecture i386 unknown").
+#if defined(__x86_64__)
+    const char* snapshot_objcopy_target = "elf64-x86-64";
+    const char* snapshot_objcopy_arch = "i386";
+#elif defined(__aarch64__)
+    const char* snapshot_objcopy_target = "elf64-littleaarch64";
+    const char* snapshot_objcopy_arch = "aarch64";
+#else
+#error "snapshot_save_impl: unsupported architecture for objcopy binary wrap"
+#endif
+    cmd = OBJCOPY_BINARY " --input-target binary --output-target " +
+          std::string(snapshot_objcopy_target) + " --binary-architecture " +
+          snapshot_objcopy_arch + " " +
           filename + " " + obj_filename + " --redefine-sym _binary_" + mangled_name +
           "_start=" CXX_MACRO_STRING(SNAPSHOT_START) " --redefine-sym _binary_" + mangled_name +
           "_end=" CXX_MACRO_STRING(SNAPSHOT_END) " --redefine-sym _binary_" + mangled_name +
           "_size=" CXX_MACRO_STRING(SNAPSHOT_SIZE);
-    if (system(cmd.c_str()) < 0) {
-      std::cerr << "Creation of binary object failed." << std::endl << std::flush;
-      return NULL;
+    if (int rc = system(cmd.c_str())) {
+      // system() returns -1 on fork failure and a non-zero wait status when the
+      // command itself fails; the old `< 0` test missed the latter and fell through
+      // to exit(0), masking the failure from the build.
+      std::cerr << "Creation of binary object failed (rc=" << rc << "): " << cmd << std::endl << std::flush;
+      exit(1);
     }
 
     cmd = CXX_BINARY " " BUILD_LINKFLAGS " -L" + snapshot_data->_LibDir + " -o" + snapshot_data->_FileName + " " + obj_filename +
@@ -1885,9 +1901,9 @@ void* snapshot_save_impl(void* data) {
     std::cout << "Link command:" << std::endl << std::flush;
     std::cout << cmd << std::endl << std::flush;
     std::cout << "Linking executable..." << std::endl << std::flush;
-    if (system(cmd.c_str()) < 0) {
-      std::cerr << "Linking of executable failed." << std::endl << std::flush;
-      return NULL;
+    if (int rc = system(cmd.c_str())) {
+      std::cerr << "Linking of executable failed (rc=" << rc << "): " << cmd << std::endl << std::flush;
+      exit(1);
     }
 
 #ifdef _TARGET_OS_LINUX


### PR DESCRIPTION
## Problem

On aarch64 Linux, `(save-lisp-and-die … :executable t)` does not produce a working executable. The snapshot data is written correctly, but the binary-object wrap step fails:

```
Creating binary object from snapshot...
objcopy: architecture i386 unknown
/usr/bin/ld.gold: error: /tmp/ss-XXXXXX: file is empty
clang++: error: linker command failed with exit code 1
```

Two bugs in `snapshot_save_impl` (`src/gctools/snapshotSaveLoad.cc`), in the `_TARGET_OS_LINUX` `_Executable` path:

1. **Hardcoded x86-64 objcopy target.** The objcopy that wraps the snapshot blob into an object hardcodes `--output-target elf64-x86-64 --binary-architecture i386`. On aarch64, objcopy rejects this (`architecture i386 unknown`), leaving the `mkstemp` object file empty, which `ld.gold` then rejects (`file is empty`). The Darwin path uses `-sectcreate` and is unaffected; x86-64 Linux happens to match the hardcoded values, which is why CI (x86-64 Linux + aarch64 macOS) never caught it.

2. **`system()` return value mis-checked.** Both `if (system(cmd.c_str()) < 0)` guards only detect *fork* failure (`system()` returns `-1`); they miss a non-zero *exit status*. So the failing objcopy and the subsequent failing link are ignored and execution falls through to `exit(0)` — the build reports success with no artifact produced.

## Fix

- Select the objcopy `--output-target` / `--binary-architecture` by build architecture: `__x86_64__` → `elf64-x86-64`/`i386` (unchanged), `__aarch64__` → `elf64-littleaarch64`/`aarch64`, `#error` otherwise.
- Make both `system()` checks detect any non-zero result and `exit(1)` with the command and code, so a failed snapshot can no longer masquerade as success.

## Testing

aarch64 Linux (Ubuntu 24.04, clang/llvm 18, `boehmprecise` variant): `ninja snapshot-boehmprecise` now produces a working ~212 MB `ELF 64-bit … ARM aarch64` PIE executable that boots from its embedded snapshot and runs (smoke: `*features*` contains `:clasp`, `fib(25)=75025`, `(compile …)`+`funcall` work). x86-64 Linux behavior is unchanged (identical target/arch values as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)