### PR TITLE
koga: depend the generated lisp-info on libclasp, not just iclasp

### DIFF
--- a/src/koga/ninja.lisp
+++ b/src/koga/ninja.lisp
@@ -632,6 +632,8 @@
          (image (image-source configuration))
          (image-installed (image-source configuration :root :package-lib))
          (iclasp (make-source "iclasp" :variant))
+         (libclasp (make-source (lib-filename configuration "libclasp" :dynamic t)
+                                :variant-lib))
          (clasp-with-env (wrap-with-env configuration iclasp))
          (fasls (mapcar #'source-fasl sources))
          (cfasls (mapcar (lambda (source)
@@ -646,7 +648,7 @@
                                       runtime-variables.lisp runtime-info.lisp
                                       type-map.lisp fli-specs.lisp)
                        :clasp clasp-with-env
-                       :implicit-inputs (list iclasp))
+                       :implicit-inputs (list iclasp libclasp))
     (ninja:write-build output-stream :generate-encodings
                        :inputs (list (make-source "tools-for-build/encodingdata.txt" :code))
                        :outputs (list generated-encodings.lisp))


### PR DESCRIPTION
The generated lisp-info files never regenerate when the Lisp or C++ content changes, so a build can silently use package, symbol and class data belonging to a different tree state.

## The broken chain

```
build …/generated/features.sexp …/runtime-packages.lisp …/cxx-classes.lisp …:
    generate-lisp-info | boehmprecise/iclasp             <- implicit dep: iclasp only

build boehmprecise/iclasp: link …/main.o || boehmprecise/lib/libclasp.so
                                                         <- ORDER-ONLY dep (||)
```

`generate-lisp-info` runs `iclasp`, which loads `libclasp.so` at runtime via rpath and dumps the packages, functions, variables, classes and type map it finds there. Its output therefore depends on **`libclasp.so`'s contents**. But the only path from the generator to that library runs through `iclasp`, which depends on it **order-only** — in ninja that means "build it first if missing, but changes to it do not make me dirty". And `iclasp` is just `main.o` plus a link, so it rarely changes on its own.

The declaration of `iclasp` as an implicit input shows the dependency was intended; it just names the wrong artifact. All the content the generator reads lives in the library, not in the executable.

## Reproduction, before the fix

```
generated stamp: 2026-08-03 23:42:47
libclasp.so:     2026-08-04 00:05:50        <- newer
$ touch build/boehmprecise/lib/libclasp.so && ninja -C build
ninja rc=0   generated stamp: 2026-08-03 23:42:47    <- unchanged
$ ninja -C build -n boehmprecise/generated/runtime-packages.lisp
ninja: no work to do.
```

Worse in practice: walking a single build tree through **eight branches** in sequence, rebuilding at each, left the generated files at their original timestamp and byte sizes the whole way — including across a branch that adds new C++ sources and therefore new scraped symbols. Eight images, each built from another branch's lisp-info, with nothing to indicate it.

## The change

`lib-filename` already returns `.a` under `--static-linking`, so a single call is correct for both linkage modes.

## Verification, x86-64 Linux / LLVM 18

```
edge now reads: generate-lisp-info | boehmprecise/iclasp boehmprecise/lib/libclasp.so
$ touch build/boehmprecise/lib/libclasp.so
ninja sees generator dirty?  YES
generated stamp before: 2026-08-04 00:21:25
generated stamp after:  2026-08-04 00:25:23     <- regenerated
```

Full build and regression suite unaffected.

## Relationship to #1823 / #1826

Separate bugs, similar damage, and they interact: #1823 is the generator leaving a stale tail *when it runs*; this is the generator not running when it should. Fixing #1823 alone is insufficient, since the regeneration that would apply that fix never happens.
