### PR TITLE
Don't deadlock in exit() when a thread is blocked in stdio

### DIFF
--- a/include/clasp/core/lispStream.h
+++ b/include/clasp/core/lispStream.h
@@ -188,6 +188,8 @@ typedef enum : claspCharacter {
 T_sp stream_open(T_sp fn, StreamDirection direction, StreamIfExists if_exists, StreamIfDoesNotExist if_does_not_exist,
                  gctools::Fixnum byte_size, int flags, T_sp external_format);
 T_sp stream_close(T_sp stream, T_sp abort);
+// Flush every FILE* clasp has open, skipping any another thread currently holds locked.
+void flush_open_c_streams();
 
 // Low level byte functions
 

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -1380,7 +1380,9 @@ DOCGROUP(clasp);
   }
   VirtualMachine& vm = my_thread->_VM;
   vm.shutdown();
-  exit(exitValue);
+  // _IO_cleanup() would block on a FILE another thread is wedged inside, so flush explicitly and skip it.
+  flush_open_c_streams();
+  _exit(exitValue);
 #endif
 };
 

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -4257,6 +4257,49 @@ static int safe_close(int f) {
   return output;
 }
 
+// Function-local so they are constructed on first use: safe_fopen can run before file-scope
+// statics of other translation units are initialized.
+static std::mutex& open_files_mutex() {
+  static std::mutex m;
+  return m;
+}
+
+static std::set<FILE*>& open_files() {
+  static std::set<FILE*> s;
+  return s;
+}
+
+static void register_open_file(FILE* f) {
+  if (!f)
+    return;
+  std::lock_guard<std::mutex> guard(open_files_mutex());
+  open_files().insert(f);
+}
+
+static void unregister_open_file(FILE* f) {
+  if (!f)
+    return;
+  std::lock_guard<std::mutex> guard(open_files_mutex());
+  open_files().erase(f);
+}
+
+// Flush what we can lock right now; a stream another thread is blocked inside is skipped, not waited on.
+void flush_open_c_streams() {
+  std::vector<FILE*> snapshot;
+  if (open_files_mutex().try_lock()) {
+    snapshot.assign(open_files().begin(), open_files().end());
+    open_files_mutex().unlock();
+  }
+  snapshot.push_back(stdout);
+  snapshot.push_back(stderr);
+  for (FILE* f : snapshot) {
+    if (f && ftrylockfile(f) == 0) {
+      fflush(f);
+      funlockfile(f);
+    }
+  }
+}
+
 static FILE* safe_fopen(const char* filename, const char* mode) {
   FILE* output;
   BEGIN_PARK {
@@ -4264,6 +4307,7 @@ static FILE* safe_fopen(const char* filename, const char* mode) {
       output = fopen(filename, mode);
     } while (!output && errno == EINTR);
   } END_PARK;
+  register_open_file(output);
   return output;
 }
 
@@ -4335,11 +4379,13 @@ static FILE* safe_fdopen(int fildes, const char* mode) {
       perror("In safe_fdopen");
     }
   } END_PARK;
