### PR TITLE
Make MP:CAS on an SVREF place actually atomic

### DIFF
--- a/src/core/array.cc
+++ b/src/core/array.cc
@@ -552,18 +552,36 @@ CL_DEFUN T_sp cl__aref(Array_sp array, Vaslist_sp vargs) {
   return array->rowMajorAref(rowMajorIndex);
 }
 
-// Big evil FIXME: These are functions are basically backup for when the
-// compiler can't inline an atomic access. BUT: They aren't actually atomic.
-// This is difficult to fix as the underlying GCArrays are actually not atomic.
-// Perhaps C++20's atomic_ref could help in the future?
-// And a bit of a KLUDGE: These ignore the atomic order, since figuring that
-// out at runtime seems a little silly.
+// These functions are the backup for when the compiler can't inline an atomic access,
+// e.g. in bytecode or interpreted code. A general array stores one tagged word per
+// element, so the atomic builtins can operate on that word in place; specialized arrays
+// have no such word and are handled by the ordinary accessors instead.
+// A bit of a KLUDGE: These ignore the atomic order and always use the strongest one,
+// since figuring that out at runtime seems a little silly. That is always valid, just
+// possibly stronger than the caller asked for. Compare core__car_atomic in cons.cc.
+
+// A libatomic call would take a lock inside the swap, so fail the build instead.
+static_assert(__atomic_always_lock_free(sizeof(T_O*), 0), "Tagged words must swap lock-free");
+
+// Address of the tagged word holding element ROWMAJORINDEX of ARRAY, or NULL when ARRAY's
+// elements are not general objects. Handles displacement via asAbstractSimpleVectorRange.
+static T_O** generalArrayElementAddress(Array_sp array, size_t rowMajorIndex) {
+  AbstractSimpleVector_sp sv;
+  size_t start, end;
+  array->asAbstractSimpleVectorRange(sv, start, end);
+  unlikely_if(!gc::IsA<SimpleVector_sp>(sv)) { return NULL; }
+  return &((*gc::As_unsafe<SimpleVector_sp>(sv))[start + rowMajorIndex].theObject);
+}
+
 CL_LISPIFY_NAME("core:atomic-aref");
 CL_LAMBDA(order array core:&va-rest core::indices);
 DOCGROUP(clasp);
 CL_DEFUN T_sp core__atomic_aref(T_sp order, Array_sp array, Vaslist_sp vargs) {
   (void)order; // ignore
-  return cl__aref(array, vargs);
+  cl_index rowMajorIndex = array->arrayRowMajorIndex(vargs);
+  T_O** slot = generalArrayElementAddress(array, rowMajorIndex);
+  unlikely_if(!slot) { return array->rowMajorAref(rowMajorIndex); }
+  return T_sp((gctools::Tagged)__atomic_load_n(slot, __ATOMIC_SEQ_CST));
 }
 
 CL_LISPIFY_NAME("core:atomic-aref");
@@ -571,17 +589,27 @@ CL_LAMBDA(value order array core:&va-rest core::indices);
 DOCGROUP(clasp);
 CL_DEFUN_SETF T_sp core__atomic_aset(T_sp value, T_sp order, Array_sp array, Vaslist_sp indices) {
   (void)order; // ignore
-  return core__aset(value, array, indices);
+  cl_index rowMajorIndex = array->arrayRowMajorIndex(indices);
+  T_O** slot = generalArrayElementAddress(array, rowMajorIndex);
+  unlikely_if(!slot) {
+    array->rowMajorAset(rowMajorIndex, value);
+    return value;
+  }
+  __atomic_store_n(slot, value.theObject, __ATOMIC_SEQ_CST);
+  return value;
 }
 
 CL_LAMBDA(order old value array core:&va-rest core::indices);
 DOCGROUP(clasp);
 CL_DEFUN T_sp core__acas(T_sp order, T_sp cmp, T_sp nvalue, Array_sp array, Vaslist_sp indices) {
   (void)order; // ignore
-  T_sp old = cl__aref(array, indices);
-  if (cmp == old)
-    core__aset(nvalue, array, indices);
-  return old;
+  T_O** slot = generalArrayElementAddress(array, array->arrayRowMajorIndex(indices));
+  unlikely_if(!slot) { TYPE_ERROR(array, core::lisp_createList(cl::_sym_array, cl::_sym_T_O)); }
+  // On failure the builtin overwrites EXPECTED with the value it actually saw, so EXPECTED
+  // is the prior value of the slot either way -- which is exactly what MP:CAS returns.
+  T_O* expected = cmp.theObject;
+  __atomic_compare_exchange_n(slot, &expected, nvalue.theObject, false, __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);
+  return T_sp((gctools::Tagged)expected);
 }
 
 CL_LAMBDA(array core:&va-rest indices);

