### PR TITLE
Fix: %mem-set OFFSET has no default, unlike %mem-ref

### DIFF
--- a/src/lisp/kernel/lsp/fli.lisp
+++ b/src/lisp/kernel/lsp/fli.lisp
@@ -343,7 +343,7 @@
                             (%offset-address-as-integer ptr offset)))
                         unless (eq type :void)
                           collect
-                        `(defmethod %mem-set (ptr (type (eql ',type)) value &optional offset)
+                        `(defmethod %mem-set (ptr (type (eql ',type)) value &optional (offset 0))
                            (,(intern (concatenate 'string "%MEM-SET-" (string type))
                                      "CLASP-FFI")
                             (%offset-address-as-integer ptr offset) value))))))

--- a/src/lisp/regression-tests/defcallback-native.lisp
+++ b/src/lisp/regression-tests/defcallback-native.lisp
@@ -34,3 +34,12 @@
                      collect (clasp-ffi:%mem-ref array :int (* i intsize))))
           (clasp-ffi:%foreign-free array)))
       ((1 2 3 4 5 6 7 8 9 10)))
+
+;;; %mem-set must default OFFSET to 0, the way %mem-ref already does.
+(test mem-set-default-offset
+      (let ((p (clasp-ffi:%foreign-alloc (clasp-ffi:%foreign-type-size :int))))
+        (unwind-protect
+             (progn (clasp-ffi:%mem-set p :int 42)
+                    (clasp-ffi:%mem-ref p :int))
+          (clasp-ffi:%foreign-free p)))
+      (42))


### PR DESCRIPTION
## What is broken

The methods generated for `%mem-set` in `fli.lisp` take `&optional offset` with **no default**, while the matching `%mem-ref` methods take `&optional (offset 0)`. Calling `%mem-set` with the documented three arguments therefore passes `NIL` through to `%offset-address-as-integer` and fails:

```lisp
(defparameter *p* (clasp-ffi:%allocate-foreign-object :float))

(clasp-ffi:%mem-ref *p* :float)         ; => 0.0     ok
(clasp-ffi:%mem-set *p* :float 2.5)     ; => error:  NIL is not of type INTEGER.
(clasp-ffi:%mem-set *p* :float 2.5 0)   ; => ok
```

So an offset must be supplied explicitly to `%mem-set` but not to `%mem-ref`. Both generic functions declare `&optional offset`, so the two accessors were plainly meant to be symmetric — only the generated methods disagree.

## Fix

One token in the `generate-methods` macrolet: `&optional offset` becomes `&optional (offset 0)`, matching the `%mem-ref` method generated three lines above it.

## Compatibility

Strictly additive. The only arity whose behaviour changes is the 3-argument call, which previously errored unconditionally:

- 3 args — was an error, now works as offset 0.
- 4 args with an offset — unchanged.
- 4 args with an explicit `NIL` — unchanged, still errors, because an explicitly supplied argument means the default form never runs.

No call that worked before behaves differently.

## Tests

Adds `mem-set-default-offset` to the FFI suite in `defcallback-native.lisp`. The pre-existing `cffi-defcallback` test exercises `%mem-set` *with* explicit offsets, so the 4-argument path is covered by an existing test rather than only by argument.

Full regression suite on `boehm`: **1975 successes, zero unexpected failures** (1974 baseline + the new test). `Passed MEM-SET-DEFAULT-OFFSET`, `Passed CFFI-DEFCALLBACK`.

Found while investigating #1811, but entirely independent of it — this is a plain lambda-list oversight, not related to dispatch.
