### PR TITLE
Add POSIX shared-memory support

### DIFF
--- a/src/core/cscript.lisp
+++ b/src/core/cscript.lisp
@@ -49,6 +49,7 @@
            #~"externalObject.cc"
            #~"myReadLine.cc"
            #~"unixfsys.cc"
+           #~"shmem.cc"
            #~"unixsys.cc"
            #~"lispList.cc"
            #~"candoOpenMp.cc"

--- a/src/core/shmem.cc
+++ b/src/core/shmem.cc
@@ -110,6 +110,7 @@ CL_DEFUN T_sp core__sys_shm_constants() {
   SHMC("SYNC", MS_SYNC);
   SHMC("ASYNC", MS_ASYNC);
   SHMC("INVALIDATE", MS_INVALIDATE);
+  SHMC("EEXIST", EEXIST);
 #undef SHMC
   return l.cons();
 }

--- a/src/core/shmem.cc
+++ b/src/core/shmem.cc
@@ -1,0 +1,117 @@
+#include <clasp/core/foundation.h>
+
+#include <string.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/mman.h>
+
+#include <clasp/core/object.h>
+#include <clasp/core/lisp.h>
+#include <clasp/core/array.h>
+#include <clasp/core/numbers.h>
+#include <clasp/core/unixfsys.h>
+#include <clasp/core/lispList.h>
+#include <clasp/core/ql.h>
+#include <clasp/core/wrappers.h>
+
+#ifndef MAP_ANONYMOUS
+#ifdef MAP_ANON
+#define MAP_ANONYMOUS MAP_ANON
+#endif
+#endif
+
+namespace core {
+
+CL_DOCSTRING(R"dx(Raw POSIX shm_open. Returns (values fd errno); errno is 0 on success.)dx");
+DOCGROUP(clasp);
+CL_DEFUN T_mv core__sys_shm_open(const string& name, int oflag, int mode) {
+  int fd = ::shm_open(name.c_str(), oflag, (mode_t)mode);
+  return Values(make_fixnum(fd), make_fixnum(fd < 0 ? errno : 0));
+}
+
+DOCGROUP(clasp);
+CL_DEFUN T_mv core__sys_shm_unlink(const string& name) {
+  int r = ::shm_unlink(name.c_str());
+  return Values(make_fixnum(r), make_fixnum(r < 0 ? errno : 0));
+}
+
+DOCGROUP(clasp);
+CL_DEFUN T_mv core__sys_ftruncate(int fd, Integer_sp length) {
+  int r = ::ftruncate(fd, (off_t)clasp_to_size_t(length));
+  return Values(make_fixnum(r), make_fixnum(r < 0 ? errno : 0));
+}
+
+CL_DOCSTRING(R"dx(Raw POSIX mmap. addr/length/offset are integers. Returns (values address errno).)dx");
+DOCGROUP(clasp);
+CL_DEFUN T_mv core__sys_mmap(Integer_sp addr, Integer_sp length, int prot, int flags, int fd, Integer_sp offset) {
+  void* p = ::mmap((void*)clasp_to_uintptr_t(addr), clasp_to_size_t(length), prot, flags, fd,
+                   (off_t)clasp_to_uint64_t(offset));
+  if (p == MAP_FAILED)
+    return Values(make_fixnum(0), make_fixnum(errno));
+  return Values(Integer_O::create((uint64_t)(uintptr_t)p), make_fixnum(0));
+}
+
+DOCGROUP(clasp);
+CL_DEFUN T_mv core__sys_munmap(Integer_sp addr, Integer_sp length) {
+  int r = ::munmap((void*)clasp_to_uintptr_t(addr), clasp_to_size_t(length));
+  return Values(make_fixnum(r), make_fixnum(r < 0 ? errno : 0));
+}
+
+DOCGROUP(clasp);
+CL_DEFUN T_mv core__sys_mprotect(Integer_sp addr, Integer_sp length, int prot) {
+  int r = ::mprotect((void*)clasp_to_uintptr_t(addr), clasp_to_size_t(length), prot);
+  return Values(make_fixnum(r), make_fixnum(r < 0 ? errno : 0));
+}
+
+DOCGROUP(clasp);
+CL_DEFUN T_mv core__sys_msync(Integer_sp addr, Integer_sp length, int flags) {
+  int r = ::msync((void*)clasp_to_uintptr_t(addr), clasp_to_size_t(length), flags);
+  return Values(make_fixnum(r), make_fixnum(r < 0 ? errno : 0));
+}
+
+DOCGROUP(clasp);
+CL_DEFUN T_mv core__sys_mlock(Integer_sp addr, Integer_sp length) {
+  int r = ::mlock((void*)clasp_to_uintptr_t(addr), clasp_to_size_t(length));
+  return Values(make_fixnum(r), make_fixnum(r < 0 ? errno : 0));
+}
+
+DOCGROUP(clasp);
+CL_DEFUN T_mv core__sys_munlock(Integer_sp addr, Integer_sp length) {
+  int r = ::munlock((void*)clasp_to_uintptr_t(addr), clasp_to_size_t(length));
+  return Values(make_fixnum(r), make_fixnum(r < 0 ? errno : 0));
+}
+
+DOCGROUP(clasp);
+CL_DEFUN int core__sys_getpagesize() { return (int)::getpagesize(); }
+
+DOCGROUP(clasp);
+CL_DEFUN String_sp core__sys_strerror(int errno_value) { return clasp_strerror(errno_value); }
+
+CL_DOCSTRING(R"dx(Return an alist of (keyword . int) for all POSIX shm/mmap flag constants.)dx");
+DOCGROUP(clasp);
+CL_DEFUN T_sp core__sys_shm_constants() {
+  ql::list l;
+#define SHMC(k, v) l << Cons_O::create(_lisp->internKeyword(k), make_fixnum(v))
+  SHMC("RDONLY", O_RDONLY);
+  SHMC("WRONLY", O_WRONLY);
+  SHMC("RDWR", O_RDWR);
+  SHMC("CREATE", O_CREAT);
+  SHMC("EXCLUSIVE", O_EXCL);
+  SHMC("TRUNCATE", O_TRUNC);
+  SHMC("NONE", PROT_NONE);
+  SHMC("READ", PROT_READ);
+  SHMC("WRITE", PROT_WRITE);
+  SHMC("EXEC", PROT_EXEC);
+  SHMC("SHARED", MAP_SHARED);
+  SHMC("PRIVATE", MAP_PRIVATE);
+  SHMC("FIXED", MAP_FIXED);
+  SHMC("ANONYMOUS", MAP_ANONYMOUS);
+  SHMC("SYNC", MS_SYNC);
+  SHMC("ASYNC", MS_ASYNC);
+  SHMC("INVALIDATE", MS_INVALIDATE);
+#undef SHMC
+  return l.cons();
+}
+
+}; // namespace core

