### PR TITLE
Basic coerce optimization

### DIFF
--- a/src/lisp/kernel/cleavir/proclamations.lisp
+++ b/src/lisp/kernel/cleavir/proclamations.lisp
@@ -33,7 +33,9 @@
 (deftype declaration-specifier () '(cons symbol))
 
 (deftype type-specifier ()
-  '(or symbol (cons symbol) class))
+  ;; could be (cons symbol) but our subtypep chokes, and this type is
+  ;; necessarily imprecise anyway
+  '(or symbol cons class))
 
 (deftype maybe (type) `(or null ,type))
 

--- a/src/lisp/kernel/cleavir/transform.lisp
+++ b/src/lisp/kernel/cleavir/transform.lisp
@@ -351,6 +351,19 @@ Optimizations are available for any of:
                    (maybe-expand-typep type 'object))))
             (decline-transform "non-constant type specifier"))))))
 
+(deftransform coerce (((object t) (tspec t)) :argstype args)
+  (with-transformer-types (object tspec) args
+    (let ((sys *clasp-system*))
+      (multiple-value-bind (tspec validp) (constant-type sys tspec)
+        (if validp
+            (let ((type (env:parse-type-specifier tspec nil sys)))
+              (cond ((ctype:subtypep object type sys) 'object)
+                    ;; here's where we could warn on invalid coerce, but
+                    ;; we don't want to do that every meta-evaluate run
+                    ;; TODO/FIXME
+                    (t (decline-transform "unimplemented"))))
+            (decline-transform "non-constant type specifier"))))))
+
 (deftransform core::%the-single (((tspec t) (value t)) :argstype args)
   (with-transformer-types (tspec value) args
     (declare (ignore value))

--- a/src/lisp/kernel/cleavir/transform.lisp
+++ b/src/lisp/kernel/cleavir/transform.lisp
@@ -319,6 +319,14 @@ Optimizations are available for any of:
                                                     :datum v
                                                     :expected-type ',ctype))))))
 
+(defun constant-type (client type)
+  (if (ctype:member-p client type)
+      (let ((members (ctype:member-members client type)))
+        (if (= (length members) 1)
+            (values (first members) t)
+            (values nil nil)))
+      (values nil nil)))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; (4) TYPES AND CLASSES
@@ -332,39 +340,36 @@ Optimizations are available for any of:
   (with-transformer-types (object tspec &optional env) args
     (declare (ignore env))
     (let ((sys *clasp-system*))
-      (if (and (ctype:member-p sys tspec)
-               (= (length (ctype:member-members sys tspec)) 1))
-          (let* ((tspec (first (ctype:member-members sys tspec)))
-                 (type (env:parse-type-specifier tspec nil sys)))
-            (cond ((ctype:subtypep object type sys) 't)
-                  ((ctype:disjointp object type sys) 'nil)
-                  (t
-                   (decline-transform "TODO")
-                   #+(or)
+      (multiple-value-bind (tspec valid) (constant-type sys tspec)
+        (if valid
+            (let ((type (env:parse-type-specifier tspec nil sys)))
+              (cond ((ctype:subtypep object type sys) 't)
+                    ((ctype:disjointp object type sys) 'nil)
+                    (t
+                     (decline-transform "TODO")
+                     #+(or)
                    (maybe-expand-typep type 'object))))
-          (decline-transform "non-constant type specifier")))))
+            (decline-transform "non-constant type specifier"))))))
 
 (deftransform core::%the-single (((tspec t) (value t)) :argstype args)
   (with-transformer-types (tspec value) args
     (declare (ignore value))
     (let ((sys *clasp-system*))
-      (if (and (ctype:member-p sys tspec)
-               (= (length (ctype:member-members sys tspec)) 1))
-          (let ((tspec (first (ctype:member-members sys tspec))))
-            `(the (values ,tspec &rest nil) value))
-          ;; the-single is only used internally, so a failure here is weird
-          (decline-transform "BUG: non-constant type specifier")))))
+      (multiple-value-bind (tspec valid) (constant-type sys tspec)
+        (if valid
+            `(the (values ,tspec &rest nil) value)
+            ;; the-single is only used internally, so a failure here is weird
+            (decline-transform "BUG: non-constant type specifier"))))))
 (deftransform core::%the-single-return
     (((tspec t) (value t) (return t)) :argstype args)
   (with-transformer-types (tspec value return) args
     (declare (ignore value return))
     (let ((sys *clasp-system*))
-      (if (and (ctype:member-p sys tspec)
-               (= (length (ctype:member-members sys tspec)) 1))
-          (let ((tspec (first (ctype:member-members sys tspec))))
-            `(progn (the (values ,tspec &rest nil) value) return))
-          ;; the-single is only used internally, so a failure here is weird
-          (decline-transform "BUG: non-constant type specifier")))))
+      (multiple-value-bind (tspec valid) (constant-type sys tspec)
+        (if valid
+            `(progn (the (values ,tspec &rest nil) value) return)
+            ;; the-single is only used internally, so a failure here is weird
+            (decline-transform "BUG: non-constant type specifier"))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -650,22 +655,22 @@ Optimizations are available for any of:
     (declare (ignore dimensions displaced-index-offset
                      initial-element initial-contents))
     (let* ((sys *clasp-system*) (null (ctype:member sys nil)))
-      (if (and (ctype:member-p sys element-type)
-               (= (length (ctype:member-members sys element-type)) 1)
-               (ctype:subtypep adjustable null sys)
-               (ctype:subtypep fill-pointer null sys)
-               (ctype:subtypep displaced-to null sys)
-               (not diosp)
-               ;; Handle these later. TODO. For efficiency,
-               ;; this will probably mean inlining lambdas with &key.
-               ;; Or replacing the make-array with a reqargs-only function,
-               ;; more likely.
-               (and (null iesp) (null icsp)))
-          (let* ((uaet (upgraded-array-element-type
-                        (first (ctype:member-members sys element-type))))
-                 (make-sv (cmp::uaet-info uaet)))
-            `(,make-sv dimensions nil nil))
-          (decline-transform "making a complex array")))))
+      (multiple-value-bind (element-type valid)
+          (constant-type sys element-type)
+        (if (and valid
+                 (ctype:subtypep adjustable null sys)
+                 (ctype:subtypep fill-pointer null sys)
+                 (ctype:subtypep displaced-to null sys)
+                 (not diosp)
+                 ;; Handle these later. TODO. For efficiency,
+                 ;; this will probably mean inlining lambdas with &key.
+                 ;; Or replacing the make-array with a reqargs-only function,
+                 ;; more likely.
+                 (and (null iesp) (null icsp)))
+            (let* ((uaet (upgraded-array-element-type element-type))
+                   (make-sv (cmp::uaet-info uaet)))
+              `(,make-sv dimensions nil nil))
+            (decline-transform "making a complex array"))))))
 
 (deftransform aref (((arr vector) (index t))) '(row-major-aref arr index))
 (deftransform (setf aref) (((val t) (arr vector) (index t)))

--- a/src/lisp/kernel/cleavir/transform.lisp
+++ b/src/lisp/kernel/cleavir/transform.lisp
@@ -364,6 +364,14 @@ Optimizations are available for any of:
                     (t (decline-transform "unimplemented"))))
             (decline-transform "non-constant type specifier"))))))
 
+(deftransform core:coerce-to-function (((object function))) 'object)
+(deftransform core:coerce-to-function (((object function-name)))
+  '(fdefinition object))
+(deftransform core:coerce-to-function (((object lambda-expression)))
+  '(eval object))
+
+(deftransform core::coerce-to-list (((x list))) 'x)
+
 (deftransform core::%the-single (((tspec t) (value t)) :argstype args)
   (with-transformer-types (tspec value) args
     (declare (ignore value))
@@ -555,6 +563,10 @@ Optimizations are available for any of:
 (deftransform float (((v double-float) (proto double-float))) 'v)
 (deftransform float ((v (proto double-float))) '(core:to-double-float v))
 (deftransform core:to-double-float (((v double-float))) 'v)
+#+short-float
+(deftransform core:to-short-float (((v short-float))) 'v)
+#+long-float
+(deftransform core:to-long-float (((v long-float))) 'v)
 
 ;;;
 
@@ -618,6 +630,8 @@ Optimizations are available for any of:
 (deftransform standard-char-p (((object standard-char))) 't)
 (deftransform standard-char-p (((object (and character (not standard-char)))))
   'nil)
+
+(deftransform character (((object character))) 'object)
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/src/lisp/kernel/cmp/opt/opt-type.lisp
+++ b/src/lisp/kernel/cmp/opt/opt-type.lisp
@@ -515,13 +515,16 @@
                     ;; type, it is returned, and otherwise a type-error
                     ;; is signaled. Nonetheless, if we reach here with a
                     ;; constant type, it's either undefined or does not
-                    ;; have a coercion defined (e.g. INTEGER), which would
-                    ;; be a weird thing to do. So we signal a style-warning.
-                    ;; FIXME: We should differentiate "not defined" and
-                    ;; "no coercion behavior", though.
-                    ;; And maybe "can't figure it out at compile time but
-                    ;; will at runtime".
-                    (cmp:warn-cannot-coerce nil type) ; FIXME
+                    ;; have a coercion defined (e.g. INTEGER).
+                    ;; Code like that can sometimes be generated, e.g.
+                    ;; Khazern is quite fond of (coerce whatever 'real),
+                    ;; and we don't want to warn about that. What we really
+                    ;; want to warn about is a type unknown to the compiler,
+                    ;; maybe, and definitely cases where coerce cannot succeed.
+                    ;; The latter however relies on type inference, e.g.
+                    ;; coercing to REAL when the value is inferred to not be
+                    ;; a number. So no warning here. FIXME, do in transforms.
+                    ;;(cmp:warn-cannot-coerce nil type) ; FIXME
                     whole)))))))))
 ) ; eval-when
 

--- a/src/lisp/kernel/cmp/opt/opt-type.lisp
+++ b/src/lisp/kernel/cmp/opt/opt-type.lisp
@@ -477,8 +477,7 @@
         (case head
           ((t) (da 'object))
           ((character base-char) (da `(character object)))
-          ;; make sure we don't convert other floats
-          ((float) (da `(if (floatp object) object (float object))))
+          ((float) (da `(float object)))
           #+short-float
           ((short-float) (da `(core:to-short-float object)))
           ((#-short-float short-float single-float)

--- a/src/lisp/kernel/lsp/predlib.lisp
+++ b/src/lisp/kernel/lsp/predlib.lisp
@@ -1400,6 +1400,12 @@ if not possible."
   ;; One easy case: types are equal
   (when (eq t1 t2)
     (return-from subtypep (values t t)))
+  ;; another easy and common case: everything is a subtype of T,
+  ;; and NIL is a subtype of everything. This is required for conformance
+  ;; reasons, and practicality, even if the below code fails
+  ;; (as it does for example on nontrivial cons types).
+  (when (or (eq t1 nil) (eq t2 't))
+    (return-from subtypep (values t t)))
   ;; Another easy case: types are classes.
   (when (and (clos::classp t1) (clos::classp t2))
     (return-from subtypep (values (subclassp t1 t2) t)))


### PR DESCRIPTION
Optimizes out `(coerce (the thing x) 'thing)`, since I noticed Khazern does that a lot. Also silences the "can't coerce to REAL" type warnings until we have sophisticated enough machinery to note genuinely invalid coercions.

Also special cases `(subtypep foo 't)` because the Baker subtypep is really bad (conformance-breakingly, even) on cons types.