### PR TITLE
frgo misc optimization

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -27,6 +27,7 @@
 * `setf` of `apply` no longer has multiple evaluation problems.
 * Improve error messages for package name conflicts. Fixes #1722.
 * FASL loading is more resilient in the face of heavy file use and interruptions. Thanks @dg1sbg.
+* Writing non-base-chars into base strings by various means (e.g. `replace`) now signals an error instead of treating the low byte of the codepoint as a base char.
 
 ## Removed
 * `-z`/`--snapshot-symbols-save` command line option, occasionally used
@@ -36,6 +37,7 @@
 
 ## Optimized
 * FASL loading batches reads more, improving load times. Thanks @dg1sbg.
+* Array copying operations like `subseq` and `replace` cons less.
 
 # Version 2.7.0 (LLVM15-19) 2025-01-21
 

--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -27,7 +27,8 @@ THE SOFTWARE.
 /* -^- */
 
 #include <algorithm> // range algorithms
-#include <limits> // numeric_limits for casting
+#include <limits>    // numeric_limits for casting
+#include <type_traits> // is_integral etc.
 #include <concepts> // beware
 #include <clasp/core/array.fwd.h>
 #include <clasp/core/clasp_gmpxx.h>
@@ -534,30 +535,14 @@ public:
                          begin() + dest_start + n);
     }
   }
-  // OK case: Copying between integral types can be done without boxing.
-  // We do need to signal errors if something won't fit, though, and that's
-  // a runtime check for each element.
-  using Base::element_type;
-  template <typename SourceArray_O>
-  requires (std::derived_from<SourceArray_O, AbstractSimpleVector_O>
-            && std::integral<typename leaf_type::simple_element_type>
-            && std::integral<typename SourceArray_O::simple_element_type>
-            && !std::same_as<SourceArray_O, leaf_type>)
-    void copy_n(gctools::smart_ptr<SourceArray_O> source,
-                size_t dest_start, size_t source_start, size_t n) {
-    for (size_t i = 0; i < n; ++i) {
-      auto elt = (*source)[source_start + i];
-      // clang can probably optimize this out when the source type always fits.
-      if (elt < std::numeric_limits<typename leaf_type::simple_element_type>::min()
-          || elt > std::numeric_limits<typename leaf_type::simple_element_type>::max())
-        TYPE_ERROR(Integer_O::create(elt), element_type());
-      else (*this)[dest_start + i] = elt;
-    }
-  }
   // Worst specific case: box and unbox,
   // but we can at least avoid virtual rowMajorAref.
+  // If the element types are integral we try to copy them without boxing,
+  // but this may need type checks for every element if the destination's
+  // integers are smaller than the source's.
   // We'd hit the specific expansion if SourceArray_O = leaf_type,
   // so we don't need to worry about aliasing.
+  using Base::element_type;
   template <typename SourceArray_O>
   requires (std::derived_from<SourceArray_O, AbstractSimpleVector_O>
             && !std::same_as<SourceArray_O, leaf_type>
@@ -565,11 +550,33 @@ public:
             && !std::same_as<SourceArray_O, AbstractSimpleVector_O>)
     void copy_n(gctools::smart_ptr<SourceArray_O> source,
                 size_t dest_start, size_t source_start, size_t n) {
-    // note: no std::transform since if the unary_op throws, the program is
-    // std::terminate'd. I think.
-    for (size_t i = 0; i < n; ++i) {
-      T_sp elt = SourceArray_O::to_object((*source)[source_start + i]);
-      (*this)[dest_start + i] = leaf_type::from_object(elt);
+    if constexpr(std::is_integral_v<typename leaf_type::simple_element_type>
+                 && std::is_integral_v<typename SourceArray_O::simple_element_type>) {
+      // Specialish case so we can copy integers without boxing.
+      // if constexpr is because constraint normalization is kind of dumb,
+      // making it difficult to keep the templates unambiguous.
+      for (size_t i = 0; i < n; ++i) {
+        auto elt = (*source)[source_start + i];
+        // clang can probably optimize this test out when the source type
+        // always fits
+        if (elt < std::numeric_limits<typename leaf_type::simple_element_type>::min()
+            || elt > std::numeric_limits<typename leaf_type::simple_element_type>::max()) {
+          if constexpr(std::is_base_of_v<SimpleString_O, leaf_type>)
+            // very special case to get an actual lisp character into the
+            // type error. (plus there's no Integer_O::create for claspCharacter
+            // as i write this, since it's char32_t)
+            TYPE_ERROR(clasp_make_character(elt), element_type());
+          else
+            TYPE_ERROR(Integer_O::create(elt), element_type());
+        } else (*this)[dest_start + i] = elt;
+      }
+    } else {
+      // note: no std::transform since if the unary_op throws, the program is
+      // std::terminate'd. I think.
+      for (size_t i = 0; i < n; ++i) {
+        T_sp elt = SourceArray_O::to_object((*source)[source_start + i]);
+        (*this)[dest_start + i] = leaf_type::from_object(elt);
+      }
     }
   }
   // default specialization when we know source is simple but nothing else
@@ -735,27 +742,24 @@ public:
   using Base::element_type;
   template <typename SourceArray_O>
   requires (std::derived_from<SourceArray_O, AbstractSimpleVector_O>
-            && std::integral<typename SourceArray_O::simple_element_type>
-            && !std::same_as<SourceArray_O, leaf_type>)
-    void copy_n(gctools::smart_ptr<SourceArray_O> source,
-                size_t dest_start, size_t source_start, size_t n) {
-    for (size_t i = 0; i < n; ++i) {
-      auto elt = (*source)[source_start + i];
-      if (elt < std::numeric_limits<typename leaf_type::simple_element_type>::min()
-          || elt > std::numeric_limits<typename leaf_type::simple_element_type>::max())
-        TYPE_ERROR(Integer_O::create(elt), element_type());
-      else (*this)[dest_start + i] = elt;
-    }
-  }
-  template <typename SourceArray_O>
-  requires (std::derived_from<SourceArray_O, AbstractSimpleVector_O>
             && !std::same_as<SourceArray_O, leaf_type>
             && !std::same_as<SourceArray_O, AbstractSimpleVector_O>)
   void copy_n(gctools::smart_ptr<SourceArray_O> source,
               size_t dest_start, size_t source_start, size_t n) {
-    for (size_t i = 0; i < n; ++i) {
-      T_sp elt = SourceArray_O::to_object((*source)[source_start + i]);
-      (*this)[dest_start + i] = leaf_type::from_object(elt);
+    if constexpr(std::is_integral_v<typename SourceArray_O::simple_element_type>) {
+      static_assert(std::is_integral_v<typename leaf_type::simple_element_type>);
+      for (size_t i = 0; i < n; ++i) {
+        auto elt = (*source)[source_start + i];
+        if (elt < std::numeric_limits<typename leaf_type::simple_element_type>::min()
+            || elt > std::numeric_limits<typename leaf_type::simple_element_type>::max())
+          TYPE_ERROR(Integer_O::create(elt), element_type());
+        else (*this)[dest_start + i] = elt;
+      }
+    } else {
+      for (size_t i = 0; i < n; ++i) {
+        T_sp elt = SourceArray_O::to_object((*source)[source_start + i]);
+        (*this)[dest_start + i] = leaf_type::from_object(elt);
+      }
     }
   }
   template <>

--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -27,6 +27,8 @@ THE SOFTWARE.
 /* -^- */
 
 #include <algorithm> // range algorithms
+#include <limits> // numeric_limits for casting
+#include <concepts> // beware
 #include <clasp/core/array.fwd.h>
 #include <clasp/core/clasp_gmpxx.h>
 #include <clasp/core/object.h>
@@ -246,6 +248,11 @@ public: // Functions here
   virtual Array_sp unsafe_subseq(size_t start, size_t end) const = 0;
   virtual Array_sp unsafe_setf_subseq(size_t start, size_t end, Array_sp newSubseq) = 0;
   virtual void unsafe_fillArrayWithElt(T_sp initial_element, size_t start, size_t end) = 0;
+  // copy_n (below) but dispatching on the dest.
+  // does not fully dispatch on the source's element type, but at least handles
+  // the common case of dest and source having the same element type,
+  // and unwrapping MDArrays.
+  virtual void copy_nd(Array_sp source, size_t dest_start, size_t source_start, size_t len) = 0;
 };
 
 }; // namespace core
