### PR TITLE
cmpltv: don't raise from print-object on a half-built creator

### DIFF
--- a/src/lisp/kernel/cmp/cmpltv.lisp
+++ b/src/lisp/kernel/cmp/cmpltv.lisp
@@ -38,7 +38,7 @@
 ;;; The object may be fully initialized or may require further initialization.
 (defclass creator (instruction)
   ((%index :initform nil :initarg :index :accessor index
-           :type (integer 0))))
+           :type (or null (integer 0)))))
 ;;; A creator for which a prototype value (which the eventual LTV will be
 ;;; similar to) is available.
 (defclass vcreator (creator)
@@ -55,7 +55,9 @@
 
 (defmethod print-object ((object creator) stream)
   (print-unreadable-object (object stream :type t)
-    (format stream "~d" (index object)))
+    (if (slot-boundp object '%index)
+        (format stream "~d" (index object))
+        (write-string "[no index]" stream)))
   object)
 
 (defmethod print-object ((object vcreator) stream)
@@ -63,7 +65,9 @@
     (if (slot-boundp object '%prototype)
         (prin1 (prototype object) stream)
         (write-string "[no prototype]" stream))
-    (format stream " ~d" (index object)))
+    (if (slot-boundp object '%index)
+        (format stream " ~d" (index object))
+        (write-string " [no index]" stream)))
   object)
 
 ;;; An instruction that performs some action for effect. This can include


### PR DESCRIPTION
Two small robustness changes in `src/lisp/kernel/cmp/cmpltv.lisp`. Neither fixes a bug I can currently demonstrate; both were found while chasing a failure whose real cause the first one was actively hiding.

## `print-object` can raise and swallow the condition it was printing

`print-object` for `vcreator` already guards `%prototype` with `slot-boundp`, but reads `(index object)` unguarded three lines later — and the `creator` method reads it unguarded too. A creator whose index has not yet been assigned therefore signals an unbound-slot error *from inside the printer*, which replaces whatever condition was actually being reported and splices the new message into the middle of the old one:

```
#<CMPLTV::BASE-STRING-CREATOR [no prototype]The slot CMPLTV::%INDEX is
                                            unbound in an instance of
                                            CMPLTV::BASE-STRING-CREATOR.
```

That is what the failure I was investigating looked like, and it cost real time — the visible error is entirely about the printer, while the original condition is gone. This guards both reads the way `%prototype` already is, so such an object prints as `[no index]` and the real condition survives.

## `%index` type contradicts its own initform

The slot is declared `:type (integer 0)` with `:initform nil`, which the type excludes. Upstream Maclina has `:type (or null (integer 0))` for the same slot; this looks like drift. Nothing enforces it today — I checked, `make-instance` stores `nil` there without complaint — so this is tidiness rather than a fix, but the declaration should not contradict the initform.

## Verification

x86-64 Linux, LLVM 18, `--build-mode=bytecode`: builds clean, regression suite **1963 successes / `TEST_EXIT=0`**, identical to baseline.
