### PR TITLE
Fix Apple Silicon W^X SIGBUS in setf_jit_lookup_t (FFI callbacks)

### DIFF
--- a/src/llvmo/llvmoPackage.cc
+++ b/src/llvmo/llvmoPackage.cc
@@ -55,6 +55,7 @@ THE SOFTWARE.
 #include <clasp/llvmo/debugInfoExpose.h>
 #include <clasp/llvmo/intrinsics.h>
 #include <clasp/llvmo/claspLinkPass.h>
+#include <clasp/llvmo/code.h> // JITDataReadWriteMaybeExecute / JITDataReadExecute (W^X)
 #include <clasp/core/bytecode.h>
 #include <clasp/core/instance.h>
 #include <clasp/core/funcallableInstance.h>
@@ -690,7 +691,15 @@ CL_DEFUN_SETF core::T_sp setf_jit_lookup_t(core::T_sp value, JITDylib_sp dylib, 
   if (!found)
     SIMPLE_ERROR("Could not find pointer for name |{}|", name);
   core::T_O** tptr = (core::T_O**)ptr;
+  // The JIT'd global (e.g. an FFI callback's `callback-lisp-function-N`) lives in
+  // MAP_JIT memory, which on Apple Silicon is write-protected (execute mode) by
+  // default; switch this thread to write mode around the store or it faults with a
+  // SIGBUS (KERN_PROTECTION_FAILURE). This is the W^X store site that make-callback
+  // / %defcallback hits (the defcallback-native regression test); the other literal
+  // write sites are wrapped in compiler.cc / loadltv.cc.
+  JITDataReadWriteMaybeExecute();
   *tptr = value.raw_();
+  JITDataReadExecute();
   return value;
 }
 


### PR DESCRIPTION
## Problem

On Apple Silicon, JIT'd code/data lives in `MAP_JIT` memory that is write-protected (execute mode) by default. A thread must switch it to write mode (`pthread_jit_write_protect_np`) around any store, or the store faults with `SIGBUS` (`KERN_PROTECTION_FAILURE`).

`setf_jit_lookup_t` (`llvmo:jit-lookup-t` setf, `src/llvmo/llvmoPackage.cc`) stores a Lisp function pointer into a JIT-emitted global. `make-callback` / `clasp-ffi:%defcallback` reach it via `(setf (llvm-sys:jit-lookup-t dylib varname) function)`, and on arm64-darwin this store **SIGBUSes at compile time** — which is what makes the `defcallback-native` regression test (`CFFI-DEFCALLBACK`) crash during `compile-file`.

## Fix

Wrap the store in `JITDataReadWriteMaybeExecute()` / `JITDataReadExecute()`, matching the existing W^X guards on the other JIT-literal write sites (`core__literals_vset` in compiler.cc, `op_setf_literals` / `attr_clasp_module_native` in loadltv.cc). This is the one remaining unguarded JIT-data store, unique to the FFI-callback path.

## Verification

macOS arm64, native `boehmprecise` image: `CFFI-DEFCALLBACK` now **passes** (previously a Bus error during compile-file). Full regression suite: no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)