@@ -256,6 +263,7 @@ class MDArray_O : public Array_O {
   LISP_ABSTRACT_CLASS(core, CorePkg, MDArray_O, "mdarray", Array_O);
 
 public:
+  typedef AbstractSimpleVector_O simple_type;
   typedef size_t value_type; // this is container - needs value_type
   typedef gctools::GCArray_moveable<value_type> vector_type;
   struct Flags {
@@ -501,29 +509,117 @@ public:
     BOUNDS_ASSERT(start <= end && end <= this->length());
     return leaf_type::make(end - start, value_type(), true, end - start, (value_type*)this->rowMajorAddressOfElement_(start));
   }
-  using Base::element_type; // not otherwise visible in this weird template
-  virtual Array_sp unsafe_setf_subseq(size_t start, size_t end, Array_sp newSubseq) final {
-    // NOTE: This needs to copy left to right (as std::copy does) in case
-    // newSubseq is us, i.e. the ranges are overlapping.
-    BOUNDS_ASSERT(start <= end && end <= this->length());
-    // If newSubseq has the same element type, copy elements directly, without
-    // boxing up a Lisp object for every element.
-    if (element_type() == newSubseq->element_type()) {
-      AbstractSimpleVector_sp baseother;
-      size_t ostart, oend;
-      newSubseq->asAbstractSimpleVectorRange(baseother, ostart, oend);
-      leaf_smart_ptr_type other = baseother.as_assert<leaf_type>();
-      std::copy(other->begin() + ostart, other->begin() + ostart + end - start,
-                begin() + start);
+
+  // copy_n is the base function for copying data between arrays.
+  // If you pass it a source array of known leaf type it will copy without
+  // dispatching, and when possible without boxing.
+  // If you pass it an array of generic type it will do a lot of virtual dispatch
+  // and will box, except that the case of the underlying element type being
+  // identical between source and dest is dispatched on to not box.
+  template <typename SourceArray_O>
+  void copy_n(gctools::smart_ptr<SourceArray_O> source,
+              size_t dest_start, size_t source_start, size_t n);
+
+  // Best case: copying from an array with the same element type.
+  // This does raise the possibility of aliasing though, so watch out for that.
+  template <>
+  void copy_n(leaf_smart_ptr_type source,
+              size_t dest_start, size_t source_start, size_t n) {
+    if (dest_start <= source_start) {
+      std::copy(source->begin() + source_start,
+                source->begin() + source_start + n,
+                begin() + dest_start);
     } else {
-      // Otherwise do the dumb thing. This could potentially be smarter in some
-      // cases, e.g. copying bytes to uint16_t doesn't need boxing. TODO?
-      // But it would require type discrimination, so it might be left better
-      // for Lisp compiler specialization of REPLACE.
-      for (size_t i(start), ni(0); i < end; ++i, ++ni) {
-        (*this)[i] = leaf_type::from_object(newSubseq->rowMajorAref(ni));
-      }
+      std::copy_backward(source->begin() + source_start,
+                         source->begin() + source_start + n,
+                         begin() + dest_start + n);
     }
+  }
+  // OK case: Copying between integral types can be done without boxing.
+  // We do need to signal errors if something won't fit, though, and that's
+  // a runtime check for each element.
+  using Base::element_type;
+  template <typename SourceArray_O>
+  requires (std::derived_from<SourceArray_O, AbstractSimpleVector_O>
+            && std::integral<typename leaf_type::simple_element_type>
+            && std::integral<typename SourceArray_O::simple_element_type>
+            && !std::same_as<SourceArray_O, leaf_type>)
+    void copy_n(gctools::smart_ptr<SourceArray_O> source,
+                size_t dest_start, size_t source_start, size_t n) {
+    for (size_t i = 0; i < n; ++i) {
+      auto elt = (*source)[source_start + i];
+      // clang can probably optimize this out when the source type always fits.
+      if (elt < std::numeric_limits<typename leaf_type::simple_element_type>::min()
+          || elt > std::numeric_limits<typename leaf_type::simple_element_type>::max())
+        TYPE_ERROR(Integer_O::create(elt), element_type());
+      else (*this)[dest_start + i] = elt;
+    }
+  }
+  // Worst specific case: box and unbox,
+  // but we can at least avoid virtual rowMajorAref.
+  // We'd hit the specific expansion if SourceArray_O = leaf_type,
+  // so we don't need to worry about aliasing.
+  template <typename SourceArray_O>
+  requires (std::derived_from<SourceArray_O, AbstractSimpleVector_O>
+            && !std::same_as<SourceArray_O, leaf_type>
+            // needs its own specialization since we need virtual rowMajorAref
+            && !std::same_as<SourceArray_O, AbstractSimpleVector_O>)
+    void copy_n(gctools::smart_ptr<SourceArray_O> source,
+                size_t dest_start, size_t source_start, size_t n) {
+    // note: no std::transform since if the unary_op throws, the program is
+    // std::terminate'd. I think.
+    for (size_t i = 0; i < n; ++i) {
+      T_sp elt = SourceArray_O::to_object((*source)[source_start + i]);
+      (*this)[dest_start + i] = leaf_type::from_object(elt);
+    }
+  }
+  // default specialization when we know source is simple but nothing else
+  template <>
+  void copy_n(AbstractSimpleVector_sp source,
+              size_t dest_start, size_t source_start, size_t n) {
+    // Dynamic dispatch the common self case for speed, and also to avoid
+    // any aliasing problems.
+    if (source.isA<leaf_type>())
+      // KLUDGE: apparently the generic smart_ptr template does not define
+      // as_unsafe, so source.as_unsafe gets you a base_ptr, which does not
+      // fit the templates. WTF?
+      copy_n(gc::As_unsafe<leaf_smart_ptr_type>(source), dest_start, source_start, n);
+    else
+      for (size_t i = 0; i < n; ++i)
+        // virtual dispatch is required unless we want to hardcode
+        // a test for each type of array, which no
+        (*this)[dest_start + i] = leaf_type::from_object(source->rowMajorAref(i));
+  }
+  // For MDArrays, get the underlying simple array of the source
+  // and copy from that.
+  // This also covers MDArray_O itself with simple_type = AbstractSimpleVector_O
+  template <typename SourceArray_O>
+  requires std::derived_from<SourceArray_O, MDArray_O>
+  void copy_n(gctools::smart_ptr<SourceArray_O> source,
+              size_t dest_start, size_t source_start, size_t n) {
+    AbstractSimpleVector_sp sv;
+    size_t sstart, send;
+    source->asAbstractSimpleVectorRange(sv, sstart, send);
+    gctools::smart_ptr<typename SourceArray_O::simple_type> rsv = sv.as_unsafe<typename SourceArray_O::simple_type>();
+    copy_n(rsv, dest_start, source_start + sstart, n);
+  }
+  // default specialization when source array type is not known at all
+  template <>
+  void copy_n(Array_sp source, size_t dest_start, size_t source_start, size_t n) {
+    AbstractSimpleVector_sp sv;
+    size_t sstart, send;
+    source->asAbstractSimpleVectorRange(sv, sstart, send);
+    copy_n(sv, dest_start, source_start + sstart, n);
+  }
+
+  void copy_nd(Array_sp source,
+               size_t dest_start, size_t source_start, size_t n) final {
+    copy_n(source, dest_start, source_start, n);
+  }
+
+  virtual Array_sp unsafe_setf_subseq(size_t start, size_t end, Array_sp newSubseq) final {
+    BOUNDS_ASSERT(start <= end && end <= this->length());
+    copy_n(newSubseq, 0, start, end - start);
     return newSubseq;
   }
 };
@@ -622,23 +718,87 @@ public:
     std::copy(begin() + start, begin() + end, sbv->begin());
     return sbv;
   }
-  using Base::element_type;
-  Array_sp unsafe_setf_subseq(size_t start, size_t end, Array_sp other) override {
+
+  // see definitions in template_SimpleVector::copy_n for more comments
+  template <typename SourceArray_O>
+  void copy_n(gctools::smart_ptr<SourceArray_O> source,
+              size_t dest_start, size_t source_start, size_t n);
+
+  template <>
+  void copy_n(leaf_smart_ptr_type source,
+              size_t dest_start, size_t source_start, size_t n) {
     // TODO: Could be done much faster without boxing by copying whole bit
     // array words and masking appropriately.
-    // See also notes in template_SimpleVector unsafe_setf_subseq above.
-    BOUNDS_ASSERT(0 <= start && start < end && end <= this->length());
-    if (element_type() == other->element_type()) {
-      AbstractSimpleVector_sp baseother;
-      size_t ostart, oend;
-      other->asAbstractSimpleVectorRange(baseother, ostart, oend);
-      leaf_smart_ptr_type rother = baseother.as_assert<leaf_type>();
-      std::copy(rother->begin() + ostart, rother->begin() + ostart + end - start,
-                begin() + start);
+    if (dest_start <= source_start) {
+      std::copy(source->begin() + source_start,
+                source->begin() + source_start + n,
+                begin() + dest_start);
     } else {
-      for (size_t i = start, ni = 0; i < end; ++i, ++ni)
-        (*this)[i] = from_object(other->rowMajorAref(ni));
+      std::copy_backward(source->begin() + source_start,
+                         source->begin() + source_start + n,
+                         begin() + dest_start + n);
     }
+  }
+  using Base::element_type;
+  template <typename SourceArray_O>
+  requires (std::derived_from<SourceArray_O, AbstractSimpleVector_O>
+            && std::integral<typename SourceArray_O::simple_element_type>
+            && !std::same_as<SourceArray_O, leaf_type>)
+    void copy_n(gctools::smart_ptr<SourceArray_O> source,
+                size_t dest_start, size_t source_start, size_t n) {
+    for (size_t i = 0; i < n; ++i) {
+      auto elt = (*source)[source_start + i];
+      if (elt < std::numeric_limits<typename leaf_type::simple_element_type>::min()
+          || elt > std::numeric_limits<typename leaf_type::simple_element_type>::max())
+        TYPE_ERROR(Integer_O::create(elt), element_type());
+      else (*this)[dest_start + i] = elt;
+    }
+  }
+  template <typename SourceArray_O>
+  requires (std::derived_from<SourceArray_O, AbstractSimpleVector_O>
+            && !std::same_as<SourceArray_O, leaf_type>
+            && !std::same_as<SourceArray_O, AbstractSimpleVector_O>)
+  void copy_n(gctools::smart_ptr<SourceArray_O> source,
+              size_t dest_start, size_t source_start, size_t n) {
+    for (size_t i = 0; i < n; ++i) {
+      T_sp elt = SourceArray_O::to_object((*source)[source_start + i]);
+      (*this)[dest_start + i] = leaf_type::from_object(elt);
+    }
+  }
+  template <>
+  void copy_n(AbstractSimpleVector_sp source,
+              size_t dest_start, size_t source_start, size_t n) {
+    if (source.isA<leaf_type>())
+      copy_n(gc::As_unsafe<leaf_smart_ptr_type>(source), dest_start, source_start, n);
+    else
+      for (size_t i = 0; i < n; ++i)
+        (*this)[dest_start + i] = leaf_type::from_object(source->rowMajorAref(i));
+  }
+  template <typename SourceArray_O>
+  requires std::derived_from<SourceArray_O, MDArray_O>
+  void copy_n(gctools::smart_ptr<SourceArray_O> source,
+              size_t dest_start, size_t source_start, size_t n) {
+    AbstractSimpleVector_sp sv;
+    size_t sstart, send;
+    source->asAbstractSimpleVectorRange(sv, sstart, send);
+    gctools::smart_ptr<typename SourceArray_O::simple_type> rsv = sv.as_unsafe<typename SourceArray_O::simple_type>();
+    copy_n(rsv, dest_start, source_start + sstart, n);
+  }
+  template <>
+  void copy_n(Array_sp source, size_t dest_start, size_t source_start, size_t n) {
+    AbstractSimpleVector_sp sv;
+    size_t sstart, send;
+    source->asAbstractSimpleVectorRange(sv, sstart, send);
+    copy_n(sv, dest_start, source_start + sstart, n);
+  }
+
+  void copy_nd(Array_sp source, size_t dest_start, size_t source_start, size_t n) final {
+    copy_n(source, dest_start, source_start, n);
+  }
+
+  Array_sp unsafe_setf_subseq(size_t start, size_t end, Array_sp other) override {
+    BOUNDS_ASSERT(0 <= start && start < end && end <= this->length());
+    copy_n(other, 0, start, end - start);
     return other;
   }
 };
@@ -729,8 +889,8 @@ public:
 
 public:
   void asAbstractSimpleVectorRange(AbstractSimpleVector_sp& sv, size_t& start, size_t& end) const final {
-    LIKELY_if(gc::IsA<gc::smart_ptr<simple_type>>(this->_Data)) {
-      sv = gc::As<AbstractSimpleVector_sp>(this->_Data);
+    if (this->_Data.template isA<simple_type>()) [[likely]] {
+      sv = gc::As_unsafe<gctools::smart_ptr<simple_type>>(this->_Data);
       start = this->_DisplacedIndexOffset;
       end = start + this->arrayTotalSize();
     }
@@ -772,6 +932,20 @@ public:
   CL_METHOD_OVERLOAD virtual void rowMajorAset(size_t idx, T_sp value) final { (*this)[idx] = simple_type::from_object(value); }
   CL_METHOD_OVERLOAD virtual T_sp rowMajorAref(size_t idx) const final { return simple_type::to_object((*this)[idx]); }
   bool equal(T_sp obj) const override { return this->eq(obj); };
+
+  template <typename SourceArray_O>
+  void copy_n(gctools::smart_ptr<SourceArray_O> source,
+              size_t dest_start, size_t source_start, size_t n) {
+    AbstractSimpleVector_sp dest;
+    size_t dstart, dend;
+    asAbstractSimpleVectorRange(dest, dstart, dend);
+    dest.as_unsafe<simple_type>()->copy_n(source, dest_start + dstart,
+                                          source_start, n);
+  }
+
+  void copy_nd(Array_sp source, size_t dest_start, size_t source_start, size_t n) final {
+    copy_n(source, dest_start, source_start, n);
+  }
 };
 }; // namespace core
 
@@ -902,6 +1076,19 @@ public:
     return make_fixnum(idx);
   }
 #pragma clang diagnostic pop
+  template <typename SourceArray_O>
+  void copy_n(gctools::smart_ptr<SourceArray_O> source,
+              size_t dest_start, size_t source_start, size_t n) {
+    AbstractSimpleVector_sp dest;
+    size_t dstart, dend;
+    asAbstractSimpleVectorRange(dest, dstart, dend);
+    dest.as_unsafe<simple_type>()->copy_n(source, dest_start + dstart,
+                                          source_start, n);
+  }
+  void copy_nd(Array_sp source,
+               size_t dest_start, size_t source_start, size_t n) final {
+    copy_n(source, dest_start, source_start, n);
+  }
 };
 }; // namespace core
 