+  register_open_file(output);
   return output;
 }
 
 static int safe_fclose(FILE* stream) {
   int output;
+  unregister_open_file(stream);
   BEGIN_PARK {
     output = fclose(stream);
   } END_PARK;


### PR DESCRIPTION
## The bug

`core:quit` calls `exit()`. glibc's `exit()` runs `_IO_cleanup()` → `_IO_flush_all()`, which takes
the lock on **every open `FILE*`**. A Lisp thread blocked in `(read)` is inside `fread` **holding
stdin's `FILE` lock**, so that lock is never released and the process hangs instead of exiting.

Backtrace of a hung `iclasp` (x86-64 Linux, glibc 2.39):

```
Thread 1 (exiting):
  #2  __GI__IO_flush_all ()  at ./libio/genops.c:698     <- blocked on a FILE lock
  #3  _IO_cleanup ()         at ./libio/genops.c:843
  #4  __run_exit_handlers () at ./stdlib/exit.c:129
  #5  __GI_exit ()           at ./stdlib/exit.c:138
  #6  core::core__exit       at src/core/lisp.cc:1383

Thread 2 (reader):
  #4  __GI__IO_fread                                     <- holds stdin's FILE lock
  #3  __GI__IO_file_xsgetn
  #2  _IO_new_file_underflow
  #0  __GI___libc_read                                   <- and blocks here
```

The remaining threads are Boehm markers in `GC_wait_marker` — bystanders.

## How it shows up in CI

`src/lisp/regression-tests/interrupt.lisp`'s `INPUT-INTERRUPTIBLE` starts a thread that calls
`(read)`. Whenever the runner's stdin genuinely blocks — rather than hitting EOF on `/dev/null` —
the suite runs to completion and then never exits. Two PR jobs were killed at GitHub's **6-hour**
job limit this way (`clasp/ubuntu-latest/bytecode/no/no`, 6h00m15s each), reported as **cancelled**
rather than failed, with `iclasp` left as an orphan process. That reads as infrastructure flakiness,
so it has been retried rather than investigated.

## Reproduction

Deterministic, and needs no Lisp at all — a 14-line C program:

```c
#include <stdio.h>
#include <stdlib.h>
#include <pthread.h>
#include <unistd.h>
static void *reader(void *arg){ char b[16]; fread(b,1,sizeof b,stdin); return 0; }
int main(int argc, char **argv){
  pthread_t t; pthread_create(&t, 0, reader, 0);
  sleep(1);                                    /* let it block inside fread */
  if (argv[1][0] == 'e') exit(0);              /* hangs  */
  _Exit(0);                                    /* clean  */
}
```
```sh
mkfifo /tmp/c.fifo; ( setsid sleep 60 > /tmp/c.fifo 2>/dev/null </dev/null & )
timeout 10 ./exitdl exit  < /tmp/c.fifo ; echo $?   # 124  (hung)
timeout 10 ./exitdl _Exit < /tmp/c.fifo ; echo $?   # 0    (clean)
```

In Clasp, with stdin on such a fifo:
```lisp
(mp:process-run-function 'blocked (lambda () (read)))
(sleep 1)
(core:quit 0)          ; never returns
```
`mp:process-cancel` is **not** involved — the hang reproduces with no cancel at all, and 8/8
cancel+join trials pass.

## The fix

Keep a registry of the `FILE*`s clasp opens, hooked into `safe_fopen`, `safe_fdopen` and
`safe_fclose`, and flush it explicitly at exit:

```c
for (FILE* f : snapshot)          /* registry + stdout/stderr */
  if (f && ftrylockfile(f) == 0) { fflush(f); funlockfile(f); }
_exit(exitValue);                 /* skip _IO_cleanup entirely */
```

`ftrylockfile` is non-blocking, so a stream another thread is wedged inside is **skipped**, not
waited on -- and unlike `_IO_flush_all` the walk does not stop there, so everything else is still
flushed. This flushes strictly more than `exit()` managed before.

The registry lives in **function-local statics**: `safe_fopen` can run before file-scope statics of
other translation units are constructed, and a file-scope version of this produced a
non-deterministic crash (2 of 4 full-suite runs) that a 4-run unpatched control did not reproduce.

`ftrylockfile` is POSIX, not a GNU extension. Darwin returns from `core__exit` through a separate
branch and is unchanged; the registry itself is platform independent.

## Verification

**x86-64 Linux, clang-18, boehmprecise**

- all five reproductions exit 0 (previously 124 / 6h timeout)
- a file stream written without `finish-output` reaches disk **with a wedged reader present**, and
  also when the wedged stream is *newer* than it -- the case a plain list walk cannot reach
- `TEST_SUITES=mp,interrupt` -> 52 successes, 0 failures, `INPUT-INTERRUPTIBLE` passes
- **four consecutive full suites: 1997 successes each, 0 crashes**, same five expected failures as
  baseline (`SBCL-CROSS-COMPILE-4`, `INCLUDE-LEVEL-2B`, `INCLUDE-LEVEL-3`, `TYPES-CLASSES-10`,
  `WEAK-KEY-OR-VALUE-WEAKNESS`)
- **four-run unpatched control on the same box: 0 crashes, 1997 each** -- the patched and unpatched
  arms match

**macOS arm64, LLVM 22, boehmprecise**: clean build (the registry's first compile on Darwin), full
suite 1997 successes. The exit change itself compiles out there, so this verifies the registry is
portable and costs nothing, not the deadlock fix.
