### PR TITLE
Bump cffi for the :default library lookup fix

### DIFF
--- a/repos.sexp
+++ b/repos.sexp
@@ -80,7 +80,7 @@
   :directory "src/lisp/kernel/contrib/cffi/"
   :repository "https://github.com/cffi/cffi.git"
   :branch "master"
-  :commit "71fdf5d4864dd07a74534c953350041ceaa93f0e"
+  :commit "8e2928ee10d29b26e5a6048b2e784cc5f0a2da12"
   :pin 1)
  (:name :cl-bench
   :directory "dependencies/cl-bench/"


### PR DESCRIPTION
Follow-up to #1792 (the foreign-alloc lifetime fix, now merged).

Bumps the `:cffi` pin in `repos.sexp` to upstream cffi master `8e2928ee`, which is the merge of [cffi/cffi#432](https://github.com/cffi/cffi/pull/432).

That commit maps CFFI's `:default` library marker to `:rtld-default` in the Clasp backend. Without it, `cffi:foreign-symbol-pointer` called without an explicit `:library` always returns NIL on Clasp (`clasp-ffi:%dlsym` only understands `:rtld-default`/`:rtld-next` and treats `:default` as a library handle). cffi-libffi's `type-descriptor-ptr` depends on this lookup, so together with #1792 this gives cando builds working struct-by-value support.

Verified on macOS arm64 (boehmprecise): full regression suite 1963 pass / 4 fail (all four known-preexisting), plus the cffi-fsbv stress test (300k mixed struct-by-value calls, no crash).