### PR TITLE
koga: give installed binaries an rpath pointing at the install prefix

### DIFF
--- a/src/koga/units.lisp
+++ b/src/koga/units.lisp
@@ -322,11 +322,32 @@ has not been set."
          (message :emph "Configuring non-reproducible build")
          (loop for variant in (variants configuration)
                do (append-ldflags variant
-                                  ;; Quote the path: the build directory may
-                                  ;; contain spaces, and ninja passes ldflags
-                                  ;; through /bin/sh which would otherwise split
+                                  ;; Two rpaths, in this order.
+                                  ;;
+                                  ;; First a loader-relative one. `install' copies the
+                                  ;; binary but cannot rewrite the rpath baked in at link
+                                  ;; time, so without this an INSTALLED clasp resolves
+                                  ;; libclasp through the absolute build path below and
+                                  ;; keeps loading out of the build tree: removing that
+                                  ;; tree breaks the install, rebuilding it silently
+                                  ;; changes the installed clasp, and two installs cannot
+                                  ;; coexist.  In the install layout the binary is in
+                                  ;; <prefix>/bin and the library in <prefix>/lib, so
+                                  ;; ../lib resolves; in the build tree the binary sits in
+                                  ;; <build>/<variant>/ with its library in
+                                  ;; <build>/<variant>/lib, so ../lib names <build>/lib,
+                                  ;; which does not exist and is simply skipped.
+                                  ;;
+                                  ;; Then the absolute build path, which is what the
+                                  ;; in-tree binary actually uses.  Quote it: the build
+                                  ;; directory may contain spaces, and ninja passes
+                                  ;; ldflags through /bin/sh which would otherwise split
                                   ;; the rpath at the space.
-                                  (format nil "-Wl,-rpath,\"~a\""
+                                  (format nil "~a -Wl,-rpath,\"~a\""
+                                          #+darwin "-Wl,-rpath,@loader_path/../lib"
+                                          ;; $ORIGIN must survive both ninja ($$) and
+                                          ;; /bin/sh (single quotes) to reach the linker.
+                                          #-darwin "-Wl,-rpath,'$$ORIGIN/../lib'"
                                           (normalize-directory
                                            (uiop:ensure-absolute-pathname
                                             (merge-pathnames


### PR DESCRIPTION
Fixes #1831 — installed binaries keep loading `libclasp` out of the build tree.

## The bug

The link step emits one rpath: the absolute build lib directory. `install` copies the binary but cannot rewrite an rpath baked in at link time, so an installed clasp resolves `libclasp` through the build tree.

```
$ otool -l <prefix>/bin/iclasp | grep -A2 LC_RPATH
    path /path/to/clasp/build/boehmprecise/lib
$ DYLD_PRINT_LIBRARIES=1 <prefix>/bin/clasp --version
dyld[...] /path/to/clasp/build/boehmprecise/lib/libclasp.dylib
```

Even with a single install this means removing the build tree breaks the install, rebuilding it silently changes which clasp the installed binary runs, and the `libclasp` copied into the prefix is never loaded. With two installs neither works: both resolve to whatever the build tree currently holds, so each reports the other's version. I found it exactly that way.

## The change

Emit a loader-relative rpath **ahead of** the absolute one:

```lisp
#+darwin "-Wl,-rpath,@loader_path/../lib"
#-darwin "-Wl,-rpath,'$$ORIGIN/../lib'"
```

| layout | binary | library | `../lib` resolves to |
|---|---|---|---|
| install | `<prefix>/bin/iclasp` | `<prefix>/lib` | **`<prefix>/lib`** ✓ |
| build | `<build>/<variant>/iclasp` | `<build>/<variant>/lib` | `<build>/lib` — absent, skipped |

So one link serves both: installed binaries prefer their own prefix, and the in-tree binary falls through to the absolute entry exactly as before. No install-time rewriting, and no dependency on `install_name_tool` or `patchelf` (the latter is often not installed).

`$ORIGIN` must survive two layers to reach the linker — ninja (`$$`) and `/bin/sh` (single quotes). Confirmed via `ninja -t commands`:

```
-Wl,-rpath,'$ORIGIN/../lib'
```

## Verification

**macOS** (arm64, LLVM 22):

```
$ otool -l build/boehmprecise/iclasp | grep -A2 LC_RPATH
    path @loader_path/../lib
    path /path/to/clasp/build/boehmprecise/lib
in-tree binary:            ok 42, loads .../build/boehmprecise/lib/libclasp.dylib
copy in install layout:    loads /tmp/rpx/lib/libclasp.dylib
```

**x86-64 Linux** (LLVM 18, bytecode):

```
$ readelf -d build/boehmprecise/iclasp | grep RUNPATH
  Library runpath: [$ORIGIN/../lib:/mnt/.../build/boehmprecise/lib]
in-tree binary:            intree-ok 42
copy in install layout:    /tmp/rpx/bin/../lib/libclasp.so   (build tree still present)
```

In both cases the install-layout copy prefers its own prefix while the build tree exists, and the in-tree binary is unchanged.

## One thing worth your eye

The relative entry is inert in the build tree **only because `<build>/lib` does not exist**. That holds for every variant today, but it is a load-bearing assumption: a future layout that creates `build/lib` would make the in-tree binary prefer it. If you would rather not depend on that, the alternative is rewriting the rpath during `install` (what CMake does), at the cost of requiring `install_name_tool`/`patchelf` — happy to do it that way instead.

The reproducible-build branch of that `cond` is untouched; it already remaps paths for its own reasons and I did not want to disturb it without understanding the intent.