@@ -980,6 +1167,20 @@ public:
   CL_METHOD_OVERLOAD virtual void rowMajorAset(size_t idx, T_sp value) final { (*this)[idx] = simple_type::from_object(value); }
   CL_METHOD_OVERLOAD virtual T_sp rowMajorAref(size_t idx) const final { return simple_type::to_object((*this)[idx]); }
   bool equal(T_sp obj) const override { return this->eq(obj); };
+
+  template <typename SourceArray_O>
+  void copy_n(gctools::smart_ptr<SourceArray_O> source,
+              size_t dest_start, size_t source_start, size_t n) {
+    AbstractSimpleVector_sp dest;
+    size_t dstart, dend;
+    asAbstractSimpleVectorRange(dest, dstart, dend);
+    dest.as_unsafe<simple_type>()->copy_n(source, dest_start + dstart,
+                                          source_start, n);
+  }
+  void copy_nd(Array_sp source,
+               size_t dest_start, size_t source_start, size_t n) final {
+    copy_n(source, dest_start, source_start, n);
+  }
 };
 }; // namespace core
 

--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -239,14 +239,14 @@ public: // Functions here
       notVectorError(this->asSmartPtr());
     size_t_pair p = sequenceStartEnd(core::_sym_setf_subseq, this->length(), start, end);
     Array_sp newVec = gc::As<Array_sp>(new_subseq);
-    return this->unsafe_setf_subseq(p.start, p.end, newVec);
+    this->copy_nd(newVec, p.start, 0, p.end - p.start);
+    return newVec;
   }
   void fillInitialContents(T_sp initialContents);
   virtual void sxhash_equalp(HashGenerator& hg) const override;
   // --------------------------------------------------
-  // Ranged operations with explicit limits
+  // Unsafe ranged operations with explicit limits
   virtual Array_sp unsafe_subseq(size_t start, size_t end) const = 0;
-  virtual Array_sp unsafe_setf_subseq(size_t start, size_t end, Array_sp newSubseq) = 0;
   virtual void unsafe_fillArrayWithElt(T_sp initial_element, size_t start, size_t end) = 0;
   // copy_n (below) but dispatching on the dest.
   // does not fully dispatch on the source's element type, but at least handles
@@ -351,7 +351,6 @@ public:
   virtual T_sp vectorPush(T_sp newElement) final;
   virtual Fixnum_sp vectorPushExtend(T_sp newElement, size_t extension = 0) override;
   virtual Array_sp unsafe_subseq(size_t start, size_t end) const override;
-  virtual Array_sp unsafe_setf_subseq(size_t start, size_t end, Array_sp newSubseq) override;
 };
 }; // namespace core
 
@@ -616,12 +615,6 @@ public:
                size_t dest_start, size_t source_start, size_t n) final {
     copy_n(source, dest_start, source_start, n);
   }
-
-  virtual Array_sp unsafe_setf_subseq(size_t start, size_t end, Array_sp newSubseq) final {
-    BOUNDS_ASSERT(start <= end && end <= this->length());
-    copy_n(newSubseq, 0, start, end - start);
-    return newSubseq;
-  }
 };
 }; // namespace core
 
@@ -794,12 +787,6 @@ public:
 
   void copy_nd(Array_sp source, size_t dest_start, size_t source_start, size_t n) final {
     copy_n(source, dest_start, source_start, n);
-  }
-
-  Array_sp unsafe_setf_subseq(size_t start, size_t end, Array_sp other) override {
-    BOUNDS_ASSERT(0 <= start && start < end && end <= this->length());
-    copy_n(other, 0, start, end - start);
-    return other;
   }
 };
 }; // namespace core

--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -334,11 +334,7 @@ public:
   virtual std::string get_std_string() const override { notStringError(this->asSmartPtr()); }
   virtual std::string get_path_string() const override { notStringError(this->asSmartPtr()); }
   virtual vector<size_t> arrayDimensionsAsVector() const override {
-    vector<size_t> dims;
-    for (size_t i(0); i < this->_Dimensions.length(); ++i) {
-      dims.push_back(this->_Dimensions[i]);
-    }
-    return dims;
+    return vector<size_t>(_Dimensions.begin(), _Dimensions.end());
   }
   virtual void resize(size_t size, T_sp init_element = nil<T_O>(), bool initElementSupplied = false) = 0;
   virtual void unsafe_fillArrayWithElt(T_sp element, size_t start, size_t end) final {
@@ -426,9 +422,7 @@ public:
     end = this->length();
   }
   virtual vector<size_t> arrayDimensionsAsVector() const override {
-    vector<size_t> dims;
-    dims.push_back(this->length());
-    return dims;
+    return vector<size_t>(1, length());
   }
 };
 }; // namespace core
@@ -487,9 +481,8 @@ public:
   virtual size_t elementSizeInBytes() const override { return sizeof(value_type); };
   virtual void* rowMajorAddressOfElement_(size_t i) const override { return (void*)&(this->_Data[i]); };
   virtual void unsafe_fillArrayWithElt(T_sp initialElement, size_t start, size_t end) override {
-    for (size_t i(start); i < end; ++i) {
-      (*this)[i] = leaf_type::from_object(initialElement);
-    }
+    std::fill(begin() + start, begin() + end,
+              leaf_type::from_object(initialElement));
   };
   virtual Array_sp reverse() const final {
     auto result = leaf_type::make(this->length());
@@ -508,11 +501,28 @@ public:
     BOUNDS_ASSERT(start <= end && end <= this->length());
     return leaf_type::make(end - start, value_type(), true, end - start, (value_type*)this->rowMajorAddressOfElement_(start));
   }
+  using Base::element_type; // not otherwise visible in this weird template
   virtual Array_sp unsafe_setf_subseq(size_t start, size_t end, Array_sp newSubseq) final {
-    // TODO: Write specialized versions of this to speed it up
+    // NOTE: This needs to copy left to right (as std::copy does) in case
+    // newSubseq is us, i.e. the ranges are overlapping.
     BOUNDS_ASSERT(start <= end && end <= this->length());
-    for (size_t i(start), ni(0); i < end; ++i, ++ni) {
-      (*this)[i] = leaf_type::from_object(newSubseq->rowMajorAref(ni));
+    // If newSubseq has the same element type, copy elements directly, without
+    // boxing up a Lisp object for every element.
+    if (element_type() == newSubseq->element_type()) {
+      AbstractSimpleVector_sp baseother;
+      size_t ostart, oend;
+      newSubseq->asAbstractSimpleVectorRange(baseother, ostart, oend);
+      leaf_smart_ptr_type other = baseother.as_assert<leaf_type>();
+      std::copy(other->begin() + ostart, other->begin() + ostart + end - start,
+                begin() + start);
+    } else {
+      // Otherwise do the dumb thing. This could potentially be smarter in some
+      // cases, e.g. copying bytes to uint16_t doesn't need boxing. TODO?
+      // But it would require type discrimination, so it might be left better
+      // for Lisp compiler specialization of REPLACE.
+      for (size_t i(start), ni(0); i < end; ++i, ++ni) {
+        (*this)[i] = leaf_type::from_object(newSubseq->rowMajorAref(ni));
+      }
     }
     return newSubseq;
   }
@@ -587,8 +597,7 @@ public:
   static T_sp to_object(value_type v) { return Integer_O::create(v); }
   virtual void unsafe_fillArrayWithElt(T_sp initialElement, size_t start, size_t end) override {
     // FIXME: Could be done more efficiently by writing whole words, but be careful about the ends.
-    for (size_t i = start; i < end; ++i)
-      (*this)[i] = from_object(initialElement);
+    std::fill(begin() + start, begin() + end, from_object(initialElement));
   }
   virtual size_t elementSizeInBytes() const override { bitVectorDoesntSupportError(); }
   virtual void* rowMajorAddressOfElement_(size_t i) const override { bitVectorDoesntSupportError(); }
@@ -610,14 +619,26 @@ public:
   Array_sp unsafe_subseq(size_t start, size_t end) const override {
     BOUNDS_ASSERT(0 <= start && start < end && end <= this->length());
     leaf_smart_ptr_type sbv = leaf_type::make(end - start);
-    for (size_t i(0), iEnd(end - start); i < iEnd; ++i)
-      (*sbv)[i] = (*this)[start + i];
+    std::copy(begin() + start, begin() + end, sbv->begin());
     return sbv;
   }
+  using Base::element_type;
   Array_sp unsafe_setf_subseq(size_t start, size_t end, Array_sp other) override {
+    // TODO: Could be done much faster without boxing by copying whole bit
+    // array words and masking appropriately.
+    // See also notes in template_SimpleVector unsafe_setf_subseq above.
     BOUNDS_ASSERT(0 <= start && start < end && end <= this->length());
-    for (size_t i = start, ni = 0; i < end; ++i, ++ni)
-      (*this)[i] = from_object(other->rowMajorAref(ni));
+    if (element_type() == other->element_type()) {
+      AbstractSimpleVector_sp baseother;
+      size_t ostart, oend;
+      other->asAbstractSimpleVectorRange(baseother, ostart, oend);
+      leaf_smart_ptr_type rother = baseother.as_assert<leaf_type>();
+      std::copy(rother->begin() + ostart, rother->begin() + ostart + end - start,
+                begin() + start);
+    } else {
+      for (size_t i = start, ni = 0; i < end; ++i, ++ni)
+        (*this)[i] = from_object(other->rowMajorAref(ni));
+    }
     return other;
   }
 };
