### PR TITLE
Carry dynamic-extent declarations from bytecode into BIR

### DIFF
--- a/src/lisp/kernel/cleavir/compile-bytecode.lisp
+++ b/src/lisp/kernel/cleavir/compile-bytecode.lisp
@@ -1404,6 +1404,10 @@
           for index = (core:bytecode-debug-var/frame-index bdv)
           for ctype = (declared-variable-ctype
                        (core:bytecode-debug-var/decls bdv) (consp name))
+          ;; Permission to stack allocate; the escape analysis still has to agree.
+          for dxp = (and (member 'cl:dynamic-extent
+                                 (core:bytecode-debug-var/decls bdv))
+                         t)
           for (datum) = (aref (locals context) index)
           ;; We make all variables IGNORABLE because the bytecode compiler
           ;; has already warned about any syntactically unused variables
@@ -1415,9 +1419,9 @@
                            :ignore 'cl:ignorable :name name)
           do (etypecase datum
                (bir:linear-datum
-                (bind-variable variable datum ctype inserter context))
+                (bind-variable variable datum ctype inserter context dxp))
                ((cons bir:linear-datum) ; cell
-                (bind-variable variable (car datum) ctype inserter context)))
+                (bind-variable variable (car datum) ctype inserter context dxp)))
              (setf (aref (locals context) index)
                    (cons variable cellp))
           collect (cons name ctype) into typemap
@@ -1443,14 +1447,16 @@
           return (env:parse-type-specifier (second decl) env sys)
         finally (return (ctype:top sys))))
 
-(defun bind-variable (variable value ctype inserter context)
+(defun bind-variable (variable value ctype inserter context
+                      &optional dynamic-extent)
   (let ((typed (compile-type-decl :setq ctype value inserter context)))
-    (%bind-variable variable typed inserter)))
+    (%bind-variable variable typed inserter dynamic-extent)))
 
-(defun %bind-variable (variable value inserter)
+(defun %bind-variable (variable value inserter &optional dynamic-extent)
   (build:insert inserter 'bir:leti
                 :inputs (list value)
-                :outputs (list variable)))
+                :outputs (list variable)
+                :dynamic-extent dynamic-extent))
 
 (defmethod end-annotation ((annot core:bytecode-debug-vars)
                            inserter context)

--- a/src/lisp/regression-tests/control01.lisp
+++ b/src/lisp/regression-tests/control01.lisp
@@ -164,3 +164,20 @@
                   item))
           result))
       (4))
+
+;;; DETERMINE-CLOSURE-EXTENT marked an ENCLOSE :dynamic as soon as one reader
+;;; turned out to be a dx-call, before the remaining readers were checked; a
+;;; later escaping reader then bailed out without undoing it, so a closure that
+;;; is returned got stack allocated. Cleavir sets are EQ hash tables, so which
+;;; reader came first -- and hence whether the bug fired -- varied per compile.
+;;; Repeat enough times that the old behaviour is caught with certainty.
+(test-true dynamic-extent-escaping-closure
+      (let ((src '(lambda (x)
+                    (let ((g (lambda (y) (+ x y))))
+                      (mapcar g '(1 2 3))
+                      g))))
+        (every (lambda (f)
+                 (eql 15 (handler-case (funcall (funcall f 10) 5)
+                           (error () nil))))
+               (let ((cmp:*compile-native* t))
+                 (loop repeat 30 collect (compile nil src))))))

--- a/src/lisp/regression-tests/control01.lisp
+++ b/src/lisp/regression-tests/control01.lisp
@@ -181,3 +181,30 @@
                            (error () nil))))
                (let ((cmp:*compile-native* t))
                  (loop repeat 30 collect (compile nil src))))))
