### PR TITLE
Don't register EHFrameRegistrationPlugin on MachO (fixes #1782)

### DIFF
--- a/src/llvmo/runtimeJit.cc
+++ b/src/llvmo/runtimeJit.cc
@@ -599,8 +599,11 @@ ClaspJIT_O::ClaspJIT_O() {
 #if LLVM_VERSION_MAJOR < 22
           .setObjectLinkingLayerCreator([this, &ExitOnErr](ExecutionSession& ES, const Triple& TT) {
             auto ObjLinkingLayer = std::make_unique<ObjectLinkingLayer>(ES, std::make_unique<ClaspAllocator>());
-            ObjLinkingLayer->addPlugin(
-                std::make_unique<EHFrameRegistrationPlugin>(ES, std::make_unique<jitlink::InProcessEHFrameRegistrar>()));
+            // issue #1782: see the LLVM>=22 branch below — EHFrameRegistrationPlugin deletes __compact_unwind on MachO,
+            // which is the only unwind info for arm64-darwin native code. Only register it for non-MachO (ELF).
+            if (!TT.isOSBinFormatMachO())
+              ObjLinkingLayer->addPlugin(
+                  std::make_unique<EHFrameRegistrationPlugin>(ES, std::make_unique<jitlink::InProcessEHFrameRegistrar>()));
             ObjLinkingLayer->addPlugin(std::make_unique<ClaspPlugin>());
             // GDB registrar isn't working at the moment
             if (!getenv("CLASP_NO_GDB_JIT")) {
@@ -617,7 +620,14 @@ ClaspJIT_O::ClaspJIT_O() {
 #else
           .setObjectLinkingLayerCreator([this, &ExitOnErr](ExecutionSession& ES) {
             auto ObjLinkingLayer = std::make_unique<ObjectLinkingLayer>(ES, std::make_unique<ClaspAllocator>());
-            ObjLinkingLayer->addPlugin(ExitOnErr(orc::EHFrameRegistrationPlugin::Create(ES)));
+            // issue #1782: On MachO (Apple) native code unwinds via compact-unwind/__unwind_info, NOT eh-frame
+            // (clasp's arm64-darwin objects carry no __eh_frame). EHFrameRegistrationPlugin's MachO path inserts a
+            // front PrePrune pass that DELETES the __LD,__compact_unwind section before CompactUnwindManager can
+            // synthesize __TEXT,__unwind_info, so native frames end up with no runtime unwind info and a C++ throw
+            // cannot unwind across them (mp:abort aborts). Only register it for non-MachO (ELF .eh_frame); on MachO
+            // the default platform's UnwindInfoRegistrationPlugin handles compact-unwind correctly.
+            if (!ES.getTargetTriple().isOSBinFormatMachO())
+              ObjLinkingLayer->addPlugin(ExitOnErr(orc::EHFrameRegistrationPlugin::Create(ES)));
             ObjLinkingLayer->addPlugin(std::make_unique<ClaspPlugin>());
             if (!getenv("CLASP_NO_GDB_JIT")) {
               Error TargetSymErr = Error::success();


### PR DESCRIPTION
## Problem

The long-standing `clasp`/`cando` **macos-latest/native** "Run regression tests" CI failure (#1782): the `mp` regression suite reaches `PROCESS-ABORT-1` and the process `std::terminate`s instead of unwinding (`startRunStop.cc:135 unhandled unknown exception` → `Abort signal`). Ubuntu native and the bytecode image are unaffected — only the **native image on arm64-darwin**.

## Root cause

On macOS/arm64, native (cleavir-compiled) code unwinds via **compact-unwind** (`__TEXT,__unwind_info`), not DWARF `.eh_frame` — clasp's native MachO objects carry **no** `__eh_frame`. `ClaspJIT_O` adds `orc::EHFrameRegistrationPlugin` to its `ObjectLinkingLayer`. But that plugin's MachO path inserts a *front* PrePrune pass that **removes the `__LD,__compact_unwind` section**:

```cpp
// llvm/lib/ExecutionEngine/Orc/EHFrameRegistrationPlugin.cpp
if (LG.getTargetTriple().isOSBinFormatMachO())
  PassConfig.PrePrunePasses.insert(PassConfig.PrePrunePasses.begin(),
    [](LinkGraph &G) {
      if (auto *CUSec = G.findSectionByName(MachOCompactUnwindSectionName))
        G.removeSection(*CUSec);
      return Error::success();
    });
```

That deletes the only unwind info native code has, **before** JITLink's `CompactUnwindManager` can synthesize `__TEXT,__unwind_info`. libunwind is then left with no description for native PCs, so a C++ exception thrown below a native frame (`mp::abort_process` → `throw AbortProcess()`) and caught above it (`Process_O::runInner`) cannot find its handler → `std::terminate` → abort.

(For the record: the `__compact_unwind` records are valid self-sufficient `UNWIND_ARM64_MODE_FRAME` entries; the original "objects lack `__eh_frame`" framing was a red herring — they correctly lack it, and `0x04000000` is `MODE_FRAME` on arm64, not `MODE_DWARF`.)

## Fix

Only add `EHFrameRegistrationPlugin` for **non-MachO (ELF)** targets. On MachO it has no eh-frame to register anyway, so its sole effect was deleting the compact-unwind. With it gone, the stock pipeline works end-to-end: `CompactUnwindManager` synthesizes `__unwind_info` and the default `setUpGenericLLVMIRPlatform`'s `UnwindInfoRegistrationPlugin` registers it with Apple libunwind. LLVM's own writer handles personality/LSDA, so landing-pad functions are covered too.

## Verification

Apple silicon, LLVM 22, `boehmprecise` native image:

- `mp` regression suite: **44 successes, 0 failures** — `PROCESS-ABORT-1/2/3/5` and `PROCESS-EXIT` pass (were aborting CI).
- `mp:abort-process` now unwinds across native frames and signals `PROCESS-JOIN-ERROR` (the documented behavior) instead of `std::terminate`.
- `llvm::orc::UnwindInfoManager::registerSectionsImpl` now runs per loaded object (15349×; was **never** called before); libunwind's `findSectionsImpl` resolves during the throw.
- No regressions in the `unwind` / `conditions` / `control` suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)