### PR TITLE
Fix Apple Silicon SIGBUS writing native-module literals (JIT W^X)

### DIFF
--- a/src/core/compiler.cc
+++ b/src/core/compiler.cc
@@ -210,7 +210,12 @@ CL_DEFUN T_sp core__literals_vref(Pointer_sp lvec, size_t index) {
 CL_LISPIFY_NAME("core:literals_vref");
 CL_DEFUN_SETF T_sp core__literals_vset(T_sp val, Pointer_sp lvec, size_t index)
 {
+  // The literals vector lives in JIT (MAP_JIT) memory, which on Apple Silicon
+  // is write-protected (execute mode) by default; we must switch this thread to
+  // write mode around the store or it faults with a SIGBUS (KERN_PROTECTION_FAILURE).
+  llvmo::JITDataReadWriteMaybeExecute();
   ((T_sp*)(lvec->ptr()))[index] = val;
+  llvmo::JITDataReadExecute();
   return val;
 }
 

--- a/src/core/loadltv.cc
+++ b/src/core/loadltv.cc
@@ -900,7 +900,11 @@ struct loadltv {
     bool seen = false;
     for (size_t i = 0; i < nlits; ++i) {
       if (lits[i] == function.raw_()) {
+        // lits[] is in write-protected JIT (MAP_JIT) memory on Apple Silicon;
+        // switch this thread to write mode just for the store.
+        llvmo::JITDataReadWriteMaybeExecute();
         lits[i] = scf.raw_();
+        llvmo::JITDataReadExecute();
         seen = true;
       }
     }
@@ -1094,7 +1098,13 @@ struct loadltv {
     } else {
       T_O** lits = (T_O**)vlits;
       for (size_t i = 0; i < nlits; ++i) {
-        lits[i] = get_ltv(read_index()).raw_();
+        // Read the literal in execute mode (reads are fine), then switch this
+        // thread to write mode only for the store: lits[] is in write-protected
+        // JIT (MAP_JIT) memory on Apple Silicon and a bare store faults (SIGBUS).
+        T_O* value = get_ltv(read_index()).raw_();
+        llvmo::JITDataReadWriteMaybeExecute();
+        lits[i] = value;
+        llvmo::JITDataReadExecute();
       }
       /*
       uint16_t nfuns = read_u16();


### PR DESCRIPTION
## Problem

On Apple Silicon the LLVM ORC JITLink code/data slab is mapped `MAP_JIT` and is write-protected (execute mode) per-thread by default; a thread must call `pthread_jit_write_protect_np(false)` before it may write into that memory. clasp stores Lisp object pointers into each native module's literals vector, which lives in this JIT memory. Several of those stores were not bracketed by a switch to write mode, so on Apple Silicon they fault with **SIGBUS** (`EXC_BAD_ACCESS code=2`, `KERN_PROTECTION_FAILURE`).

This manifests as a crash in `loadltv::attr_clasp_module_native` while loading freshly compiled native FASLs during the **"Compiling Clasp native image"** bootstrap step, and at `core::core__literals_vset` more generally. On x86-64 and Linux the page is genuinely RWX, so the bug is latent there.

## Fix

The helpers `JITDataReadWriteMaybeExecute()` / `JITDataReadExecute()` already exist for exactly this purpose. This wraps the three native-module literal write sites with them:

- **`src/core/compiler.cc`** `core__literals_vset` — the store into the literals vector.
- **`src/core/loadltv.cc`** `op_setf_literals` (`lits[i] = scf`) — replacing a bytecode function with its native simple-fun.
- **`src/core/loadltv.cc`** `attr_clasp_module_native` (`lits[i] = value` loop) — filling a freshly loaded native module's literals; the `get_ltv` read stays in execute mode and only the store switches to write mode.

## Verification

On Apple M5 / macOS 15 / LLVM 22.1.5: before the fix, `(require :asdf)` against the bytecode image SIGBUS'd at `compiler.cc:213`; with the first wrap the fault moved to `loadltv.cc`; with all three, `(require :asdf)` loads cleanly and the native image (`base.nfasl`) builds and boots — which previously aborted at the native-image compile step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)