--- a/src/lisp/regression-tests/mp.lisp
+++ b/src/lisp/regression-tests/mp.lisp
@@ -253,3 +253,63 @@
         (spam-processes nthreads (lambda () (mp:atomic-push nil (car place))))
         (car place))
       ((nil nil nil nil nil nil nil)))
+
+;;; MP:CAS on an SVREF place must arbitrate between threads, not merely compile.
+;;; CORE:ACAS is reached through FDEFINITION in the "out-of-line" variants so that the
+;;; runtime implementation is exercised even in a build where the compiler inlines a
+;;; cmpxchg for the MP:CAS form instead.
+
+(defun cas-svref-contention (casser nthreads per-thread)
+  (let ((v (vector 0)))
+    (spam-processes nthreads
+                    (lambda ()
+                      (dotimes (i per-thread)
+                        (loop for old = (svref v 0)
+                              until (eql old (funcall casser v old (1+ old)))))))
+    (svref v 0)))
+
+(defun cas-svref-inline (v old new) (mp:cas (svref v 0) old new))
+
+(defun cas-svref-out-of-line (v old new)
+  (funcall (fdefinition 'core::acas) :sequentially-consistent old new v 0))
+
+(test cas-svref-single-thread
+      (cas-svref-contention #'cas-svref-inline 1 10000)
+      (10000))
+
+(test cas-svref-contended
+      (cas-svref-contention #'cas-svref-inline 4 10000)
+      (40000))
+
+(test cas-svref-out-of-line-contended
+      (cas-svref-contention #'cas-svref-out-of-line 4 10000)
+      (40000))
+
+(test cas-svref-semantics
+      (let ((v (vector 5)))
+        (list (mp:cas (svref v 0) 5 6) (svref v 0)
+              (mp:cas (svref v 0) 99 7) (svref v 0)))
+      ((5 6 6 6)))
+
+(test cas-svref-out-of-line-semantics
+      (let ((v (vector 5)))
+        (list (cas-svref-out-of-line v 5 6) (svref v 0)
+              (cas-svref-out-of-line v 99 7) (svref v 0)))
+      ((5 6 6 6)))
+
+;;; The out-of-line CAS must still honour displacement.
+(test cas-displaced-general-array
+      (let* ((base (vector 0 0 0 0))
+             (d (make-array 2 :displaced-to base :displaced-index-offset 1)))
+        (list (funcall (fdefinition 'core::acas) :sequentially-consistent 0 'x d 1)
+              (coerce base 'list)))
+      ((0 (0 0 x 0))))
+
+;;; A specialized array has no tagged word to swap, so it is refused rather than
+;;; silently swapped non-atomically.
+(test-expect-error cas-specialized-array
+                   (funcall (fdefinition 'core::acas) :sequentially-consistent 0 1
+                            (make-array 1 :element-type 'double-float
+                                          :initial-element 0d0)
+                            0)
+                   :type type-error)


### PR DESCRIPTION
`MP:CAS` on an `SVREF` place compiles, is correct single-threaded, and does not arbitrate
between threads. Four threads running 50000 compare-and-swap increments each land
171000-182000 of 200000 — 9-15% of the updates silently lost, on every run.

This is worse than a refusal, because every single-threaded test passes. `SVREF` has been
the documented place that works for portable compare-and-swap, so code built on that
reading is silently unsound.

## Why

The `SVREF` atomic expander (`src/lisp/kernel/lsp/atomics.lisp:349-367`) emits `CORE:ACAS`,
which has two implementations:

* **Native** — `bir-to-bmir.lisp:426` transforms the call to the `CORE:ACAS` primop and
  `primop.lisp:679` lowers it to an LLVM `cmpxchg`. Genuinely atomic.
* **C++ fallback** `core__acas` (`src/core/array.cc`) — a plain `aref`, an `EQ` compare and
  a plain `aset`, with the order discarded. Its own comment said so: *"BUT: They aren't
  actually atomic."*

The fallback is not a corner case. The bytecode VM has no atomic opcode at all, so besides
every `--build-mode=bytecode` build, `EVAL`, the REPL and `LOAD` of a source file reach it
in **every** build. `CORE:ATOMIC-AREF` and its `SETF` had the identical defect.

Measured in one process before the change:

| arm | result |
|---|---|
| interpreted | LOST 8366 / 80000 |
| bytecode | LOST 12458 / 80000 |
| native (asserted `SIMPLE-CORE-FUN`) | exact |

## The fix

A simple vector stores elements in a plain `GCArray_moveable<T_sp>`, so unlike `Rack` —
which stores `GCArray_atomic<T_sp>`, and is why every CLOS-side casser already arbitrated —
there is no `std::atomic` to call. The three entry points now operate on the element's
tagged word with the atomic builtins.

This needs no GC cooperation: Clasp has no write barrier of any kind, no GC variant
relocates objects (Boehm is mark-sweep with interior pointers; the MMTk variant runs Immix
with copying compiled out), the only relocating operation is snapshot save and it runs with
the world stopped, and `gc_yield` is called only on function entry so no safepoint can fall
inside the swap. It is also precisely what the native path already emits — verified by
disassembly: one inline `casal`, and `llvm-nm -u` shows no `__atomic_*` libcall.

All three resolve the address through `asAbstractSimpleVectorRange`, so displaced and
fill-pointer general arrays keep working, and the row-major index is computed once instead
of twice.

## Behaviour change worth reviewing

`CORE:ACAS` on storage that is not a simple vector of `T` now signals a `TYPE-ERROR` of
expected type `(ARRAY T)`, where it previously performed a non-atomic read-compare-write
that could not have succeeded anyway — a freshly boxed element is never `EQ` to the
expected value.

The refusal is deliberately asymmetric and mirrors the native path's own asymmetry:
`bir-to-bmir.lisp` transforms `CORE:ACAS` only for `SIMPLE-VECTOR`, so refusing other
storage makes the two implementations agree on their domain; but it transforms
`CORE:ATOMIC-AREF` for `single-float`, `double-float`, `base-char` and `character` arrays
too, so making the reader and writer refuse those would have made the same source succeed
natively and error in bytecode. They keep their existing behaviour instead.

A `static_assert` requires the tagged word to swap lock-free, so a target without an
8-byte lock-free CAS fails the build rather than quietly emitting a libatomic call that
takes a lock inside the swap window.

## Tests

Seven tests in the existing `mp` suite. The "out-of-line" variants reach `CORE:ACAS`
through `FDEFINITION` so the runtime implementation is exercised even where the compiler
would inline a `cmpxchg` instead. They cover contention, the single-threaded and
single-swap controls, displacement, and the refusal.

They are a real gate: against the pre-fix binary 3 of the 7 fail; after the fix all 7 pass.
The 4 that pass pre-fix are the controls, which must keep passing — a "fix" that made every
swap succeed, or every swap refuse, would satisfy the arithmetic and fail those.

## Verification

macOS arm64, `boehmprecise`, plain Clasp (no extensions), built from this branch's parent
plus this commit:

* Reproducer: 5/5 runs exit 0 at exactly 200000/200000.
* All four arms exact at 4x50000: interpreted, bytecode, native, and the direct
  out-of-line call.
* Regression suite: **2004 successes** = 1997 baseline + these 7 tests; failures are exactly
  the 5 known ones by name (`SBCL-CROSS-COMPILE-4`, `INCLUDE-LEVEL-2B`, `INCLUDE-LEVEL-3`,
  `WEAK-KEY-OR-VALUE-WEAKNESS`, `TYPES-CLASSES-10`).
* ANSI: 21936 tests, 27 failures, **0 unexpected**.
* `clang-format` clean.

Reported as dg1sbg/clasp#1, which carries the standalone reproducer.