@@ -998,7 +1019,7 @@ T_mv clasp_vectorStartEnd(Symbol_sp fn, T_sp thing, Fixnum_sp start, Fixnum_sp e
 
 namespace core {
 
-void core__copy_subarray(Array_sp dest, Fixnum_sp destStart, Array_sp orig, Fixnum_sp origStart, Fixnum_sp len);
+void core__copy_subarray(Array_sp dest, size_t destStart, Array_sp orig, size_t origStart, size_t len);
 
 T_sp core__rowMajorAset(T_sp, Array_sp, gc::Fixnum);
 T_sp cl__rowMajorAref(Array_sp, gc::Fixnum);

--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -600,7 +600,7 @@ public:
       for (size_t i = 0; i < n; ++i)
         // virtual dispatch is required unless we want to hardcode
         // a test for each type of array, which no
-        (*this)[dest_start + i] = leaf_type::from_object(source->rowMajorAref(i));
+        (*this)[dest_start + i] = leaf_type::from_object(source->rowMajorAref(source_start + i));
   }
   // For MDArrays, get the underlying simple array of the source
   // and copy from that.
@@ -776,7 +776,7 @@ public:
       copy_n(gc::As_unsafe<leaf_smart_ptr_type>(source), dest_start, source_start, n);
     else
       for (size_t i = 0; i < n; ++i)
-        (*this)[dest_start + i] = leaf_type::from_object(source->rowMajorAref(i));
+        (*this)[dest_start + i] = leaf_type::from_object(source->rowMajorAref(source_start + i));
   }
   template <typename SourceArray_O>
   requires std::derived_from<SourceArray_O, MDArray_O>

