### PR TITLE
Fix three CLOS guards whose read-time class literals never match (eql-gf memoization, static slot-value, validate-superclass)

### DIFF
--- a/src/lisp/kernel/clos/class.lisp
+++ b/src/lisp/kernel/clos/class.lisp
@@ -168,13 +168,14 @@ argument was supplied for metaclass ~S." (class-of class))))))))
   supplied-superclasses)
 
 (defmethod validate-superclass ((class class) (superclass class))
+  ;; NOTE: runtime lookups (a #. literal never matches), deferred and errorp nil for bootstrap safety.
   (or (let ((c1 (class-of class))
 	    (c2 (class-of superclass)))
 	(or (eq c1 c2)
-	  (and (eq c1 #.(find-class 'standard-class))
-            (eq c2 #.(find-class 'funcallable-standard-class)))
-	  (and (eq c2 #.(find-class 'standard-class))
-            (eq c1 #.(find-class 'funcallable-standard-class)))))
+	    (let ((std (find-class 'standard-class nil))
+		  (fstd (find-class 'funcallable-standard-class nil)))
+	      (or (and (eq c1 std) (eq c2 fstd))
+		  (and (eq c2 std) (eq c1 fstd))))))
       (or (typep class 'forward-referenced-class)
           (typep superclass 'forward-referenced-class))))
 

--- a/src/lisp/kernel/clos/miss.lisp
+++ b/src/lisp/kernel/clos/miss.lisp
@@ -262,8 +262,9 @@
                       ;; another thread has already added this entry
                       nil
                       (list (cons key outcome)))))
+               ;; NOTE: must be a runtime lookup; a #. literal here never matches.
                ((eq (class-of generic-function)
-                    #.(find-class 'standard-generic-function))
+                    (find-class 'standard-generic-function))
                 (memoize-eql-specialized generic-function method-combination
                                          call-history argument-classes))
                (t

--- a/src/lisp/kernel/clos/static-gfs/svuc.lisp
+++ b/src/lisp/kernel/clos/static-gfs/svuc.lisp
@@ -16,11 +16,12 @@ TODO 2: Build a cell system like we do for make-instance.
 ;;;; NOTE: The static-foo macros may evaluate the instance form more than once.
 ;;;; (Because we know here that it's always just a variable.)
 
+;;; NOTE: must be runtime lookups; #. literals here never match.
 (defun uncustomizable-slot-p (class slotd)
   (let ((metaclass (class-of class)))
-    (and (or (eq metaclass #.(find-class 'standard-class))
-             (eq metaclass #.(find-class 'clos:funcallable-standard-class)))
-         (eq (class-of slotd) #.(find-class 'clos:standard-effective-slot-definition)))))
+    (and (or (eq metaclass (find-class 'standard-class))
+             (eq metaclass (find-class 'clos:funcallable-standard-class)))
+         (eq (class-of slotd) (find-class 'clos:standard-effective-slot-definition)))))
 
 ;;; I said "constant slotd", but slotds aren't dumpable, so to satisfy
 ;;; COMPILE-FILE what we'll actually get is (ltv-slotd class slotd),

--- a/src/lisp/regression-tests/fastgf.lisp
+++ b/src/lisp/regression-tests/fastgf.lisp
@@ -5,3 +5,12 @@
 (defmethod fgf-foo ((x symbol)) :symbol)
 (test dispatch-symbol (fgf-foo :yadda) (:symbol))
 (test-expect-error dispatch-no-applicable-method (fgf-foo 1.2) :description "This should not dispatch")
+
+(defmethod fgf-eql ((x (eql :alpha))) :alpha)
+(defmethod fgf-eql ((x (eql :beta))) :beta)
+(test dispatch-eql-alpha (fgf-eql :alpha) (:alpha))
+(test dispatch-eql-beta (fgf-eql :beta) (:beta))
+;;; Without memoization every eql-specialized call is a full dispatch miss.
+(test-true dispatch-eql-memoized
+           (progn (fgf-eql :alpha)
+                  (plusp (length (clos::generic-function-call-history #'fgf-eql)))))

--- a/src/lisp/regression-tests/mop.lisp
+++ b/src/lisp/regression-tests/mop.lisp
@@ -110,3 +110,20 @@
         (loop for n in nonwriters
               when (fboundp `(setf ,n))
                 collect n)))
+
+;;; AMOP allows a standard-class and a funcallable-standard-class in each
+;;; other's superclass chain; validate-superclass must accept both directions.
+(defclass vsc-plain () ((a :initform 1)))
+
+(test-true validate-superclass-mixed-metaclasses
+           (and (clos:validate-superclass (find-class 'standard-generic-function)
+                                          (find-class 'vsc-plain))
+                (clos:validate-superclass (find-class 'vsc-plain)
+                                          (find-class 'standard-generic-function))
+                t))
+
+(test-true validate-superclass-funcallable-from-standard
+           (progn (eval '(defclass vsc-funcallable (vsc-plain) ()
+                           (:metaclass clos:funcallable-standard-class)))
+                  (eq (class-of (find-class 'vsc-funcallable))
+                      (find-class 'clos:funcallable-standard-class))))


### PR DESCRIPTION
Fixes #1811.

Three guards in CLOS compare a class against a **read-time** literal, `#.(find-class ...)`. All three evaluate false in the built image, so all three silently take their fallback path. Two cost performance; the third is a correctness bug.

## 1. `miss.lisp:266` — eql-specialized generic functions never memoize

Any generic function with an `eql` specializer takes a **full dispatch miss on every call**. Its call history stays permanently empty, so `compute-applicable-methods`, `compute-effective-method` and a fresh `effective-method-function` run every single time. Class-specialized generic functions are unaffected.

```lisp
((eq (class-of generic-function)
     #.(find-class 'standard-generic-function))
 (memoize-eql-specialized ...))
```

False in the built image, so `miss-info` falls through to `(t nil)` and never calls `memoize-eql-specialized`. Nothing is added to the call history, so the next call misses again.

This is *not* discriminating-function recomputation: `updatedp` is always NIL, so `force-discriminator` never runs. The raw miss path is simply taken every time — which is why the cost is flat across the first and last key rather than looking like a search.

| | before | after |
|---|---|---|
| 30-method eql gf, first key | 14656 B/call | **0.0 B** |
| 30-method eql gf, last key | 14656 B/call | **0.0 B** |
| eql gf call history | 0 | **31** |
| `clasp-ffi:%mem-ref` | 19448 B, 321620 ns | **0.0 B, 88 ns** |
| `clasp-ffi:%mem-set` | 20240 B | **0.0 B** |
| `%mem-ref` call history | 0 | **27** |

`clasp-ffi:%mem-ref` / `%mem-set` define one `eql` method per foreign type, so **every CFFI foreign memory access** was paying this. Cost scaled at roughly 6300 B + 288 B/method. Confirmed one layer up: compiled `(cffi:mem-ref p :float off)` goes from that to **0.00 B/call**.

## 2. `svuc.lisp:21-23` — static slot-value optimization disabled

`uncustomizable-slot-p` returned NIL for a plain `standard-class` with a `standard-effective-slot-definition`, silently disabling the static `slot-value` / `slot-boundp` optimization for **every** standard class. Both `eq` tests are true when evaluated at runtime.

## 3. `class.lisp:174-177` — `validate-superclass` rejects AMOP-legal hierarchies

This one is a correctness bug. The two clauses permitting a `standard-class` and a `funcallable-standard-class` in each other's superclass chain are both dead, so the mixed case is refused:

```lisp
(defclass plain-sc () ())
(defclass fsc-from-sc (plain-sc) () (:metaclass clos:funcallable-standard-class))
;; => Class #<STANDARD-CLASS PLAIN-SC> is not a valid superclass for
;;    #<FUNCALLABLE-STANDARD-CLASS FSC-FROM-SC>
```

Called directly, both directions returned NIL where T is required.

## Fix

Runtime `find-class` in all three. In `validate-superclass` the lookups are deferred behind the existing `(eq c1 c2)` fast path and use `errorp nil`, so the common same-metaclass case does no lookup and bootstrap cannot trip over a metaclass that is not yet registered. `cl:find-class` is a C++ `CL_DEFUN` hash lookup, not a generic function, so it is safe on the dispatch miss path.

## Verification

Six new tests, in `fastgf.lisp` and `mop.lisp`. Each fails before and passes after.

- `boehm`: **1974** successes, zero unexpected failures.
- `boehmprecise`: **1976**, zero unexpected failures.
- **Clean-bootstrap `boehmprecise`**: kernel Lisp and both images deleted and regenerated from source — no errors, **1979** successes, zero unexpected failures. This specifically checks that replacing load-time literals with runtime lookups does not destabilise bootstrap ordering, since all three sites run during bootstrap (`validate-superclass` on every `defclass`, `miss-info` on every dispatch miss, `uncustomizable-slot-p` at every kernel compile).

## Worth a second look

The change fixes the symptom; **the reason the comparisons fail is not explained**, which is why #1811 is open separately. The module literal, the live class and `(class-of x)` are all `eq` to one another; the bytecode decodes correctly; every input to the `cond` is correct — yet witness counters on the guarded functions stay at zero, and recompiling the identical source at runtime works.

Not all such guards fail: `class.lisp:184`, `class.lisp:307` and `generic.lisp:284` behave correctly. The audit in #1811 rules out per-class, per-file, `defun` vs `defmethod`, test-vs-value, and `class-of` vs `si::instance-class` as the discriminator. Whatever the real cause is, it can silently disable any future `#.(find-class ...)` guard the same way — which is exactly how the slot-value optimization sat dead without anyone noticing.
