### PR TITLE
Fix #1784: route mp:abort-process/exit-process via SJLJ on macOS arm64

### DIFF
--- a/src/core/mpPackage.cc
+++ b/src/core/mpPackage.cc
@@ -157,6 +157,30 @@ void Process_O::runInner(core::List_sp bindings) {
   } else {
     updatePhase(Running);
     core::T_mv result_mv;
+#ifdef _TARGET_OS_DARWIN
+    // issue #1784: On macOS arm64 a C++ exception cannot be unwound across the
+    // JIT'd native cleavir frames in clasp's interrupt-dispatch path — libunwind
+    // derails before reaching the catch below, so a raw `throw AbortProcess()`
+    // from a delivered interrupt (e.g. mp:process-cancel) reaches std::terminate
+    // and aborts the whole process. clasp's own SJLJ non-local exit DOES cross
+    // those frames (it's how cl:throw/handler-case already unwind here). So on
+    // Darwin mp:abort-process / mp:exit-process do sjlj_throw to this process
+    // object as the catch tag instead of throwing; we establish the matching
+    // catch here. The thrower sets _Aborted/_AbortCondition (abort) or
+    // _ReturnValuesList (exit) before unwinding; completed_normally stays false
+    // unless apply0 returns without a non-local exit.
+    bool completed_normally = false;
+    result_mv = core::call_with_catch(this->asSmartPtr(), [&]() -> core::T_mv {
+      core::T_mv r = core::core__apply0(core::coerce::calledFunctionDesignator(_Function), _Arguments);
+      completed_normally = true;
+      return r;
+    });
+    if (!completed_normally) {
+      // Reached via mp:abort-process or mp:exit-process; their state is set.
+      updatePhase(Exited);
+      return;
+    }
+#else
     try {
       result_mv = core::core__apply0(core::coerce::calledFunctionDesignator(_Function), _Arguments);
     } catch (ExitProcess& e) {
@@ -172,6 +196,7 @@ void Process_O::runInner(core::List_sp bindings) {
       updatePhase(Exited);
       return;
     }
+#endif
     updatePhase(Exited);
     ql::list return_values;
     int nv = result_mv.number_of_values();
@@ -540,7 +565,13 @@ DOCGROUP(clasp)dx");
 CL_DEFUN void mp__exit_process(core::List_sp values) {
   Process_sp this_process = gc::As<Process_sp>(_sym_STARcurrent_processSTAR->symbolValue());
   this_process->_ReturnValuesList = values;
+#ifdef _TARGET_OS_DARWIN
+  // issue #1784: SJLJ non-local exit instead of a C++ throw that can't unwind
+  // across JIT cleavir frames on macOS arm64. See Process_O::runInner.
+  core::sjlj_throw(this_process);
+#else
   throw ExitProcess();
+#endif
 };
 
 // See abort-process in mp.lisp
@@ -553,7 +584,15 @@ DOCGROUP(clasp);
 CL_DEFUN void mp__PERCENTabort_process(core::T_sp maybe_condition) {
   Process_sp this_process = gc::As<Process_sp>(_sym_STARcurrent_processSTAR->symbolValue());
   this_process->_AbortCondition = maybe_condition;
+#ifdef _TARGET_OS_DARWIN
+  // issue #1784: SJLJ non-local exit instead of a C++ throw that can't unwind
+  // across JIT cleavir frames on macOS arm64. Mark the abort ourselves (runInner's
+  // C++ catch does this on other platforms). See Process_O::runInner.
+  this_process->_Aborted = true;
+  core::sjlj_throw(this_process);
+#else
   throw AbortProcess();
+#endif
 }
 
 CL_DOCSTRING(R"dx(Return the name of the mutex, as provided at creation. The mutex may be normal or recursive.)dx");


### PR DESCRIPTION
## Problem (#1784)

On macOS arm64 (native image), the `interrupt` regression suite aborts the whole process at its first test, `CANCELLATION-INTERRUPT` (`mp:process-cancel`), with `startRunStop.cc:135 ... unhandled unknown exception` → `Abort signal`.

## Root cause

A deep C++ `AbortProcess` throw that originates **inside clasp's interrupt-dispatch machinery** (`check-pending-interrupts` → `handle_queued_interrupt` → `funcall(signal-interrupt)` → … → `mp:abort-process` → `throw AbortProcess()`) cannot be unwound by macOS-arm64 libunwind across the JIT'd native cleavir frames in that path. The `__unwind_info`-driven EH unwind **derails** before reaching `catch (AbortProcess&)` in `Process_O::runInner`, so `__cxa_throw` falls through to `std::terminate`.

Evidence (all deterministic):
- A **signal-free** repro — a process that self-interrupts (`mp:interrupt-process (mp:current-process) #'mp:abort-process`) and drains via `core:check-pending-interrupts` — terminates identically, with **no `_sigtramp` on the stack**. So this is *not* the "throw across the signal trampoline" hazard; it's the C++ EH unwinder failing on the JIT frames.
- The **same dispatch path** raising a Lisp `error` under `handler-case` is caught fine, because clasp's Lisp unwinder (`_longjmp`, no unwind tables) crosses those frames where the C++ EH unwinder does not.
- A personality (`__gxx_personality_v0`) walk shows phase-1 reaching the bytecode VM frames but never `runInner`'s catch; `findSectionsImpl` stops being consulted at the offending JIT frame.

This is distinct from #1782/#1783 (which fixes *shallow* C++ throws across native frames by registering compact-unwind); the deep interrupt-dispatch path still derails, and this fix sidesteps it rather than relying on the EH unwinder at all.

## Fix

Route `mp:abort-process` and `mp:exit-process` through clasp's own **SJLJ** non-local exit (`core::sjlj_throw` to the process object as the catch tag, with the matching catch established via `call_with_catch` in `Process_O::runInner`) instead of `throw AbortProcess()` / `throw ExitProcess()`. `_longjmp` uses no unwind tables, so it is immune to the derail — and it is exactly how `cl:throw`/`handler-case` already unwind across these frames.

- Gated to `_TARGET_OS_DARWIN`. **Non-Darwin keeps the C++ throw path byte-for-byte unchanged.**
- A `completed_normally` flag set as the last statement of the catch lambda distinguishes a normal return from a non-local exit (whose `_Aborted`/`_AbortCondition` or `_ReturnValuesList` state is set before unwinding).
- One file, three functions. The throw sites (`mpPackage.cc`) and the only catcher (`runInner`) are all in this file.

## Verification (macOS arm64, native boehmprecise image)

- `TEST_SUITES=mp,interrupt` → **52 successes, 0 failures**. `CANCELLATION-INTERRUPT` now passes, as do `SLEEP/LOCK/INPUT-INTERRUPTIBLE` and `UNWIND-PROTECT.INTERRUPT.1/2`, and all `PROCESS-ABORT-*`/`PROCESS-EXIT`/`ATOMIC-*`.
- Broader sweep (`mp,interrupt,unwind,conditions,control01,ehkiller,clos,update-instance-abort`) → **135 successes, 0 failures**, no regressions.

Companion to #1783 (#1782); together they take the macOS-arm64 native CI green through the `interrupt` suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)