### PR TITLE
Route save-lisp-and-die through SJLJ on macOS arm64 (sibling of #1784)

### DIFF
--- a/include/clasp/gctools/snapshotSaveLoad.h
+++ b/include/clasp/gctools/snapshotSaveLoad.h
@@ -111,6 +111,16 @@ private:
 void snapshot_save(SaveLispAndDie& data);
 void snapshot_load(void* maybeStartOfSnapshot, void* maybeEndOfSnapshot, const std::string& filename);
 
+// SJLJ routing for save-lisp-and-die's non-local exit on targets where a raw C++
+// `throw SaveLispAndDie` cannot be unwound to run_clasp's catch (macOS arm64 native
+// image — the same EH-derail defect #1784 fixes for mp:abort/exit-process). The throw
+// side stashes the (GC-free) payload and sjlj_throws to this catch tag; run_clasp
+// establishes the matching catch via call_with_catch and runs snapshot_save on the
+// stashed payload. Only used under _TARGET_OS_DARWIN.
+core::T_sp save_lisp_and_die_catch_tag();
+void set_pending_save_lisp_and_die(const SaveLispAndDie& data);
+SaveLispAndDie& pending_save_lisp_and_die();
+
 void clearLibraries();
 void encodeEntryPointInLibrary(Fixup* fixup, uintptr_t* ptrptr);
 void decodeEntryPointInLibrary(Fixup* fixup, uintptr_t* ptrptr);

--- a/src/gctools/gcFunctions.cc
+++ b/src/gctools/gcFunctions.cc
@@ -13,6 +13,7 @@
 #include <clasp/core/funcallableInstance.h>
 #include <clasp/core/fileSystem.h>
 #include <clasp/core/evaluator.h>
+#include <clasp/core/unwind.h> // sjlj_throw (issue #1784 SLAD routing)
 #include <clasp/core/pathname.h>
 #include <clasp/core/hashTableEq.h>
 #include <clasp/core/lispStream.h>
@@ -457,8 +458,21 @@ The following &KEY arguments are defined:
 DOCGROUP(clasp);
 CL_DEFUN void gctools__save_lisp_and_die(core::String_sp filename, bool executable, bool testMemory) {
 #ifdef USE_PRECISE_GC
-  throw(snapshotSaveLoad::SaveLispAndDie(filename->get_std_string(), executable,
-                                         globals_->_Bundle->_Directories->_LibDir, true, snapshotSaveLoad::ForwardingEnum::noStomp, testMemory ));
+  snapshotSaveLoad::SaveLispAndDie sld(filename->get_std_string(), executable,
+                                       globals_->_Bundle->_Directories->_LibDir, true,
+                                       snapshotSaveLoad::ForwardingEnum::noStomp, testMemory);
+#ifdef _TARGET_OS_DARWIN
+  // issue #1784 (sibling): on macOS arm64 a raw C++ `throw SaveLispAndDie` derails
+  // across the deep native frames before reaching the catch in run_clasp -> the
+  // process terminates instead of saving (the SLAD-SNAPSHOT/SLAD-EXECUTABLE tests).
+  // Route it through clasp's SJLJ unwind (_longjmp, no unwind tables -> immune), the
+  // same way #1784 routes mp:abort/exit-process. The payload is GC-free; stash it and
+  // sjlj_throw to the catch tag established in run_clasp.
+  snapshotSaveLoad::set_pending_save_lisp_and_die(sld);
+  core::sjlj_throw(snapshotSaveLoad::save_lisp_and_die_catch_tag());
+#else
+  throw sld;
+#endif
 #else
   SIMPLE_ERROR("save-lisp-and-die only works for precise GC");
 #endif

--- a/src/gctools/snapshotSaveLoad.cc
+++ b/src/gctools/snapshotSaveLoad.cc
@@ -63,6 +63,20 @@ namespace snapshotSaveLoad {
 bool global_InSnapshotLoad = false;
 size_t global_badge_count = 0;
 
+// --- SJLJ routing for save-lisp-and-die (see snapshotSaveLoad.h / #1784). ---
+// The catch tag is an interned keyword: EQ-stable and GC-rooted by the keyword
+// package. We look it up fresh each call rather than caching a T_sp in a plain
+// static, which a moving GC could leave stale.
+core::T_sp save_lisp_and_die_catch_tag() { return _lisp->internKeyword("%SAVE-LISP-AND-DIE"); }
+// The payload is a GC-free POD (std::string/bool/enum), so a heap copy is safe to
+// hold across the SJLJ unwind (which may run cleanups/GC).
+static SaveLispAndDie* global_pendingSaveLispAndDie = nullptr;
+void set_pending_save_lisp_and_die(const SaveLispAndDie& data) {
+  delete global_pendingSaveLispAndDie;
+  global_pendingSaveLispAndDie = new SaveLispAndDie(data);
+}
+SaveLispAndDie& pending_save_lisp_and_die() { return *global_pendingSaveLispAndDie; }
+
 struct MaybeTimeStartup {
   std::chrono::time_point<std::chrono::steady_clock> start;
   std::string name;

--- a/src/gctools/startRunStop.cc
+++ b/src/gctools/startRunStop.cc
@@ -40,6 +40,7 @@ THE SOFTWARE.
 #include <clasp/core/hashTable.h>
 #include <clasp/core/debugger.h>
 #include <clasp/core/evaluator.h>
+#include <clasp/core/unwind.h> // call_with_catch (issue #1784 SLAD routing)
 #include <clasp/gctools/gc_boot.h>
 #include <clasp/gctools/gcFunctions.h>
 #include <clasp/gctools/snapshotSaveLoad.h>
@@ -450,6 +451,23 @@ int startup_clasp(void** stackMarker, gctools::ClaspInfo* claspInfo, int* exitCo
 
 int run_clasp(gctools::ClaspInfo* claspInfo) {
   int exitCode;
+#if defined(USE_PRECISE_GC) && defined(_TARGET_OS_DARWIN)
+  // issue #1784 (sibling): on macOS arm64 save-lisp-and-die does an SJLJ non-local
+  // exit instead of `throw SaveLispAndDie` — a raw C++ throw derails across the deep
+  // native frames here and reaches std::terminate. Catch the SJLJ unwind via the
+  // shared tag and run snapshot_save on the stashed payload. completed_normally stays
+  // false iff _lisp->run() exited via that non-local save-lisp-and-die unwind.
+  bool completed_normally = false;
+  core::call_with_catch(snapshotSaveLoad::save_lisp_and_die_catch_tag(), [&]() -> core::T_mv {
+    exitCode = _lisp->run();
+    completed_normally = true;
+    return core::T_mv();
+  });
+  if (!completed_normally) {
+    snapshotSaveLoad::snapshot_save(snapshotSaveLoad::pending_save_lisp_and_die());
+    exitCode = 0;
+  }
+#else
   try {
     exitCode = _lisp->run();
   } catch (snapshotSaveLoad::SaveLispAndDie& ee) {
@@ -458,6 +476,7 @@ int run_clasp(gctools::ClaspInfo* claspInfo) {
 #endif
     exitCode = 0;
   }
+#endif
   return exitCode;
 };
 


### PR DESCRIPTION
## Problem

On macOS arm64, `ext:save-lisp-and-die` does `throw SaveLispAndDie` (`gcFunctions.cc`), intended for `catch (SaveLispAndDie&)` in `run_clasp` (`startRunStop.cc`). On the native image that raw C++ exception **derails across the deep native cleavir frames** before reaching the catch — `__cxa_throw` finds no handler → `std::terminate` → the process aborts **before `snapshot_save` ever runs**.

This is the same EH-unwind defect that #1784 fixes for `mp:abort-process` / `mp:exit-process` (a Lisp `error`/`handler-case` through the same frames is caught fine, because clasp's own SJLJ unwinder uses `_longjmp` — no unwind tables — where the C++ EH unwinder derails).

## Fix

Route it through clasp's SJLJ non-local exit (`sjlj_throw` / `call_with_catch`), gated to `_TARGET_OS_DARWIN`; other platforms keep the C++ throw unchanged. The throw side stashes the GC-free `SaveLispAndDie` payload and `sjlj_throw`s to a shared catch tag (an interned keyword); `run_clasp` establishes the matching catch via `call_with_catch` and runs `snapshot_save` on the stashed payload.

## Verification

macOS arm64, native `boehmprecise` image: `save-lisp-and-die` no longer aborts — the child exits 0, `snapshot_save` runs (its progress output now appears), and a complete snapshot is written.

## Scope note

This fixes the **save** only. The `SLAD-SNAPSHOT` / `SLAD-EXECUTABLE` regression tests also exercise snapshot **loading** (`--snapshot <file>`), which on macOS arm64 currently SIGBUSes inside `snapshot_load` (snapshot relocation) — a separate, pre-existing issue in code untouched here. So those two tests are not yet green; this change is a necessary prerequisite that unmasks the load-side work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)