### PR TITLE
Make snapshot load position-independent (match libraries by basename)

### DIFF
--- a/src/core/debugger.cc
+++ b/src/core/debugger.cc
@@ -264,10 +264,20 @@ void executableTextSectionRange(gctools::clasp_ptr_t& start, gctools::clasp_ptr_
 bool library_with_name(const std::string& name, bool isExecutable, std::string& libraryName, uintptr_t& start, uintptr_t& end,
                        uintptr_t& vtableStart, uintptr_t& vtableEnd) {
   WITH_READ_LOCK(debugInfo()._OpenDynamicLibraryMutex);
+  // Match libraries by basename (SONAME), not by requiring the recorded name to be a path-suffix
+  // of the loaded library. The recorded name can be an absolute path captured at snapshot-save
+  // time; if the library is later loaded from a different directory (a relocated/bundled install,
+  // or the target's /usr/lib vs a build path) the old suffix test fails and snapshot load aborts.
+  // Comparing basenames makes snapshot load position-independent.
+  auto base_name = [](const std::string& p) -> std::string {
+    std::size_t slash = p.find_last_of('/');
+    return slash == std::string::npos ? p : p.substr(slash + 1);
+  };
+  const std::string nameBase = base_name(name);
   for (auto entry : debugInfo()._OpenDynamicLibraryHandles) {
     std::string libName = entry.second->_Filename;
     if (ExecutableLibraryInfo* eli = dynamic_cast<ExecutableLibraryInfo*>(entry.second)) {
-      if (isExecutable || (name.size() <= libName.size() && name == libName.substr(libName.size() - name.size()))) {
+      if (isExecutable || base_name(libName) == nameBase) {
         libraryName = eli->_Filename;
         start = (uintptr_t)(eli->_TextStart);
         end = (uintptr_t)(eli->_TextEnd);
@@ -278,7 +288,7 @@ bool library_with_name(const std::string& name, bool isExecutable, std::string& 
         return true;
       }
     } else {
-      if (name.size() <= libName.size() && name == libName.substr(libName.size() - name.size())) {
+      if (base_name(libName) == nameBase) {
         if (isExecutable) {
           printf("%s:%d:%s THERE IS A PROBLEM - The library %s is being searched for as Executable but it is not\n", __FILE__,
                  __LINE__, __FUNCTION__, name.c_str());


### PR DESCRIPTION
## Problem

`snapshot_load` re-resolves the C++ libraries a snapshot references via `core::library_with_name`, which accepted a loaded library only if a recorded library name was a **path suffix** of the loaded library's path:

```cpp
name.size() <= libName.size() && name == libName.substr(libName.size() - name.size())
```

The recorded name is the **absolute path captured by `dladdr` at save time**. So if a snapshot's libraries are later loaded from a different directory than at save — a relocated or bundled install, a different install prefix, or a different machine — the suffix test fails and `snapshot_load` aborts in `snapshotSaveLoad.cc` with *"Unable to find library: …"*. On aarch64 Linux, a `save-lisp-and-die :executable t` image `SIGABRT`s before its banner once it (and its libraries) are moved.

## Fix

Match libraries by **basename (SONAME)** instead of by save-time path suffix. The `nm`/`dlsym` load-address computation that follows already uses the *matched, currently-loaded* path, so the matcher was the only place bound to the save-time path.

This makes `save-lisp-and-die` executables and snapshot files **relocatable** across prefixes/machines — useful for redistributing images and for embedded deployment. It is not aarch64-specific; it helps every platform.

## Testing

aarch64 Linux (Ubuntu 24.04, LLVM 18, `boehmprecise`): a `:executable` snapshot whose `libLLVM`/`libstdc++`/`libclasp` were relocated into a separate bundle directory and run via `LD_LIBRARY_PATH` now boots from its embedded snapshot and runs (`*features*` contains `:clasp`; `fib`, `compile`, `funcall` all work). Same-tree behavior is unchanged (the recorded path's basename equals the loaded basename).

🤖 Generated with [Claude Code](https://claude.com/claude-code)