--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -551,10 +551,16 @@ public:
     void copy_n(gctools::smart_ptr<SourceArray_O> source,
                 size_t dest_start, size_t source_start, size_t n) {
     if constexpr(std::is_integral_v<typename leaf_type::simple_element_type>
-                 && std::is_integral_v<typename SourceArray_O::simple_element_type>) {
+                 && std::is_integral_v<typename SourceArray_O::simple_element_type>
+                 // make sure not to copy strings into bytevectors or vice versa
+                 && ((std::is_base_of_v<SimpleString_O, leaf_type>
+                      && std::is_base_of_v<SimpleString_O, SourceArray_O>)
+                     || (!std::is_base_of_v<SimpleString_O, leaf_type>
+                         && !std::is_base_of_v<SimpleString_O, SourceArray_O>))) {
       // Specialish case so we can copy integers without boxing.
       // if constexpr is because constraint normalization is kind of dumb,
       // making it difficult to keep the templates unambiguous.
+      // actual copy loop
       for (size_t i = 0; i < n; ++i) {
         auto elt = (*source)[source_start + i];
         // clang can probably optimize this test out when the source type
@@ -746,7 +752,8 @@ public:
             && !std::same_as<SourceArray_O, AbstractSimpleVector_O>)
   void copy_n(gctools::smart_ptr<SourceArray_O> source,
               size_t dest_start, size_t source_start, size_t n) {
-    if constexpr(std::is_integral_v<typename SourceArray_O::simple_element_type>) {
+    if constexpr(std::is_integral_v<typename SourceArray_O::simple_element_type>
+                 && !std::is_base_of_v<SimpleString_O, SourceArray_O>) {
       static_assert(std::is_integral_v<typename leaf_type::simple_element_type>);
       for (size_t i = 0; i < n; ++i) {
         auto elt = (*source)[source_start + i];

--- a/include/clasp/core/character.fwd.h
+++ b/include/clasp/core/character.fwd.h
@@ -44,4 +44,8 @@ inline claspCharacter clasp_as_claspCharacter(Character_sp c) { return c.unsafe_
 
 claspCharacter char_upcase(claspCharacter);
 
+inline bool clasp_base_char_p(claspCharacter c) { return c <= 255; }
+
+inline bool clasp_base_char_p(Character_sp c) { return c.unsafe_character() >= 0 && c.unsafe_character() <= 255; }
+
 } // namespace core

--- a/include/clasp/core/character.h
+++ b/include/clasp/core/character.h
@@ -120,10 +120,6 @@ claspCharacter char_downcase(claspCharacter code);
 }
 #endif
 
-inline bool clasp_base_char_p(claspCharacter c) { return c <= 255; }
-
-inline bool clasp_base_char_p(Character_sp c) { return c.unsafe_character() >= 0 && c.unsafe_character() <= 255; }
-
 bool alphanumericp(claspCharacter c);
 
 bool alpha_char_p(claspCharacter c);

--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -685,6 +685,9 @@ public:
   String_sp get_string();
 
   claspCharacter write_char(claspCharacter c) override;
+  // Bulk override: avoids the per-character boxing + virtual vectorPushExtend
+  // of the default AnsiStream_O::write_string char-by-char loop.
+  void write_string(String_sp data, cl_index start, cl_index end) override;
   void clear_output() override;
   void finish_output() override;
   void force_output() override;

--- a/include/clasp/core/string.h
+++ b/include/clasp/core/string.h
@@ -58,11 +58,11 @@ public:
   static value_type default_initial_element(void) { return '\0'; }
   static value_type from_object(T_sp obj) {
     if (obj.characterp()) {
-      return obj.unsafe_character();
-    } else if (obj.nilp()) {
-      return '\0';
+      auto c = obj.unsafe_character();
+      if (clasp_base_char_p(c))
+        return c;
     }
-    TYPE_ERROR(obj, Cons_O::createList(cl::_sym_or, cl::_sym_character, cl::_sym_nil));
+    TYPE_ERROR(obj, cl::_sym_base_char);
   }
   static T_sp to_object(const value_type& v) { return clasp_make_character(v); };
 
@@ -155,10 +155,8 @@ public:
   static value_type from_object(T_sp obj) {
     if (obj.characterp()) {
       return obj.unsafe_character();
-    } else if (obj.nilp()) {
-      return 0;
     }
-    TYPE_ERROR(obj, Cons_O::createList(cl::_sym_or, cl::_sym_character, cl::_sym_nil));
+    TYPE_ERROR(obj, cl::_sym_character);
   }
   static T_sp to_object(const value_type& v) { return clasp_make_character(v); };
 

--- a/include/clasp/gctools/threadlocal.fwd.h
+++ b/include/clasp/gctools/threadlocal.fwd.h
@@ -24,15 +24,11 @@ struct MonitorAllocations {
 };
 #endif
 
-struct GlobalAllocationProfiler {
+struct AllocationProfiler {
   // These counters live in the THREAD_LOCAL ThreadLocalStateLowLevel (as the
   // member _Allocations) and are only ever accessed via
   // my_thread_low_level->_Allocations, i.e. by the owning thread alone (see
   // gcalloc_boehm.h, gcFunctions.cc, startRunStop.cc, memoryManagement.cc).
-  // There is no shared/global instance and no cross-thread read, so atomics are
-  // pure overhead on registerAllocation(), which runs on every heap allocation.
-  // Plain int64_t with in-class zero-init (the previous atomics were not all
-  // initialized by the constructors below).
   int64_t _BytesAllocated = 0;
   size_t _AllocationSizeThreshold;
   size_t _AllocationNumberThreshold;
@@ -44,10 +40,10 @@ struct GlobalAllocationProfiler {
   MonitorAllocations _Monitor;
 #endif
 
-  GlobalAllocationProfiler()
+  AllocationProfiler()
       : _AllocationSizeThreshold(1024 * 1024), _AllocationNumberThreshold(16386), _HitAllocationNumberCounter(0),
         _HitAllocationSizeCounter(0){};
-  GlobalAllocationProfiler(size_t size, size_t number)
+  AllocationProfiler(size_t size, size_t number)
       : _AllocationSizeThreshold(size), _AllocationNumberThreshold(number), _HitAllocationNumberCounter(0),
         _HitAllocationSizeCounter(0){};
 
@@ -96,7 +92,7 @@ struct GlobalAllocationProfiler {
 struct ThreadLocalStateLowLevel {
   void* _StackTop;
   bool _DisableInterrupts;
-  GlobalAllocationProfiler _Allocations;
+  AllocationProfiler _Allocations;
   // Time unwinds
   std::chrono::time_point<std::chrono::high_resolution_clock> _start_unwind;
   std::chrono::duration<size_t, std::nano> _unwind_time;

--- a/include/clasp/gctools/threadlocal.fwd.h
+++ b/include/clasp/gctools/threadlocal.fwd.h
@@ -25,13 +25,21 @@ struct MonitorAllocations {
 #endif
 
 struct GlobalAllocationProfiler {
-  std::atomic<int64_t> _BytesAllocated;
+  // These counters live in the THREAD_LOCAL ThreadLocalStateLowLevel (as the
+  // member _Allocations) and are only ever accessed via
+  // my_thread_low_level->_Allocations, i.e. by the owning thread alone (see
+  // gcalloc_boehm.h, gcFunctions.cc, startRunStop.cc, memoryManagement.cc).
+  // There is no shared/global instance and no cross-thread read, so atomics are
+  // pure overhead on registerAllocation(), which runs on every heap allocation.
+  // Plain int64_t with in-class zero-init (the previous atomics were not all
+  // initialized by the constructors below).
+  int64_t _BytesAllocated = 0;
   size_t _AllocationSizeThreshold;
   size_t _AllocationNumberThreshold;
-  std::atomic<int64_t> _AllocationSizeCounter;
-  std::atomic<int64_t> _AllocationNumberCounter;
-  std::atomic<int64_t> _HitAllocationNumberCounter;
-  std::atomic<int64_t> _HitAllocationSizeCounter;
+  int64_t _AllocationSizeCounter = 0;
+  int64_t _AllocationNumberCounter = 0;
+  int64_t _HitAllocationNumberCounter = 0;
+  int64_t _HitAllocationSizeCounter = 0;
 #ifdef DEBUG_MONITOR_ALLOCATIONS
   MonitorAllocations _Monitor;
 #endif

--- a/include/clasp/llvmo/code.h
+++ b/include/clasp/llvmo/code.h
@@ -428,6 +428,11 @@ namespace llvmo {
 core::T_sp identify_code_or_library(gctools::clasp_ptr_t entry_point);
 
 size_t countObjectFileNames(const std::string& name);
+// Maintain the O(1) name->count index used by countObjectFileNames.
+// recordObjectFileName is called for every registered object file;
+// clearObjectFileNameCounts is called whenever _AllObjectFiles is cleared.
+void recordObjectFileName(const std::string& name);
+void clearObjectFileNameCounts();
 
 std::string createIRModuleObjectFileName(size_t startupId, std::string& prefix);
 bool verifyIRModuleObjectFileStartupSymbol(const std::string& name);
@@ -456,6 +461,8 @@ template <typename Stage = gctools::RuntimeStage> void registerObjectFile(Object
     expected = _lisp->_Roots._AllObjectFiles.load();
     entry->rplacd(expected);
   } while (!_lisp->_Roots._AllObjectFiles.compare_exchange_weak(expected, entry));
+  // Keep the O(1) countObjectFileNames index in sync (single add point).
+  recordObjectFileName(name);
 }
 
 }; // namespace llvmo

--- a/src/core/array.cc
+++ b/src/core/array.cc
@@ -529,27 +529,11 @@ DOCGROUP(clasp)
 CL_LAMBDA(dest destStart orig origStart len)
 CL_DEFUN
 void core__copy_subarray(Array_sp dest, size_t destStart, Array_sp orig, size_t origStart, size_t len) {
-  // TODO: THIS NEEDS TO BE OPTIMIZED FOR DIFFERENT TYPES OF ARRAYS!!!!!!!
-  //       Currently this is very inefficient
   if ((len + destStart) >= dest->arrayTotalSize())
     len = dest->arrayTotalSize() - destStart;
   if ((len + origStart) >= orig->arrayTotalSize())
     len = orig->arrayTotalSize() - origStart;
-  if (destStart < origStart) {
-    for (size_t i = 0; i < len; ++i) {
-      dest->rowMajorAset(destStart, orig->rowMajorAref(origStart));
-      ++destStart;
-      ++origStart;
-    }
-  } else {
-    destStart += len;
-    origStart += len;
-    for (size_t i = 0; i < len; ++i) {
-      --destStart;
-      --origStart;
-      dest->rowMajorAset(destStart, orig->rowMajorAref(origStart));
-    }
-  }
+  dest->copy_nd(orig, destStart, origStart, len);
 }
 
 CL_LISPIFY_NAME("cl:aref"); // SETF symbol

--- a/src/core/array.cc
+++ b/src/core/array.cc
@@ -528,30 +528,26 @@ CL_DOCSTRING(R"dx(copy_subarray)dx")
 DOCGROUP(clasp)
 CL_LAMBDA(dest destStart orig origStart len)
 CL_DEFUN
-void core__copy_subarray(Array_sp dest, Fixnum_sp destStart, Array_sp orig, Fixnum_sp origStart, Fixnum_sp len) {
+void core__copy_subarray(Array_sp dest, size_t destStart, Array_sp orig, size_t origStart, size_t len) {
   // TODO: THIS NEEDS TO BE OPTIMIZED FOR DIFFERENT TYPES OF ARRAYS!!!!!!!
   //       Currently this is very inefficient
-  size_t iLen = unbox_fixnum(len);
-  if (iLen == 0) return;
-  size_t iDestStart = unbox_fixnum(destStart);
-  size_t iOrigStart = unbox_fixnum(origStart);
-  if ((iLen + iDestStart) >= dest->arrayTotalSize())
-    iLen = dest->arrayTotalSize() - iDestStart;
-  if ((iLen + iOrigStart) >= orig->arrayTotalSize())
-    iLen = orig->arrayTotalSize() - iOrigStart;
-  if (iDestStart < iOrigStart) {
-    for (size_t i = 0; i < iLen; ++i) {
-      dest->rowMajorAset(iDestStart, orig->rowMajorAref(iOrigStart));
-      ++iDestStart;
-      ++iOrigStart;
+  if ((len + destStart) >= dest->arrayTotalSize())
+    len = dest->arrayTotalSize() - destStart;
+  if ((len + origStart) >= orig->arrayTotalSize())
+    len = orig->arrayTotalSize() - origStart;
+  if (destStart < origStart) {
+    for (size_t i = 0; i < len; ++i) {
+      dest->rowMajorAset(destStart, orig->rowMajorAref(origStart));
+      ++destStart;
+      ++origStart;
     }
   } else {
-    iDestStart += iLen;
-    iOrigStart += iLen;
-    for (size_t i = 0; i < iLen; ++i) {
-      --iDestStart;
-      --iOrigStart;
-      dest->rowMajorAset(iDestStart, orig->rowMajorAref(iOrigStart));
+    destStart += len;
+    origStart += len;
+    for (size_t i = 0; i < len; ++i) {
+      --destStart;
+      --origStart;
+      dest->rowMajorAset(destStart, orig->rowMajorAref(origStart));
     }
   }
 }

--- a/src/core/array.cc
+++ b/src/core/array.cc
@@ -331,9 +331,6 @@ void MDArray_O::set_data(Array_sp a) { this->_Data = a; }
 Array_sp MDArray_O::unsafe_subseq(size_t start, size_t iend) const {
   return this->_Data->unsafe_subseq(start + this->_DisplacedIndexOffset, iend + this->_DisplacedIndexOffset);
 }
-Array_sp MDArray_O::unsafe_setf_subseq(size_t start, size_t iend, Array_sp new_subseq) {
-  return this->_Data->unsafe_setf_subseq(start + this->_DisplacedIndexOffset, iend + this->_DisplacedIndexOffset, new_subseq);
-}
 
 bool MDArray_O::equalp(T_sp other) const {
   if (&*other == this)

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -240,13 +240,14 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
   uintptr_t bytecode_start = (uintptr_t)(bc->rowMajorAddressOfElement_(0));
   uintptr_t bytecode_end = (uintptr_t)(bc->rowMajorAddressOfElement_(bc->length()));
 #endif
-  MultipleValues& multipleValues = core::lisp_multipleValues();
-  // Resolve the thread-local pointer once per VM frame. On Darwin every
-  // `my_thread` access is a _tlv_get_addr thunk call; the interpreter hits it on
-  // every call (maybe_step_call's breakstep check) and in several opcodes, so
+  // Resolve the thread-local pointer once per VM frame. Access TLS is
+  // not a trivial operation, e.g. on Darwin every `my_thread` access is a
+  // _tlv_get_addr thunk call; the interpreter hits it on every call
+  // (maybe_step_call's breakstep check) and in several opcodes, so
   // caching it here removes a per-call/per-op thunk. The thread does not change
-  // during a VM frame.
+  // during a VM frame, or really at all after the thread is initialized.
   ThreadLocalState* thread = my_thread;
+  MultipleValues& multipleValues = thread->_MultipleValues;
   unsigned char* pc = vm._pc;
   while (1) {
     VM_PC_CHECK(vm, pc, bytecode_start, bytecode_end);
@@ -682,7 +683,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
       T_sp texisting_values((gctools::Tagged)vm.pop(sp));
       size_t existing_values = texisting_values.unsafe_fixnum();
       DBG_VM("  existing-values = %zu\n", existing_values);
-      vm.copyto(sp, existing_values, &my_thread->_MultipleValues._Values[0]);
+      vm.copyto(sp, existing_values, &multipleValues._Values[0]);
       multipleValues.setSize(existing_values);
       vm.drop(sp, existing_values);
       pc++;
@@ -771,8 +772,8 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
       vm._pc = pc;
       TagbodyDynEnv_sp env = TagbodyDynEnv_O::create(frame, &target);
       vm.setreg(fp, n, env.raw_());
-      gctools::StackAllocate<Cons_O> sa_ec(env, my_thread->dynEnvStackGet());
-      DynEnvPusher dep(my_thread, sa_ec.asSmartPtr());
+      gctools::StackAllocate<Cons_O> sa_ec(env, thread->dynEnvStackGet());
+      DynEnvPusher dep(thread, sa_ec.asSmartPtr());
       _setjmp(target);
     again:
       try {
@@ -781,7 +782,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
         pc = vm._pc;
       } catch (Unwind& uw) {
         if (uw.getFrame() == frame) {
-          my_thread->dynEnvStackGet() = sa_ec.asSmartPtr();
+          thread->dynEnvStackGet() = sa_ec.asSmartPtr();
           goto again;
         } else
           throw;
@@ -1055,7 +1056,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
 static unsigned char* long_dispatch(VirtualMachine& vm, unsigned char* pc, MultipleValues& multipleValues, T_O** literals,
                                     T_O** closed, Closure_O* closure, core::T_O** fp, core::T_O** sp, size_t lcc_nargs,
                                     core::T_O** lcc_args, uint8_t sub_opcode) {
-  ThreadLocalState* thread = my_thread; // cache TLS pointer once (see bytecode_vm)
+  ThreadLocalState* thread = my_thread; // only grab TLS pointer once (see bytecode_vm)
   switch ((vm_code)sub_opcode) {
   case vm_code::ref: {
     uint8_t low = *(pc + 1);
@@ -1396,8 +1397,8 @@ static unsigned char* long_dispatch(VirtualMachine& vm, unsigned char* pc, Multi
     vm._pc = pc;
     TagbodyDynEnv_sp env = TagbodyDynEnv_O::create(frame, &target);
     vm.setreg(fp, n, env.raw_());
-    gctools::StackAllocate<Cons_O> sa_ec(env, my_thread->dynEnvStackGet());
-    DynEnvPusher dep(my_thread, sa_ec.asSmartPtr());
+    gctools::StackAllocate<Cons_O> sa_ec(env, thread->dynEnvStackGet());
+    DynEnvPusher dep(thread, sa_ec.asSmartPtr());
     _setjmp(target);
   again:
     try {
@@ -1406,7 +1407,7 @@ static unsigned char* long_dispatch(VirtualMachine& vm, unsigned char* pc, Multi
       pc = vm._pc;
     } catch (Unwind& uw) {
       if (uw.getFrame() == frame) {
-        my_thread->dynEnvStackGet() = sa_ec.asSmartPtr();
+        thread->dynEnvStackGet() = sa_ec.asSmartPtr();
         goto again;
       } else
         throw;

--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -64,9 +64,9 @@ void BytecodeModule_O::register_for_debug() {
 // Note that we check stepping in the callER not the callEE.
 // This is so that we could provide the actual source forms, as we already do
 // in native code. TODO
-static void maybe_step_call(void* frame,
+static void maybe_step_call(ThreadLocalState* thread, void* frame,
                             Function_sp func, size_t nargs, T_O** rargs) {
-  if (my_thread->_Breakstep) [[unlikely]] {
+  if (thread->_Breakstep) [[unlikely]] {
     ql::list args;
     for (size_t iarg = 0; iarg < nargs; ++iarg)
       args << T_sp((gctools::Tagged)rargs[iarg]);
@@ -241,6 +241,12 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
   uintptr_t bytecode_end = (uintptr_t)(bc->rowMajorAddressOfElement_(bc->length()));
 #endif
   MultipleValues& multipleValues = core::lisp_multipleValues();
+  // Resolve the thread-local pointer once per VM frame. On Darwin every
+  // `my_thread` access is a _tlv_get_addr thunk call; the interpreter hits it on
+  // every call (maybe_step_call's breakstep check) and in several opcodes, so
+  // caching it here removes a per-call/per-op thunk. The thread does not change
+  // during a VM frame.
+  ThreadLocalState* thread = my_thread;
   unsigned char* pc = vm._pc;
   while (1) {
     VM_PC_CHECK(vm, pc, bytecode_start, bytecode_end);
@@ -288,7 +294,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
       T_sp tfunc((gctools::Tagged)(*(vm.stackref(sp, nargs))));
       Function_sp func = gc::As_assert<Function_sp>(tfunc);
       T_O** args = vm.stackref(sp, nargs - 1);
-      maybe_step_call(__builtin_frame_address(0), func, nargs, args);
+      maybe_step_call(thread, __builtin_frame_address(0), func, nargs, args);
       // We push the PC for the debugger (see make_bytecode_frame in backtrace.cc)
       // We do this here rather than bytecode_call because e.g. we may call a
       // non-bytecode function, that in turn calls a bunch of different bytecode
@@ -311,7 +317,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
       VM_RECORD_PLAYBACK(func, "vm_call_receive_one_func");
       VM_RECORD_PLAYBACK((void*)(uintptr_t)nargs, "vm_call_receive_one_nargs");
       T_O** args = vm.stackref(sp, nargs - 1);
-      maybe_step_call(__builtin_frame_address(0), func, nargs, args);
+      maybe_step_call(thread, __builtin_frame_address(0), func, nargs, args);
 #if DEBUG_VM_RECORD_PLAYBACK == 1
       for (size_t ii = 0; ii < nargs; ii++) {
         stringstream name_args;
@@ -336,7 +342,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
       T_sp tfunc((gctools::Tagged)(*(vm.stackref(sp, nargs))));
       Function_sp func = gc::As_assert<Function_sp>(tfunc);
       T_O** args = vm.stackref(sp, nargs - 1);
-      maybe_step_call(__builtin_frame_address(0), func, nargs, args);
+      maybe_step_call(thread, __builtin_frame_address(0), func, nargs, args);
       vm.push(sp, (T_O*)pc);
       vm._pc = pc;
       vm._stackPointer = sp;
@@ -690,7 +696,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
       T_sp tfunc((gctools::Tagged)(*(vm.stackref(sp, nargs))));
       Function_sp func = gc::As_assert<Function_sp>(tfunc);
       T_O** args = vm.stackref(sp, nargs - 1);
-      maybe_step_call(__builtin_frame_address(0), func, nargs, args);
+      maybe_step_call(thread, __builtin_frame_address(0), func, nargs, args);
       vm.push(sp, (T_O*)pc);
       vm._pc = pc;
       vm._stackPointer = sp;
@@ -708,7 +714,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
       T_sp tfunc((gctools::Tagged)(*(vm.stackref(sp, nargs))));
       Function_sp func = gc::As_assert<Function_sp>(tfunc);
       T_O** args = vm.stackref(sp, nargs - 1);
-      maybe_step_call(__builtin_frame_address(0), func, nargs, args);
+      maybe_step_call(thread, __builtin_frame_address(0), func, nargs, args);
       vm.push(sp, (T_O*)pc);
       vm._pc = pc;
       vm._stackPointer = sp;
@@ -727,7 +733,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
       T_sp tfunc((gctools::Tagged)(*(vm.stackref(sp, nargs))));
       Function_sp func = gc::As_assert<Function_sp>(tfunc);
       T_O** args = vm.stackref(sp, nargs - 1);
-      maybe_step_call(__builtin_frame_address(0), func, nargs, args);
+      maybe_step_call(thread, __builtin_frame_address(0), func, nargs, args);
       vm.push(sp, (T_O*)pc);
       vm._pc = pc;
       vm._stackPointer = sp;
@@ -1049,6 +1055,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
 static unsigned char* long_dispatch(VirtualMachine& vm, unsigned char* pc, MultipleValues& multipleValues, T_O** literals,
                                     T_O** closed, Closure_O* closure, core::T_O** fp, core::T_O** sp, size_t lcc_nargs,
                                     core::T_O** lcc_args, uint8_t sub_opcode) {
+  ThreadLocalState* thread = my_thread; // cache TLS pointer once (see bytecode_vm)
   switch ((vm_code)sub_opcode) {
   case vm_code::ref: {
     uint8_t low = *(pc + 1);
@@ -1083,7 +1090,7 @@ static unsigned char* long_dispatch(VirtualMachine& vm, unsigned char* pc, Multi
     T_sp tfunc((gctools::Tagged)(*(vm.stackref(sp, nargs))));
     Function_sp func = gc::As_assert<Function_sp>(tfunc);
     T_O** args = vm.stackref(sp, nargs - 1);
-    maybe_step_call(__builtin_frame_address(0), func, nargs, args);
+    maybe_step_call(thread, __builtin_frame_address(0), func, nargs, args);
     vm.push(sp, (T_O*)pc);
     vm._pc = pc;
     vm._stackPointer = sp;
@@ -1100,7 +1107,7 @@ static unsigned char* long_dispatch(VirtualMachine& vm, unsigned char* pc, Multi
     T_sp tfunc((gctools::Tagged)(*(vm.stackref(sp, nargs))));
     Function_sp func = gc::As_assert<Function_sp>(tfunc);
     T_O** args = vm.stackref(sp, nargs - 1);
-    maybe_step_call(__builtin_frame_address(0), func, nargs, args);
+    maybe_step_call(thread, __builtin_frame_address(0), func, nargs, args);
     VM_RECORD_PLAYBACK(func, "vm_call_receive_one_func");
     VM_RECORD_PLAYBACK((void*)(uintptr_t)nargs, "vm_call_receive_one_nargs");
 #if DEBUG_VM_RECORD_PLAYBACK == 1
@@ -1129,7 +1136,7 @@ static unsigned char* long_dispatch(VirtualMachine& vm, unsigned char* pc, Multi
     T_sp tfunc((gctools::Tagged)(*(vm.stackref(sp, nargs))));
     Function_sp func = gc::As_assert<Function_sp>(tfunc);
     T_O** args = vm.stackref(sp, nargs - 1);
-    maybe_step_call(__builtin_frame_address(0), func, nargs, args);
+    maybe_step_call(thread, __builtin_frame_address(0), func, nargs, args);
     vm.push(sp, (T_O*)pc);
     vm._pc = pc;
     vm._stackPointer = sp;
@@ -1348,7 +1355,7 @@ static unsigned char* long_dispatch(VirtualMachine& vm, unsigned char* pc, Multi
     T_sp tfunc((gctools::Tagged)(*(vm.stackref(sp, nargs))));
     Function_sp func = gc::As_assert<Function_sp>(tfunc);
     T_O** args = vm.stackref(sp, nargs - 1);
-    maybe_step_call(__builtin_frame_address(0), func, nargs, args);
+    maybe_step_call(thread, __builtin_frame_address(0), func, nargs, args);
     vm.push(sp, (T_O*)pc);
     vm._pc = pc;
     vm._stackPointer = sp;

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -2723,6 +2723,89 @@ claspCharacter StringOutputStream_O::write_char(claspCharacter c) {
   return c;
 }
 
+// Bulk write_string for string-output-streams. The default
+// AnsiStream_O::write_string writes one character at a time, and each char
+// pays a boxing (clasp_make_character) plus a virtual vectorPushExtend with a
+// fill-pointer/realloc check. Here we (1) update the output cursor over the
+// appended range exactly as the per-char path would, and (2) append the
+// content in one shot with a single geometric growth and the type-safe subseq
+// copy used elsewhere for string buffers (see read_line / unsafe_setf_subseq),
+// which preserves base/extended conversion and narrowing-error behavior.
+void StringOutputStream_O::write_string(String_sp data, cl_index start, cl_index end) {
+  if (start >= end)
+    return;
+  const cl_index count = end - start;
+  const cl_index oldFill = this->_contents->fillPointer();
+  const cl_index newFill = oldFill + count;
+  // Grow the destination once (geometric) so the copy needs no per-character
+  // reallocation or fill-pointer check. _contents is always an adjustable
+  // fill-pointer string (an MDArray) for a string-output-stream; resize keeps
+  // the fill pointer for fill-pointer arrays.
+  if (newFill > static_cast<cl_index>(this->_contents->arrayTotalSize())) {
+    cl_index newTotal = static_cast<cl_index>(this->_contents->arrayTotalSize()) * 2;
+    if (newTotal < newFill)
+      newTotal = newFill;
+    gc::As<MDArray_sp>(this->_contents)->resize(newTotal);
+  }
+  StreamCursor& cur = this->_output_cursor;
+  // Resolve the underlying simple vectors so element access is a non-virtual,
+  // typed indexing operation. Boehm GC is non-moving and the copy loop below
+  // performs no allocation, so these references stay valid throughout.
+  AbstractSimpleVector_sp ssv;
+  size_t s0, s1;
+  data->asAbstractSimpleVectorRange(ssv, s0, s1);
+  AbstractSimpleVector_sp dsv;
+  size_t d0, d1;
+  this->_contents->asAbstractSimpleVectorRange(dsv, d0, d1);
+  const cl_index srcOff = static_cast<cl_index>(s0) + start;
+  const cl_index dstOff = static_cast<cl_index>(d0) + oldFill;
+  bool fast = true;
+  if (gc::IsA<SimpleCharacterString_sp>(dsv)) {
+    SimpleCharacterString_O& dst = *gc::As_unsafe<SimpleCharacterString_sp>(dsv);
+    if (gc::IsA<SimpleCharacterString_sp>(ssv)) {
+      SimpleCharacterString_O& src = *gc::As_unsafe<SimpleCharacterString_sp>(ssv);
+      for (cl_index i = 0; i < count; ++i) {
+        claspCharacter c = src[srcOff + i];
+        dst[dstOff + i] = c;
+        cur.update(c);
+      }
+    } else if (gc::IsA<SimpleBaseString_sp>(ssv)) {
+      SimpleBaseString_O& src = *gc::As_unsafe<SimpleBaseString_sp>(ssv);
+      for (cl_index i = 0; i < count; ++i) {
+        claspCharacter c = src[srcOff + i]; // widen 8 -> 32 bits
+        dst[dstOff + i] = c;
+        cur.update(c);
+      }
+    } else
+      fast = false;
+  } else if (gc::IsA<SimpleBaseString_sp>(dsv) && gc::IsA<SimpleBaseString_sp>(ssv)) {
+    SimpleBaseString_O& dst = *gc::As_unsafe<SimpleBaseString_sp>(dsv);
+    SimpleBaseString_O& src = *gc::As_unsafe<SimpleBaseString_sp>(ssv);
+    for (cl_index i = 0; i < count; ++i) {
+      claspChar c = src[srcOff + i];
+      dst[dstOff + i] = c;
+      cur.update(c);
+    }
+  } else {
+    // Character source into a base destination may narrow; defer to the safe
+    // path which raises the proper type error for out-of-range characters.
+    fast = false;
+  }
+  if (fast) {
+    this->_contents->fillPointerSet(newFill);
+    return;
+  }
+  // Safe fallback: cursor updated identically to the per-char path, content
+  // copied with the tested type-checking subseq machinery.
+  for (cl_index i = start; i < end; ++i)
+    cur.update(clasp_as_claspCharacter(cl__char(data, i)));
+  Array_sp src = (start == 0 && static_cast<cl_index>(data->length()) == end)
+                     ? gc::As_unsafe<Array_sp>(data)
+                     : gc::As_unsafe<Array_sp>(data->unsafe_subseq(start, end));
+  this->_contents->unsafe_setf_subseq(oldFill, newFill, src);
+  this->_contents->fillPointerSet(newFill);
+}
+
 T_sp StringOutputStream_O::position() { return Integer_O::create((gc::Fixnum)_contents->fillPointer()); }
 
 void StringOutputStream_O::clear_output() {}

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -1885,7 +1885,7 @@ T_mv AnsiStream_O::read_line() {
         if (extended_buffer->arrayTotalSize() < base_buffer->length())
           extended_buffer->resize(base_buffer->length());
         // copy in the base buffer, then release the base buffer
-        extended_buffer->unsafe_setf_subseq(0, base_buffer->length(), base_buffer->asSmartPtr());
+        extended_buffer->copy_n(base_buffer, 0, 0, base_buffer->length());
         extended_buffer->fillPointerSet(base_buffer->length());
         _lisp->put_Str8Ns_buffer_string(base_buffer);
       }
@@ -2727,8 +2727,7 @@ claspCharacter StringOutputStream_O::write_char(claspCharacter c) {
 // pays a boxing (clasp_make_character) plus a virtual vectorPushExtend with a
 // fill-pointer/realloc check. Here we (1) update the output cursor over the
 // appended range exactly as the per-char path would, and (2) append the
-// content in one shot with a single geometric growth and the type-safe subseq
-// copy used elsewhere for string buffers (see read_line / unsafe_setf_subseq),
+// content in one shot with a single geometric growth and copy_n,
 // which preserves base/extended conversion and narrowing-error behavior.
 void StringOutputStream_O::write_string(String_sp data, cl_index start, cl_index end) {
   if (start >= end)

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -2695,13 +2695,12 @@ CL_LAMBDA(s);
 CL_UNWIND_COOP(true);
 CL_DOCSTRING(R"dx(make_string_output_stream_from_string)dx");
 CL_DEFUN StringOutputStream_sp core__make_string_output_stream_from_string(T_sp s) {
-  StringOutputStream_sp strm = StringOutputStream_O::create();
-  bool stringp = cl__stringp(s);
-  unlikely_if(!stringp || !gc::As<Array_sp>(s)->arrayHasFillPointerP()) {
+  if (s.isA<StrNs_O>() && s.as<StrNs_O>()->arrayHasFillPointerP()) [[likely]] {
+    StringOutputStream_sp strm = StringOutputStream_O::create();
+    strm->_contents = s.as_unsafe<StrNs_O>();
+    return strm;
+  } else
     FEerror("~S is not a string with a fill-pointer.", 1, s.raw_());
-  }
-  strm->_contents = gc::As<String_sp>(s);
-  return strm;
 }
 
 void StringOutputStream_O::clear() {
@@ -2739,70 +2738,55 @@ void StringOutputStream_O::write_string(String_sp data, cl_index start, cl_index
   const cl_index newFill = oldFill + count;
   // Grow the destination once (geometric) so the copy needs no per-character
   // reallocation or fill-pointer check. _contents is always an adjustable
-  // fill-pointer string (an MDArray) for a string-output-stream; resize keeps
+  // fill-pointer string (a StrNs_O) for a string-output-stream; resize keeps
   // the fill pointer for fill-pointer arrays.
+  // Note that the C++ type of _contents is String_sp, because it's in the super
+  // shared with string input streams. Bit awkward.
   if (newFill > static_cast<cl_index>(this->_contents->arrayTotalSize())) {
-    cl_index newTotal = static_cast<cl_index>(this->_contents->arrayTotalSize()) * 2;
-    if (newTotal < newFill)
-      newTotal = newFill;
-    gc::As<MDArray_sp>(this->_contents)->resize(newTotal);
+    this->_contents.as_assert<StrNs_O>()->resize(newFill);
   }
   StreamCursor& cur = this->_output_cursor;
-  // Resolve the underlying simple vectors so element access is a non-virtual,
-  // typed indexing operation. Boehm GC is non-moving and the copy loop below
-  // performs no allocation, so these references stay valid throughout.
-  AbstractSimpleVector_sp ssv;
-  size_t s0, s1;
-  data->asAbstractSimpleVectorRange(ssv, s0, s1);
-  AbstractSimpleVector_sp dsv;
-  size_t d0, d1;
-  this->_contents->asAbstractSimpleVectorRange(dsv, d0, d1);
-  const cl_index srcOff = static_cast<cl_index>(s0) + start;
-  const cl_index dstOff = static_cast<cl_index>(d0) + oldFill;
-  bool fast = true;
-  if (gc::IsA<SimpleCharacterString_sp>(dsv)) {
-    SimpleCharacterString_O& dst = *gc::As_unsafe<SimpleCharacterString_sp>(dsv);
-    if (gc::IsA<SimpleCharacterString_sp>(ssv)) {
-      SimpleCharacterString_O& src = *gc::As_unsafe<SimpleCharacterString_sp>(ssv);
-      for (cl_index i = 0; i < count; ++i) {
-        claspCharacter c = src[srcOff + i];
-        dst[dstOff + i] = c;
-        cur.update(c);
-      }
-    } else if (gc::IsA<SimpleBaseString_sp>(ssv)) {
-      SimpleBaseString_O& src = *gc::As_unsafe<SimpleBaseString_sp>(ssv);
-      for (cl_index i = 0; i < count; ++i) {
-        claspCharacter c = src[srcOff + i]; // widen 8 -> 32 bits
-        dst[dstOff + i] = c;
-        cur.update(c);
-      }
-    } else
-      fast = false;
-  } else if (gc::IsA<SimpleBaseString_sp>(dsv) && gc::IsA<SimpleBaseString_sp>(ssv)) {
-    SimpleBaseString_O& dst = *gc::As_unsafe<SimpleBaseString_sp>(dsv);
-    SimpleBaseString_O& src = *gc::As_unsafe<SimpleBaseString_sp>(ssv);
-    for (cl_index i = 0; i < count; ++i) {
-      claspChar c = src[srcOff + i];
-      dst[dstOff + i] = c;
-      cur.update(c);
-    }
+  // copy data. We try to avoid boxing and dispatch as much as possible by
+  // using copy_n.
+  AbstractSimpleVector_sp svdata;
+  size_t svstart, svend;
+  data->asAbstractSimpleVectorRange(svdata, svstart, svend);
+  if (_contents.isA<Str8Ns_O>()) {
+    Str8Ns_sp contents = _contents.as_unsafe<Str8Ns_O>();
+    if (svdata.isA<SimpleCharacterString_O>()) {
+      SimpleCharacterString_sp rsvdata = svdata.as_unsafe<SimpleCharacterString_O>();
+      // Note that this could result in an error, if data has wide characters
+      // that don't fit in a base string!
+      contents->copy_n(rsvdata, oldFill, start + svstart, count);
+      for (cl_index i = 0; i < count; ++i)
+        cur.update((*rsvdata)[svstart + i]);
+    } else if (svdata.isA<SimpleBaseString_O>()) {
+      SimpleBaseString_sp rsvdata = svdata.as_unsafe<SimpleBaseString_O>();
+      contents->copy_n(rsvdata, oldFill, start + svstart, count);
+      for (cl_index i = 0; i < count; ++i)
+        cur.update((*rsvdata)[svstart + i]);
+    } else TYPE_ERROR(data, cl::_sym_string);
+  } else if (_contents.isA<StrWNs_O>()) {
+    StrWNs_sp contents = _contents.as_unsafe<StrWNs_O>();
+    if (svdata.isA<SimpleBaseString_O>()) {
+      SimpleBaseString_sp rsvdata = svdata.as_unsafe<SimpleBaseString_O>();
+      contents->copy_n(rsvdata, oldFill, start + svstart, count);
+      for (cl_index i = 0; i < count; ++i)
+        cur.update((*rsvdata)[svstart + i]);
+    } else if (svdata.isA<SimpleCharacterString_O>()) {
+      SimpleCharacterString_sp rsvdata = svdata.as_unsafe<SimpleCharacterString_O>();
+      contents->copy_n(rsvdata, oldFill, start + svstart, count);
+      for (cl_index i = 0; i < count; ++i)
+        cur.update((*rsvdata)[svstart + i]);
+    } else TYPE_ERROR(data, cl::_sym_string);
   } else {
-    // Character source into a base destination may narrow; defer to the safe
-    // path which raises the proper type error for out-of-range characters.
-    fast = false;
+    // contents is a StrNs but not a Str8Ns or StrWNs.
+    // should be impossible but who knows. do it the dumbest available way.
+    _contents->copy_nd(svdata, oldFill, start + svstart, count);
+    for (cl_index i = 0; i < count; ++i)
+      cur.update(clasp_as_claspCharacter(svdata->rowMajorAref(start + svstart + i).as_unsafe<Character_O>()));
   }
-  if (fast) {
-    this->_contents->fillPointerSet(newFill);
-    return;
-  }
-  // Safe fallback: cursor updated identically to the per-char path, content
-  // copied with the tested type-checking subseq machinery.
-  for (cl_index i = start; i < end; ++i)
-    cur.update(clasp_as_claspCharacter(cl__char(data, i)));
-  Array_sp src = (start == 0 && static_cast<cl_index>(data->length()) == end)
-                     ? gc::As_unsafe<Array_sp>(data)
-                     : gc::As_unsafe<Array_sp>(data->unsafe_subseq(start, end));
-  this->_contents->unsafe_setf_subseq(oldFill, newFill, src);
+
   this->_contents->fillPointerSet(newFill);
 }
 

--- a/src/core/package.cc
+++ b/src/core/package.cc
@@ -430,7 +430,7 @@ CL_DEFUN T_mv cl__gentemp(T_sp prefix, T_sp package_designator) {
     String_sp sprefix = gc::As_unsafe<String_sp>(prefix);
     ss = gc::As_unsafe<StrNs_sp>(
         core__make_vector(sprefix->element_type(), sprefix->length() + 8, true, clasp_make_fixnum(sprefix->length())));
-    ss->unsafe_setf_subseq(0, sprefix->length(), sprefix);
+    ss->copy_nd(sprefix, 0, 0, sprefix->length());
   } else {
     TYPE_ERROR(prefix, cl::_sym_string);
   }

--- a/src/core/string.cc
+++ b/src/core/string.cc
@@ -1327,7 +1327,7 @@ Str8Ns_sp Str8Ns_O::create(Str8Ns_sp other) {
 
 SimpleString_sp Str8Ns_O::asMinimalSimpleString() const {
   SimpleBaseString_sp str8 = SimpleBaseString_O::make(this->length());
-  str8->unsafe_setf_subseq(0, this->length(), this->asSmartPtr());
+  str8->copy_n(this->asSmartPtr(), 0, 0, this->length());
   return str8;
 }
 
@@ -1406,11 +1406,11 @@ std::string StrWNs_O::__repr__() const { return escaped_string(this->get_std_str
 SimpleString_sp StrWNs_O::asMinimalSimpleString() const {
   if (this->all_base_char_p()) {
     SimpleBaseString_sp str8 = SimpleBaseString_O::make(this->length());
-    str8->unsafe_setf_subseq(0, this->length(), this->asSmartPtr());
+    str8->copy_n(this->asSmartPtr(), 0, 0, this->length());
     return str8;
   } else {
     SimpleCharacterString_sp strw = SimpleCharacterString_O::make(this->length());
-    strw->unsafe_setf_subseq(0, this->length(), this->asSmartPtr());
+    strw->copy_n(this->asSmartPtr(), 0, 0, this->length());
     return strw;
   }
 }

--- a/src/gctools/snapshotSaveLoad.cc
+++ b/src/gctools/snapshotSaveLoad.cc
@@ -2321,6 +2321,7 @@ void snapshot_load(void* maybeStartOfSnapshot, void* maybeEndOfSnapshot, const s
         my_thread->finish_initialization_main_thread(nil);
         // Now we have NIL in 'nil' - use it to initialize a few things.
         _lisp->_Roots._AllObjectFiles.store(nil);
+        llvmo::clearObjectFileNameCounts(); // keep countObjectFileNames index in sync with the cleared list
         _lisp->_Roots._AllCodeBlocks.store(nil);
       }
 

--- a/src/llvmo/code.cc
+++ b/src/llvmo/code.cc
@@ -736,17 +736,15 @@ std::string CodeBlock_O::__repr__() const {
 void CodeBlock_O::describe() const { printf("%s:%d:%s entered\n", __FILE__, __LINE__, __FUNCTION__); }
 
 // Object-file names are uniquified at registration time
-// (ensureUniqueMemoryBufferName -> countObjectFileNames). The original
-// countObjectFileNames rescanned the whole _AllObjectFiles list with a memcmp
-// per call, which is O(N) per registration and therefore O(N^2) as JITted
-// modules accumulate -- a real scalability cost for long-running /
-// compilation-heavy processes (it was the #1 self-time function, ~15%, in a
-// profiled workload). We maintain an auxiliary name->count index updated at the
+// (ensureUniqueMemoryBufferName -> countObjectFileNames).
+// We maintain an auxiliary name->count index updated at the
 // single registration site (recordObjectFileName) and reset whenever
 // _AllObjectFiles is cleared (clearObjectFileNameCounts), making the lookup
 // O(1). _AllObjectFiles is only ever appended to (registerObjectFile) or
 // bulk-cleared -- never individually pruned -- so the index stays in sync. The
 // map holds no GC pointers; a mutex guards it because registration can race.
+// NOTE: If we ever get to the point of GCing object files, this is another thing
+// that will need to be kept synced.
 static std::mutex& objectFileNameCountsMutex() {
   static std::mutex m;
   return m;
@@ -758,7 +756,7 @@ static std::unordered_map<std::string, size_t>& objectFileNameCounts() {
 
 void recordObjectFileName(const std::string& name) {
   std::lock_guard<std::mutex> guard(objectFileNameCountsMutex());
-  ++objectFileNameCounts()[name];
+  ++objectFileNameCounts()[name]; // count is zero-initialized if it didn't exist
 }
 
 void clearObjectFileNameCounts() {

--- a/src/llvmo/code.cc
+++ b/src/llvmo/code.cc
@@ -10,6 +10,8 @@
 #include <dlfcn.h>
 #include <iomanip>
 #include <cstdint>
+#include <mutex>
+#include <unordered_map>
 #include <clasp/core/foundation.h>
 #include <clasp/core/lispStream.h>
 #include <clasp/core/debugger.h>
@@ -451,6 +453,7 @@ CL_LISPIFY_NAME(release_object_files);
 DOCGROUP(clasp);
 CL_DEFUN void release_object_files() {
   _lisp->_Roots._AllObjectFiles.store(nil<core::T_O>());
+  clearObjectFileNameCounts();
   core::clasp_write_string("ObjectFiles have been released\n");
 }
 
@@ -732,21 +735,42 @@ std::string CodeBlock_O::__repr__() const {
 
 void CodeBlock_O::describe() const { printf("%s:%d:%s entered\n", __FILE__, __LINE__, __FUNCTION__); }
 
+// Object-file names are uniquified at registration time
+// (ensureUniqueMemoryBufferName -> countObjectFileNames). The original
+// countObjectFileNames rescanned the whole _AllObjectFiles list with a memcmp
+// per call, which is O(N) per registration and therefore O(N^2) as JITted
+// modules accumulate -- a real scalability cost for long-running /
+// compilation-heavy processes (it was the #1 self-time function, ~15%, in a
+// profiled workload). We maintain an auxiliary name->count index updated at the
+// single registration site (recordObjectFileName) and reset whenever
+// _AllObjectFiles is cleared (clearObjectFileNameCounts), making the lookup
+// O(1). _AllObjectFiles is only ever appended to (registerObjectFile) or
+// bulk-cleared -- never individually pruned -- so the index stays in sync. The
+// map holds no GC pointers; a mutex guards it because registration can race.
+static std::mutex& objectFileNameCountsMutex() {
+  static std::mutex m;
+  return m;
+}
+static std::unordered_map<std::string, size_t>& objectFileNameCounts() {
+  static std::unordered_map<std::string, size_t> m;
+  return m;
+}
+
+void recordObjectFileName(const std::string& name) {
+  std::lock_guard<std::mutex> guard(objectFileNameCountsMutex());
+  ++objectFileNameCounts()[name];
+}
+
+void clearObjectFileNameCounts() {
+  std::lock_guard<std::mutex> guard(objectFileNameCountsMutex());
+  objectFileNameCounts().clear();
+}
+
 size_t countObjectFileNames(const std::string& name) {
   DEBUG_OBJECT_FILES_PRINT(("%s:%d:%s Lookup name %s\n", __FILE__, __LINE__, __FUNCTION__, name.c_str()));
-  size_t count = 0;
-  core::T_sp cur = _lisp->_Roots._AllObjectFiles.load();
-  while (cur.consp()) {
-    ObjectFile_sp of = gc::As<ObjectFile_sp>(CONS_CAR(cur));
-    const char* codeNameStart = (const char*)of->_CodeName->_Data.data();
-    if (of->_CodeName->length() == name.size()) {
-      if (memcmp(codeNameStart, name.data(), name.size()) == 0) {
-        count++;
-      }
-    }
-    cur = CONS_CDR(cur);
-  }
-  return count;
+  std::lock_guard<std::mutex> guard(objectFileNameCountsMutex());
+  auto it = objectFileNameCounts().find(name);
+  return it == objectFileNameCounts().end() ? 0 : it->second;
 };
 
 CL_DEFUN core::T_sp llvm_sys__allObjectFileNames() {


### PR DESCRIPTION
Incorporates and supersedes parts of @dg1sbg's #1771:

- the allocation profiler slots are now non-atomic, which saves some cycles
- `countObjectFileNames` now uses an accessory non-lisp hash table rather than walking all object files every time, which saves a big chunk of time
- cache `my_thread` in `bytecode_vm` because TLS is slightly expensive to access
- `write_string` into a string output stream copies in bulk instead of one at a time and avoids boxing/unboxing

The first three are pretty much exactly as in #1771 except that I expanded the use of the `my_thread` caching. The last with `write_string` I spun off into a generic bulk copying function for Lisp arrays which is now used for `copy-subarray` and therefore a couple different functions, like `replace`. From Lisp it only avoids consing if you copy an array into another of the same element type, but even aside from that it takes care of displacement ahead of time and etc., so it should speed things up.