--- a/src/lisp/cscript.lisp
+++ b/src/lisp/cscript.lisp
@@ -169,6 +169,7 @@
              #~"kernel/cmp/compile-file-parallel.lisp"
              #@"fli-specs.lisp"
              #~"kernel/lsp/fli.lisp"
+             #~"kernel/lsp/shmem.lisp"
              #~"kernel/lsp/cltl2.lisp"
              #~"kernel/lsp/macroexpand-all.lisp"
              #~"kernel/cmp/external-clang.lisp"

--- a/src/lisp/kernel/lsp/shmem.lisp
+++ b/src/lisp/kernel/lsp/shmem.lisp
@@ -1,0 +1,172 @@
+(in-package #:core)
+
+;;; POSIX named shared memory. Public API re-exported through CLASP-POSIX.
+;;; Raw syscalls are CORE sys-* primitives from src/core/shmem.cc, each
+;;; returning (values result errno) with errno 0 on success.
+;;; FTRUNCATE is defined on the CLASP-POSIX symbol directly: the plain name
+;;; would otherwise clobber CL:FTRUNCATE in the CORE package.
+
+(defparameter *shm-flags*
+  (let ((h (make-hash-table :test #'eq)))
+    (loop for (k . v) in (sys-shm-constants) do (setf (gethash k h) v))
+    h))
+
+(defun %shm-flag (keyword)
+  (or (gethash keyword *shm-flags*)
+      (error "Unknown POSIX shared-memory flag ~S" keyword)))
+
+(defun %shm-flags (spec)
+  (cond ((null spec) 0)
+        ((integerp spec) spec)
+        ((keywordp spec) (%shm-flag spec))
+        ((listp spec) (reduce #'logior spec :key #'%shm-flag :initial-value 0))
+        (t (error "Bad POSIX flag spec ~S" spec))))
+
+(define-condition syscall-error (error)
+  ((errno :initarg :errno :reader syscall-errno)
+   (name :initarg :name :reader syscall-name))
+  (:report (lambda (c s)
+             (format s "POSIX ~A failed: ~A (errno ~D)"
+                     (syscall-name c) (sys-strerror (syscall-errno c))
+                     (syscall-errno c)))))
+
+(deftype posix-error () 'syscall-error)
+(defun posix-error-errno (condition) (syscall-errno condition))
+
+(defun %signal-syscall-error (name errno)
+  (error 'syscall-error :name name :errno errno))
+
+(defmacro %checked (name form)
+  (let ((r (gensym)) (e (gensym)))
+    `(multiple-value-bind (,r ,e) ,form
+       (if (zerop ,e) ,r (%signal-syscall-error ,name ,e)))))
+
+(defstruct (mapping (:constructor %make-mapping) (:predicate mappingp))
+  (address 0 :type integer)
+  (size 0 :type integer)
+  (fd -1 :type integer)
+  (name nil)
+  (prot 0 :type integer)
+  (unmapped nil :type boolean))
+
+(defun mapping-pointer (mapping)
+  "Return a CFFI/clasp-ffi foreign pointer to the mapped region."
+  (when (mapping-unmapped mapping)
+    (error "Shared-memory mapping ~S is already unmapped" mapping))
+  (clasp-ffi:%make-pointer (mapping-address mapping)))
+
+(defun %addr->int (addr)
+  (cond ((null addr) 0)
+        ((integerp addr) addr)
+        (t (clasp-ffi:%foreign-data-address addr))))
+
+(defun shm-open (name oflags &optional (mode #o600))
+  "Open/create POSIX shared-memory object NAME; return a file descriptor."
+  (%checked "shm_open" (sys-shm-open name (%shm-flags oflags) mode)))
+
+(defun shm-unlink (name)
+  "Remove the POSIX shared-memory object named NAME."
+  (%checked "shm_unlink" (sys-shm-unlink name))
+  t)
+
+(defun clasp-posix::ftruncate (fd length)
+  "Set the size of the object behind FD to LENGTH bytes."
+  (%checked "ftruncate" (sys-ftruncate fd length))
+  t)
+
+(defun getpagesize ()
+  "Return the system page size in bytes."
+  (sys-getpagesize))
+
+(defun mmap (addr length prot flags fd offset)
+  "Map LENGTH bytes of FD; return a MAPPING. ADDR is usually NIL."
+  (let* ((prot-bits (%shm-flags prot))
+         (address (%checked "mmap"
+                    (sys-mmap (%addr->int addr) length
+                              prot-bits (%shm-flags flags) fd offset)))
+         (m (%make-mapping :address address :size length :fd fd :prot prot-bits)))
+    (gctools:finalize m
+                      (lambda (x)
+                        (unless (mapping-unmapped x)
+                          (sys-munmap (mapping-address x) (mapping-size x))
+                          (setf (mapping-unmapped x) t))))
+    m))
+
+(defun munmap (mapping)
+  "Unmap MAPPING; idempotent and cancels its GC finalizer."
+  (unless (mapping-unmapped mapping)
+    (%checked "munmap" (sys-munmap (mapping-address mapping) (mapping-size mapping)))
+    (setf (mapping-unmapped mapping) t)
+    (gctools:definalize mapping))
+  t)
+
+(defun mprotect (mapping prot)
+  "Change the memory protection of MAPPING to PROT."
+  (%checked "mprotect"
+    (sys-mprotect (mapping-address mapping) (mapping-size mapping) (%shm-flags prot)))
+  t)
+
+(defun msync (mapping &optional (flags '(:sync)))
+  "Flush MAPPING to its backing store."
+  (%checked "msync"
+    (sys-msync (mapping-address mapping) (mapping-size mapping) (%shm-flags flags)))
+  t)
+
+(defun mlock (mapping)
+  "Lock MAPPING into physical RAM."
+  (%checked "mlock" (sys-mlock (mapping-address mapping) (mapping-size mapping)))
+  t)
+
+(defun munlock (mapping)
+  "Unlock MAPPING from physical RAM."
+  (%checked "munlock" (sys-munlock (mapping-address mapping) (mapping-size mapping)))
+  t)
+
+(defun %direction-flags (direction)
+  (ecase direction
+    (:input  (values '(:rdonly) '(:read)))
+    (:output (values '(:rdwr)   '(:read :write)))
+    (:io     (values '(:rdwr)   '(:read :write)))))
+
+(defun open-shared-memory (name size &key (direction :io) (create t) (mode #o600))
+  "Open/create shared-memory NAME of SIZE bytes and map it; return a MAPPING."
+  (multiple-value-bind (oflags prot) (%direction-flags direction)
+    (let* ((oflags (if create (cons :create oflags) oflags))
+           (fd (shm-open name oflags mode)))
+      (when create (clasp-posix::ftruncate fd size))
+      (let ((m (mmap nil size prot '(:shared) fd 0)))
+        (setf (mapping-name m) name)
+        m))))
+
+(defun close-shared-memory (mapping &key unlink)
+  "Unmap MAPPING, close its fd, and optionally shm-unlink its name."
+  (let ((fd (mapping-fd mapping))
+        (name (mapping-name mapping)))
+    (munmap mapping)
+    (when (>= fd 0) (close-fd fd))
+    (when (and unlink name) (shm-unlink name))
+    t))
+
+(defmacro with-shared-memory ((var name size &key (direction :io) (create t)
+                                              (mode #o600) (unlink-on-exit nil))
+                              &body body)
+  "Bind VAR to a shared-memory MAPPING for the dynamic extent of BODY."
+  `(let ((,var (open-shared-memory ,name ,size :direction ,direction
+                                   :create ,create :mode ,mode)))
+     (unwind-protect (progn ,@body)
+       (close-shared-memory ,var :unlink ,unlink-on-exit))))
+
+;;; re-export through CLASP-POSIX; FTRUNCATE is already a CLASP-POSIX symbol
+(let ((syms '("SHM-OPEN" "SHM-UNLINK" "GETPAGESIZE"
+              "MMAP" "MUNMAP" "MPROTECT" "MSYNC" "MLOCK" "MUNLOCK"
+              "MAPPING" "MAPPINGP" "MAPPING-POINTER" "MAPPING-ADDRESS"
+              "MAPPING-SIZE" "MAPPING-FD" "MAPPING-NAME"
+              "OPEN-SHARED-MEMORY" "CLOSE-SHARED-MEMORY" "WITH-SHARED-MEMORY"
+              "SYSCALL-ERROR" "SYSCALL-ERRNO" "SYSCALL-NAME"
+              "POSIX-ERROR" "POSIX-ERROR-ERRNO")))
+  (dolist (n syms)
+    (let ((s (find-symbol n "CORE")))
+      (import s "CLASP-POSIX")
+      (export s "CLASP-POSIX"))))
+
+(export (intern "FTRUNCATE" "CLASP-POSIX") "CLASP-POSIX")

--- a/src/lisp/kernel/lsp/shmem.lisp
+++ b/src/lisp/kernel/lsp/shmem.lisp
@@ -41,7 +41,10 @@
     `(multiple-value-bind (,r ,e) ,form
        (if (zerop ,e) ,r (%signal-syscall-error ,name ,e)))))
 
-(defstruct (mapping (:constructor %make-mapping) (:predicate mappingp))
+;; NOT `mapping': CORE::MAPPING is already an exported C++ class (hashTable.h Mapping_O)
+(defstruct (shm-mapping (:conc-name mapping-)
+                        (:constructor %make-mapping)
+                        (:predicate mappingp))
   (address 0 :type integer)
   (size 0 :type integer)
   (fd -1 :type integer)
@@ -79,25 +82,20 @@
   (sys-getpagesize))
 
 (defun mmap (addr length prot flags fd offset)
-  "Map LENGTH bytes of FD; return a MAPPING. ADDR is usually NIL."
+  "Map LENGTH bytes of FD; return a MAPPING. ADDR is usually NIL. Unmap it explicitly."
+  ;; deliberately no GC finalizer: MAPPING-POINTER hands out a pointer that does not keep
+  ;; the MAPPING alive, so a finalizing munmap could unmap a region still in use
   (let* ((prot-bits (%shm-flags prot))
          (address (%checked "mmap"
                     (sys-mmap (%addr->int addr) length
-                              prot-bits (%shm-flags flags) fd offset)))
-         (m (%make-mapping :address address :size length :fd fd :prot prot-bits)))
-    (gctools:finalize m
-                      (lambda (x)
-                        (unless (mapping-unmapped x)
-                          (sys-munmap (mapping-address x) (mapping-size x))
-                          (setf (mapping-unmapped x) t))))
-    m))
+                              prot-bits (%shm-flags flags) fd offset))))
+    (%make-mapping :address address :size length :fd fd :prot prot-bits)))
 
 (defun munmap (mapping)
-  "Unmap MAPPING; idempotent and cancels its GC finalizer."
+  "Unmap MAPPING; idempotent."
   (unless (mapping-unmapped mapping)
     (%checked "munmap" (sys-munmap (mapping-address mapping) (mapping-size mapping)))
-    (setf (mapping-unmapped mapping) t)
-    (gctools:definalize mapping))
+    (setf (mapping-unmapped mapping) t))
   t)
 
 (defun mprotect (mapping prot)
@@ -128,15 +126,27 @@
     (:output (values '(:rdwr)   '(:read :write)))
     (:io     (values '(:rdwr)   '(:read :write)))))
 
+(defun %shm-open-or-create (name oflags mode size)
+  "Open NAME, sizing it only when we are its creator; return a file descriptor."
+  ;; only the creator may ftruncate a POSIX shm object -- on an existing one that is EINVAL
+  (multiple-value-bind (fd errno)
+      (sys-shm-open name (%shm-flags '(:create :exclusive :rdwr)) mode)
+    (cond ((zerop errno)
+           (clasp-posix::ftruncate fd size)
+           fd)
+          ((eql errno (%shm-flag :eexist))
+           (shm-open name oflags mode))
+          (t (%signal-syscall-error "shm_open" errno)))))
+
 (defun open-shared-memory (name size &key (direction :io) (create t) (mode #o600))
   "Open/create shared-memory NAME of SIZE bytes and map it; return a MAPPING."
   (multiple-value-bind (oflags prot) (%direction-flags direction)
-    (let* ((oflags (if create (cons :create oflags) oflags))
-           (fd (shm-open name oflags mode)))
-      (when create (clasp-posix::ftruncate fd size))
-      (let ((m (mmap nil size prot '(:shared) fd 0)))
-        (setf (mapping-name m) name)
-        m))))
+    (let* ((fd (if create
+                   (%shm-open-or-create name oflags mode size)
+                   (shm-open name oflags mode)))
+           (m (mmap nil size prot '(:shared) fd 0)))
+      (setf (mapping-name m) name)
+      m)))
 
 (defun close-shared-memory (mapping &key unlink)
   "Unmap MAPPING, close its fd, and optionally shm-unlink its name."
@@ -159,7 +169,7 @@
 ;;; re-export through CLASP-POSIX; FTRUNCATE is already a CLASP-POSIX symbol
 (let ((syms '("SHM-OPEN" "SHM-UNLINK" "GETPAGESIZE"
               "MMAP" "MUNMAP" "MPROTECT" "MSYNC" "MLOCK" "MUNLOCK"
-              "MAPPING" "MAPPINGP" "MAPPING-POINTER" "MAPPING-ADDRESS"
+              "SHM-MAPPING" "MAPPINGP" "MAPPING-POINTER" "MAPPING-ADDRESS"
               "MAPPING-SIZE" "MAPPING-FD" "MAPPING-NAME"
               "OPEN-SHARED-MEMORY" "CLOSE-SHARED-MEMORY" "WITH-SHARED-MEMORY"
               "SYSCALL-ERROR" "SYSCALL-ERRNO" "SYSCALL-NAME"

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -23,6 +23,7 @@
     "array0"
     "tests01"
     "finalizers"
+    "shmem"
     "strings01"
     "cons01"
     "sequences01"

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -23,6 +23,7 @@
     "array0"
     "tests01"
     "gc"
+    "shmem"
     "strings01"
     "cons01"
     "sequences01"

--- a/src/lisp/regression-tests/shmem.lisp
+++ b/src/lisp/regression-tests/shmem.lisp
@@ -1,0 +1,58 @@
+(in-package #:clasp-tests)
+
+(defun %shm-name ()
+  (format nil "/clasp-test-shm-~D" (clasp-posix:getpid)))
+
+(test shmem-roundtrip
+      (let ((name (%shm-name))
+            (size 4096))
+        (unwind-protect
+             (let ((m (clasp-posix:open-shared-memory name size :create t)))
+               (clasp-ffi:%mem-set (clasp-posix:mapping-pointer m) :uint32 #x12345678 0)
+               (clasp-posix:msync m)
+               (clasp-posix:munmap m)
+               (let ((m2 (clasp-posix:open-shared-memory name size
+                                                         :direction :input :create nil)))
+                 (prog1
+                     (clasp-ffi:%mem-ref (clasp-posix:mapping-pointer m2) :uint32 0)
+                   (clasp-posix:close-shared-memory m2))))
+          (ignore-errors (clasp-posix:shm-unlink name))))
+      (#x12345678))
+
+(test shmem-shared-backing
+      (let ((name (%shm-name))
+            (size 4096))
+        (unwind-protect
+             (let ((fd (clasp-posix:shm-open name '(:rdwr :create) #o600)))
+               (clasp-posix:ftruncate fd size)
+               (let ((a (clasp-posix:mmap nil size '(:read :write) '(:shared) fd 0))
+                     (b (clasp-posix:mmap nil size '(:read :write) '(:shared) fd 0)))
+                 (clasp-ffi:%mem-set (clasp-posix:mapping-pointer a) :uint32 12345 0)
+                 (prog1
+                     (clasp-ffi:%mem-ref (clasp-posix:mapping-pointer b) :uint32 0)
+                   (clasp-posix:munmap a)
+                   (clasp-posix:munmap b)
+                   (clasp-posix:close-fd fd))))
+          (ignore-errors (clasp-posix:shm-unlink name))))
+      (12345))
+
+(test-expect-error shmem-open-missing
+                   (clasp-posix:shm-open "/clasp-no-such-xyz" '(:rdwr))
+                   :type clasp-posix:syscall-error)
+
+(test shmem-munmap-idempotent
+      (let ((name (%shm-name))
+            (size 4096))
+        (unwind-protect
+             (let ((m (clasp-posix:open-shared-memory name size :create t)))
+               (clasp-posix:munmap m)
+               (list (clasp-posix:munmap m)
+                     (handler-case
+                         (progn (clasp-posix:mapping-pointer m) :no-error)
+                       (error () :errored))))
+          (ignore-errors (clasp-posix:shm-unlink name))))
+      ((t :errored)))
+
+(test-true shmem-pagesize
+           (let ((p (clasp-posix:getpagesize)))
+             (and (integerp p) (plusp p) (zerop (logand p (1- p))))))

--- a/src/lisp/regression-tests/shmem.lisp
+++ b/src/lisp/regression-tests/shmem.lisp
@@ -56,3 +56,27 @@
 (test-true shmem-pagesize
            (let ((p (clasp-posix:getpagesize)))
              (and (integerp p) (plusp p) (zerop (logand p (1- p))))))
+
+(test shmem-fork-ipc
+      (let ((name (%shm-name))
+            (size 4096)
+            (sentinel 7654321))
+        (unwind-protect
+             (let* ((m (clasp-posix:open-shared-memory name size :create t))
+                    (ptr (clasp-posix:mapping-pointer m)))
+               (clasp-ffi:%mem-set ptr :uint32 0 0)
+               (finish-output)
+               (finish-output *error-output*)
+               (multiple-value-bind (stream pid) (clasp-posix:fork nil)
+                 (declare (ignore stream))
+                 (cond
+                   ((zerop pid)
+                    (clasp-ffi:%mem-set ptr :uint32 sentinel 0)
+                    (core:cexit 0))
+                   (t
+                    (clasp-posix:wait)
+                    (prog1
+                        (clasp-ffi:%mem-ref ptr :uint32 0)
+                      (clasp-posix:close-shared-memory m))))))
+          (ignore-errors (clasp-posix:shm-unlink name))))
+      (7654321))

--- a/src/lisp/regression-tests/shmem.lisp
+++ b/src/lisp/regression-tests/shmem.lisp
@@ -57,6 +57,54 @@
            (let ((p (clasp-posix:getpagesize)))
              (and (integerp p) (plusp p) (zerop (logand p (1- p))))))
 
+;; a POSIX shm object may be sized only by its creator; ftruncate on an existing one is EINVAL
+(test shmem-reopen-with-default-create
+      (let ((name (%shm-name))
+            (size 4096))
+        (unwind-protect
+             (let ((a (clasp-posix:open-shared-memory name size)))
+               (clasp-ffi:%mem-set (clasp-posix:mapping-pointer a) :uint32 4242 0)
+               (let ((b (clasp-posix:open-shared-memory name size)))
+                 (prog1 (clasp-ffi:%mem-ref (clasp-posix:mapping-pointer b) :uint32 0)
+                   (clasp-posix:munmap b)
+                   (clasp-posix:close-shared-memory a))))
+          (ignore-errors (clasp-posix:shm-unlink name))))
+      (4242))
+
+(test shmem-input-direction-with-default-create
+      (let ((name (%shm-name))
+            (size 4096))
+        (unwind-protect
+             (let ((a (clasp-posix:open-shared-memory name size)))
+               (clasp-ffi:%mem-set (clasp-posix:mapping-pointer a) :uint32 99 0)
+               (let ((b (clasp-posix:open-shared-memory name size :direction :input)))
+                 (prog1 (clasp-ffi:%mem-ref (clasp-posix:mapping-pointer b) :uint32 0)
+                   (clasp-posix:munmap b)
+                   (clasp-posix:close-shared-memory a))))
+          (ignore-errors (clasp-posix:shm-unlink name))))
+      (99))
+
+;; MAPPING-POINTER hands out a pointer that does not keep the MAPPING alive
+(test-true shmem-no-gc-finalizer
+           (let ((name (%shm-name)))
+             (unwind-protect
+                  (let ((m (clasp-posix:open-shared-memory name 4096)))
+                    (prog1 (null (gctools:finalizers m))
+                      (clasp-posix:close-shared-memory m)))
+               (ignore-errors (clasp-posix:shm-unlink name)))))
+
+(test shmem-pointer-survives-gc
+      (let ((name (%shm-name)))
+        (unwind-protect
+             (let ((ptr (let ((m (clasp-posix:open-shared-memory name 4096)))
+                          (clasp-ffi:%mem-set (clasp-posix:mapping-pointer m) :uint32 31337 0)
+                          (clasp-posix:mapping-pointer m))))
+               (gctools:garbage-collect)
+               (gctools:garbage-collect)
+               (clasp-ffi:%mem-ref ptr :uint32 0))
+          (ignore-errors (clasp-posix:shm-unlink name))))
+      (31337))
+
 (test shmem-fork-ipc
       (let ((name (%shm-name))
             (size 4096)


### PR DESCRIPTION
Adds POSIX named shared memory to Clasp as a thin syscall layer plus a small Lisp ergonomics layer, exposed through `CLASP-POSIX`.

## What this adds

**`src/core/shmem.cc`** — thin `CL_DEFUN` wrappers over `shm_open`, `shm_unlink`, `ftruncate`, `mmap`, `munmap`, `mprotect`, `msync`, `mlock`, `munlock`, `getpagesize`, `strerror`. Every wrapper returns `(values result errno)` with `errno` 0 on success, so no C++ exceptions cross the FFI boundary and there is no errno race. `core__sys_shm_constants` returns an alist of the `O_*` / `PROT_*` / `MAP_*` / `MS_*` values so the Lisp side never hardcodes platform numbers.

**`src/lisp/kernel/lsp/shmem.lisp`** — flag handling that accepts a keyword, a list of keywords, or a raw integer; a `syscall-error` condition carrying `errno` and the call name with a `strerror`-based report; a single `%checked` macro that turns `(values result errno)` into either the result or a signalled condition; a `shm-mapping` struct; and the high-level `open-shared-memory`, `close-shared-memory`, and `with-shared-memory`.

**`src/lisp/regression-tests/shmem.lisp`** — 10 tests: round-trip through a mapping, two mappings of one fd aliasing the same page, error on a missing object, `munmap` idempotence, page-size sanity, cross-process IPC via `fork`, plus the four regression tests described below.

## Notes for review

**`SHM-MAPPING`, not `MAPPING`.** `CORE::MAPPING` is already an exported Clasp class — `Mapping_O` in `hashTable.h`, the abstract base of `StrongMapping_O` and `WeakKeyMapping_O`. A `defstruct mapping` inside `(in-package #:core)` redefines it as a `STRUCTURE-CLASS`, and the image then fails to load with "When redefining a class, the metaclass can not change". The struct is therefore named `shm-mapping`, with `(:conc-name mapping-)` so the accessors read naturally (`mapping-address`, `mapping-size`, `mappingp`). Happy to rename the accessors too if you'd prefer they carry the `shm-` prefix.

**Mappings are not GC-reclaimed, by design.** `mapping-pointer` hands out a `ForeignData` that holds no reference back to the `shm-mapping`, so a GC finalizer that unmaps would be free to run while that pointer is still live — the finalizer table is weak-keyed, so nothing keeps the mapping alive. Rather than hand out a pointer that can be invalidated underneath the caller, there is no finalizer: lifetime is explicit via `munmap` / `close-shared-memory`, with `with-shared-memory` for the scoped case. This mirrors the resolution taken for `foreign-alloc` in #1792.

**Only a creator may size a shm object.** `ftruncate` on an already-existing POSIX shm object fails `EINVAL` regardless of the fd's access mode, and even when the requested size is unchanged. `open-shared-memory` therefore attempts `O_CREAT|O_EXCL|O_RDWR` first and sizes the object only when that succeeds, falling back to a plain open on `EEXIST`. Without this, any call against an already-existing region fails, in every `:direction` — which is the normal case for the second and every later participant.

## Testing

macOS arm64, native build, LLVM 22.1.8, rebased onto current `main` (`da70d6ff1`):

| GC variant | tree tested | successes | unexpected failures | shmem tests |
| --- | --- | --- | --- | --- |
| `boehm` | this branch alone | 1971 | none | 10/10 |
| `boehmprecise` (clean build from scratch) | this branch + #1810 | 1973 | none | 10/10 |

The four expected failures (`SBCL-CROSS-COMPILE-4`, `INCLUDE-LEVEL-2B`, `INCLUDE-LEVEL-3`, `TYPES-CLASSES-10`) are pre-existing and unrelated. The count differs between variants only because `boehmprecise` also runs the variant-specific snapshot tests.

`boehmprecise` is the interesting one here: `shmem.cc` compiles and links under precise stack scanning with no GC layout descriptor, confirming it introduces no managed C++ class. The cross-process `fork` IPC test passes, as does a probe that forces GC while holding only the raw mapping pointer — the failure mode the removed finalizer would have caused.

For disclosure, the `boehmprecise` run came from a tree that also carried #1810 on top of this branch; #1810 touches only `clos/slot-value.lisp` and no shmem code.
