### PR TITLE
tests: make weak-table weakness tests robust under conservative GC

### DIFF
--- a/src/lisp/regression-tests/hash-tables0.lisp
+++ b/src/lisp/regression-tests/hash-tables0.lisp
@@ -127,41 +127,60 @@
 
 ;;; These tests are pretty strict - they want the garbage to actually be
 ;;; collected by that garbage-collect call, which may not be the case if we
-;;; ever get a more relaxed collector (generational or something)
+;;; ever get a more relaxed collector (generational or something).
+;;;
+;;; BUILDER is called to populate the table and then returns, so the frame
+;;; holding the dead temporaries is popped before we collect - otherwise
+;;; conservative stack scanning can see a stale reference and keep an entry
+;;; alive. For the same reason we collect up to TRIES times instead of
+;;; demanding the exact count after a single collection: a genuinely retained
+;;; entry still fails, but a transient stack artifact does not.
+(defun weak-count (builder expected &optional (tries 10))
+  (let ((table (funcall builder)))
+    (loop repeat tries
+          do (gctools:garbage-collect)
+          when (eql (hash-table-count table) expected)
+            return expected
+          finally (return (hash-table-count table)))))
+
 (test weak-key-weakness
-      (let ((table (make-hash-table :weakness :key)))
-        (setf (gethash (list 37) table) :value
-              (gethash :key table) (list nil)
-              (gethash :key2 table) (list nil))
-        (gctools:garbage-collect)
-        (hash-table-count table))
+      (weak-count (lambda ()
+                    (let ((table (make-hash-table :weakness :key)))
+                      (setf (gethash (list 37) table) :value
+                            (gethash :key table) (list nil)
+                            (gethash :key2 table) (list nil))
+                      table))
+                  2)
       (2))
 (test weak-value-weakness
-      (let ((table (make-hash-table :weakness :value)))
-        (setf (gethash :key table) (list 37)
-              (gethash (list nil) table) :value
-              (gethash (list 18) table) :value)
-        (gctools:garbage-collect)
-        (hash-table-count table))
+      (weak-count (lambda ()
+                    (let ((table (make-hash-table :weakness :value)))
+                      (setf (gethash :key table) (list 37)
+                            (gethash (list nil) table) :value
+                            (gethash (list 18) table) :value)
+                      table))
+                  2)
       (2))
 (test weak-key-and-value-weakness
-      (let ((table (make-hash-table :weakness :key-and-value)))
-        (setf (gethash (list nil) table) :value
-              (gethash :key table) (list nil)
-              (gethash (list nil) table) (list nil)
-              (gethash :key table) :value)
-        (gctools:garbage-collect)
-        (hash-table-count table))
+      (weak-count (lambda ()
+                    (let ((table (make-hash-table :weakness :key-and-value)))
+                      (setf (gethash (list nil) table) :value
+                            (gethash :key table) (list nil)
+                            (gethash (list nil) table) (list nil)
+                            (gethash :key table) :value)
+                      table))
+                  1)
       (1))
 #-use-boehm ; on boehm key-or-value tables are effectively strong.
 (test weak-key-or-value-weakness
-      (let ((table (make-hash-table :weakness :key-or)))
-        (setf (gethash (list nil) table) :value
-              (gethash :key table) (list nil)
-              (gethash (list nil) table) (list nil)
-              (gethash :key table) :value)
-        (gctools:garbage-collect)
-        (hash-table-count table))
+      (weak-count (lambda ()
+                    (let ((table (make-hash-table :weakness :key-or)))
+                      (setf (gethash (list nil) table) :value
+                            (gethash :key table) (list nil)
+                            (gethash (list nil) table) (list nil)
+                            (gethash :key table) :value)
+                      table))
+                  3)
       (3))
 
 (test equalp-hash-table-1


### PR DESCRIPTION
Fixes #1814.

`WEAK-KEY-AND-VALUE-WEAKNESS` fails intermittently on `clasp/ubuntu-latest/bytecode`. The **identical commit** failed the regression step on one run and passed it on another, while `macos/bytecode` and `ubuntu/native` passed both times — so it is non-deterministic, not a real regression. Details and run links in #1814.

## Why the tests are fragile

All four weakness tests share this shape:

```lisp
(let ((table (make-hash-table :weakness :key-and-value)))
  (setf (gethash (list nil) table) :value
        ...)
  (gctools:garbage-collect)
  (hash-table-count table))
```

Two things make that unreliable under Boehm's conservative stack scanning:

1. The throwaway `(list nil)` values are created in **the same frame that then calls `garbage-collect`**, so their addresses are still sitting in live stack slots and registers when the collector scans the stack. The collector cannot tell those words from real references and keeps the entries alive.
2. A single collection is assumed to be enough.

Either one leaves a dead entry alive and the count comes out one too high. Because it depends on register allocation and stack residue, it can be perturbed by entirely unrelated codegen changes elsewhere in the tree — which is how it surfaced.

The existing comment already acknowledged these are "pretty strict"; this makes them strict about the property being tested rather than about incidental stack layout.

## Change

- Populate the table in a builder function that **returns before** the collection, so the frame holding the temporaries is popped and below the stack pointer when the scan happens.
- Collect up to `TRIES` times rather than exactly once.
- One `WEAK-COUNT` helper shared by all four tests instead of repeating the retry logic four times.

## Not vacuous

A retry loop risks turning the test into a tautology, so I checked that it still fails on genuine retention. Holding one key in a global:

```
dead temporaries      => 1   (expected 1, passes)
one key held globally => 2   (expected 1, still fails after all attempts)
```

An entry that is really retained never reaches the expected count, so the tests keep their teeth.

## Verification

macOS arm64, boehmprecise: full suite **1979 successes, zero unexpected failures**; the weakness tests pass 3/3 across repeated `TEST_SUITES=hash-tables0` runs. (`weak-key-or-value-weakness` is `#-use-boehm` and does not run on these variants, but is updated for consistency.)