+
+;;; A DYNAMIC-EXTENT declaration is permission to stack allocate, never proof.
+;;; Here it is simply wrong -- the local function hands the closure back out --
+;;; so the compiler has to forfeit the optimisation. Believing the declaration
+;;; would return a closure whose frame is already gone.
+(test-true dynamic-extent-wrong-declaration-is-safe
+      (let ((f (let ((cmp:*compile-native* t))
+                 (compile nil '(lambda (x k)
+                                (flet ((leak-it (g) (list g k)))
+                                  (let ((c (lambda (y) (+ x y))))
+                                    (declare (dynamic-extent c))
+                                    (values (leak-it c) (leak-it c)
+                                            (leak-it c)))))))))
+        (eql 15 (handler-case (funcall (first (funcall f 10 1)) 5)
+                  (error () nil)))))
+
+;;; The same shape with a declaration that IS correct must keep its meaning.
+(test dynamic-extent-declared-closure-value
+      (let ((f (let ((cmp:*compile-native* t))
+                 (compile nil '(lambda (x k)
+                                (flet ((use-it (g) (length (mapcar g (list k 2 3)))))
+                                  (let ((c (lambda (y) (+ x y))))
+                                    (declare (dynamic-extent c))
+                                    (values (use-it c) (use-it c)
+                                            (use-it c)))))))))
+        (funcall f 10 1))
+      (3 3 3))


### PR DESCRIPTION
> **Draft: blocked on two Cleavir changes.** This branch does not build against
> `s-expressionists/Cleavir` `main` as it stands — see *Dependency* below. Opening it now so the
> Clasp side is reviewable; it will go green on its own once the Cleavir side lands, with no
> change needed here.

A `(declare (dynamic-extent g))` on a variable bound to a closure was parsed and then discarded, so it never reached the compiler. This wires it through and lets the closure extent analysis act on it.

## Where the declaration was lost

Clasp does not use Cleavir's CST-to-AST front end — `CLEAVIR-CST-TO-AST`, `CLEAVIR-AST` and `CLEAVIR-AST-TO-BIR` are not present in the image at all. Clasp goes source → bytecode → BIR, so the declaration has to travel through the bytecode, and it already does: `cmp/cmpltv.lisp` packs a dynamic-extent bit into the debug-var flags byte, and `compile-bytecode.lisp`'s `start-annotation` already reads `(core:bytecode-debug-var/decls bdv)` to recover the declared type. The bit simply was not passed on.

This reads `cl:dynamic-extent` out of that same list and sets it on the `bir:leti` that binds the variable, which is where BIR's own docstring says a dynamic-extent declaration belongs — the declaration constrains the extent of the *value* bound rather than of the variable.

## Permission, not proof

The declaration only permits the compiler to *try*. The escape analysis still has to succeed independently, so a declaration that is wrong costs the optimisation rather than memory safety. Two deliberately-wrong cases were checked: a local function that returns the closure, and one that stores it in a global. Both keep the closure heap-allocated and both still work when called afterwards.

## Effect

A closure passed to a capturing `flet` called from three sites, 100000 calls: **544 → 504 bytes per call**, results unchanged. The 40 bytes are the closure moving to the stack.

It only fires when the local function captures something. A non-capturing `flet` compiles to a constant function, so the call's callee is a constant reference with no BIR function behind it to analyse.

## Dependency

Needs both of these in Cleavir:

- `Only mark a closure dynamic-extent once every reader has been checked` — a soundness fix, independent of this feature. `determine-closure-extent` marked an enclose `:dynamic` as soon as one reader turned out to be a DX call; a later escaping reader bailed out without undoing it. Because Cleavir sets are EQ hash tables the iteration order varies, so compiling an escaping closure 300 times stack-allocated it 154 times, and calling one gives `EXT:BUS-ERROR`.
- `Let a dynamic-extent declaration reach the closure extent analysis` — adds the `bir:leti` `:dynamic-extent` slot this branch writes to, plus the escape analysis that consumes it.

Without the second one, `build:insert 'bir:leti :dynamic-extent …` is an initarg no slot accepts, so this does not merely fail a test — the tree does not build. `repos.sexp` tracks Cleavir `main` unpinned, so once both land upstream this branch picks them up with no change here.

## Tests

Two regression tests, neither of which needs the optimisation to fire in order to be meaningful:

- a wrong declaration forfeits the optimisation rather than handing back a closure whose frame is gone
- a correct declaration does not change the value computed

The companion test for the Cleavir soundness fix compiles an escaping closure 30 times and calls each result, since a single compile is a coin flip.
