### PR TITLE
koga: make `ninja install` produce a usable libclasp.pc

### DIFF
--- a/src/koga/configure.lisp
+++ b/src/koga/configure.lisp
@@ -152,7 +152,7 @@
                :type pathname
                :documentation "The directory under which to install shared Clasp files.")
    (pkgconfig-path :accessor pkgconfig-path
-                   :initform #P"/usr/lib/pkgconfig/"
+                   :initform #P"/usr/local/lib/pkgconfig/"
                    :initarg :pkgconfig-path
                    :type pathname
                    :documentation "The directory under which to install the pkgconfig files.")

--- a/src/koga/configure.lisp
+++ b/src/koga/configure.lisp
@@ -147,7 +147,7 @@
                :type pathname
                :documentation "The directory under which to install shared Clasp files.")
    (pkgconfig-path :accessor pkgconfig-path
-                   :initform #P"/usr/lib/pkgconfig/"
+                   :initform #P"/usr/local/lib/pkgconfig/"
                    :initarg :pkgconfig-path
                    :type pathname
                    :documentation "The directory under which to install the pkgconfig files.")

--- a/src/koga/scripts.lisp
+++ b/src/koga/scripts.lisp
@@ -536,7 +536,9 @@ Libs: ~a -lclasp~%"
             (format nil "-I~a -I~a"
                     (root :install-share)
                     (make-source "include/" :install-share))
-            ""
+            (format nil "-L~a -Wl,-rpath,~a"
+                    (root :install-dylib)
+                    (root :install-dylib))
             :remove-include t))
 
 (defmethod print-prologue (configuration (name (eql :libclasp-pc-variant)) output-stream)

--- a/src/koga/scripts.lisp
+++ b/src/koga/scripts.lisp
@@ -549,7 +549,9 @@ Libs: ~a -lclasp~%"
             (format nil "-I~a -I~a"
                     (root :install-share)
                     (make-source "include/" :install-share))
-            ""
+            (format nil "-L~a -Wl,-rpath,~a"
+                    (root :install-dylib)
+                    (root :install-dylib))
             :remove-include t))
 
 (defmethod print-prologue (configuration (name (eql :libclasp-pc-variant)) output-stream)

--- a/src/koga/setup.lisp
+++ b/src/koga/setup.lisp
@@ -232,6 +232,7 @@ writing the build and variant outputs."
                               :code #P""
                               :install-bin (bin-path *configuration*)
                               :install-share (share-path *configuration*)
+                              :install-dylib (dylib-path *configuration*)
                               :install-lib (lib-path *configuration*)
                               :install-generated install-generated
                               :package-bin (resolve-package-path (bin-path *configuration*))


### PR DESCRIPTION
Two independent defects in koga's pkg-config handling, one commit each. Together they mean `ninja install` cannot complete on macOS, and that the pkg-config file it installs cannot link anything on any platform.

## 1. `pkgconfig-path` defaults into a SIP-protected directory

`bin-path`, `lib-path`, `dylib-path` and `share-path` all default under `/usr/local`, but `pkgconfig-path` defaults to `/usr/lib/pkgconfig/`. On macOS Catalina and later `/usr/lib` is on the sealed read-only system volume and is protected by System Integrity Protection, so `ninja -C build install` ends with:

```
[1/1] Installing libclasp.pc to /usr/lib/pkgconfig/libclasp.pc
FAILED: [code=71] /usr/lib/pkgconfig/libclasp.pc
install -C -m 644 libclasp.pc /usr/lib/pkgconfig/libclasp.pc
install: /usr/lib/pkgconfig/INS@na30mW: Operation not permitted
ninja: build stopped: subcommand failed.
```

`sudo` does not help — the `EPERM` is SIP, not ownership; root has no access to that directory either. So `ninja install` cannot run to completion out of the box on any recent Mac.

Changed the default to `/usr/local/lib/pkgconfig/`, which is in pkg-config's default `pc_path` on both Linux and macOS and is consistent with the other four install paths.

## 2. The installed `libclasp.pc` cannot link anything

`print-prologue (:libclasp-pc)` passed `""` where `write-pc` expects the `Libs` prefix, producing `Libs:  -lclasp` with no library search path:

```
$ clang++ t.cc -o t $(pkg-config --libs libclasp)
ld: library 'clasp' not found
```

The per-variant `.pc` (`:libclasp-pc-variant`) does pass the variant ldflags, so only the installed copy was affected.

`-L` alone is not sufficient on macOS. `otool -D` shows `libclasp.dylib`'s install name is `@rpath/libclasp.dylib`, so a consumer that now links successfully still dies at startup:

```
dyld: Library not loaded: @rpath/libclasp.dylib
  Reason: no LC_RPATH's found
```

so the fix emits `-Wl,-rpath,` as well, and the flags work end to end.

`dylib-path` had no entry in `*root-paths*` — `:install-bin`, `:install-share` and `:install-lib` are all present — so this adds `:install-dylib` alongside them. It deliberately uses the unresolved install path rather than the `--package-path`-resolved one, matching `:install-share` directly above: a staged package must still describe where the files will finally live.

**One point you may want to push back on:** putting `-Wl,-rpath,` in `Libs:` is the pragmatic fix. The alternative is to give the installed dylib an absolute `-install_name` so no rpath is needed at all, but that is a larger change and would diverge from the build tree, which relies on `@rpath`. Happy to split the rpath half out or rework it that way if you prefer.

## Testing

macOS 15 / Apple Silicon, `:build-mode :native`, install prefix `/opt/clasp`.

Before: `ninja install` fails on the `.pc`; with the file installed by hand, `pkg-config --libs libclasp` yields `-lclasp` and linking fails with `ld: library 'clasp' not found`.

After:

```
$ pkg-config --libs libclasp
-L/opt/clasp/lib/ -Wl,-rpath,/opt/clasp/lib/ -lclasp -L.../gmp/lib -lgmpxx -lgmp -L.../fmt/lib -lfmt

$ clang++ t.cc -o t $(pkg-config --libs libclasp) && ./t && echo ok
ok

$ otool -l t | grep -A2 LC_RPATH
          cmd LC_RPATH
      cmdsize 32
         path /opt/clasp/lib/ (offset 12)
```

`ninja -C build install` then completes with exit 0, and a second run reports `no work to do`.

The new default was verified independently by removing the local `config.sexp` override and re-running `./koga`: `build.ninja` then targets `/usr/local/lib/pkgconfig/libclasp.pc`.

Neither change triggers a rebuild. Regenerating with `./koga` touches only `build.ninja` — koga's timestamp-preserving output streams leave `config.h` and the generated headers byte-identical, so `ninja -n install` afterwards shows a single pending edge.
