### PR TITLE
Add compare-and-swap on foreign memory: %CAS-MEM-UINT32 and -UINT64

### DIFF
--- a/include/clasp/core/fli.h
+++ b/include/clasp/core/fli.h
@@ -451,6 +451,22 @@ DOCGROUP(clasp)
 CL_DEFUN core::T_sp PERCENTmem_set_unsigned_char(core::Integer_sp address, core::T_sp value);
 SYMBOL_EXPORT_SC_(Clasp_ffi_pkg, PERCENTmem_set_unsigned_char);
 
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// FOREIGN MEMORY DIRECT ACCESS - COMPARE AND SWAP
+// ---------------------------------------------------------------------------
+// MEM-CAS
+
+CL_DOCSTRING(R"dx(Atomically store DESIRED at ADDRESS if the word there is EXPECTED. Returns the prior word, so the swap happened iff that value is = to EXPECTED. ADDRESS must be aligned for the width.)dx");
+DOCGROUP(clasp)
+CL_DEFUN core::T_sp PERCENTcas_mem_uint32(core::Integer_sp address, core::T_sp expected, core::T_sp desired);
+SYMBOL_EXPORT_SC_(Clasp_ffi_pkg, PERCENTcas_mem_uint32);
+
+CL_DOCSTRING(R"dx(Atomically store DESIRED at ADDRESS if the word there is EXPECTED. Returns the prior word, so the swap happened iff that value is = to EXPECTED. ADDRESS must be aligned for the width.)dx");
+DOCGROUP(clasp)
+CL_DEFUN core::T_sp PERCENTcas_mem_uint64(core::Integer_sp address, core::T_sp expected, core::T_sp desired);
+SYMBOL_EXPORT_SC_(Clasp_ffi_pkg, PERCENTcas_mem_uint64);
+
 void* clasp_to_void_pointer(ForeignData_sp sp_lisp_value);
 
 // ---------------------------------------------------------------------------

--- a/src/core/fli.cc
+++ b/src/core/fli.cc
@@ -1146,6 +1146,41 @@ core::T_sp PERCENTmem_set_unsigned_char(core::Integer_sp address, core::T_sp val
   return mk_fixnum_uint8(tmp);
 }
 
+// ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// MEM-CAS
+// ---------------------------------------------------------------------------
+
+// A libatomic call would take a lock inside the swap, so fail the build instead.
+static_assert(__atomic_always_lock_free(sizeof(uint32_t), 0) && __atomic_always_lock_free(sizeof(uint64_t), 0),
+              "Foreign words must swap lock-free");
+
+template <typename T> inline T cas_mem(uintptr_t address, T expected, T desired) {
+  if (address % alignof(T) != 0) {
+    SIMPLE_ERROR("Address {} is not {}-byte aligned, so it cannot be swapped atomically", address, alignof(T));
+  }
+  // The builtin overwrites EXPECTED with the word it saw, so EXPECTED is the prior word either way.
+  __atomic_compare_exchange_n(reinterpret_cast<T*>(address), &expected, desired, false, __ATOMIC_SEQ_CST,
+                              __ATOMIC_SEQ_CST);
+  return expected;
+}
+
+core::T_sp PERCENTcas_mem_uint32(core::Integer_sp address, core::T_sp expected, core::T_sp desired) {
+  uint32_t prior =
+      cas_mem<uint32_t>(core::clasp_to_uintptr_t(address), translate::make_from_object<uint32_t>(expected),
+                        translate::make_from_object<uint32_t>(desired));
+  DEBUG_PRINT(BF("%s (%s:%d) | prior = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % prior);
+  return mk_fixnum_uint32(prior);
+}
+
+core::T_sp PERCENTcas_mem_uint64(core::Integer_sp address, core::T_sp expected, core::T_sp desired) {
+  uint64_t prior =
+      cas_mem<uint64_t>(core::clasp_to_uintptr_t(address), translate::make_from_object<uint64_t>(expected),
+                        translate::make_from_object<uint64_t>(desired));
+  DEBUG_PRINT(BF("%s (%s:%d) | prior = %d\n.") % __FUNCTION__ % __FILE__ % __LINE__ % prior);
+  return mk_integer_uint64(prior);
+}
+
 /*const struct section_64* get_section_data(const char* segment_name, const char* section_name) {
   const struct section_64* p_section = (struct section_64*)NULL;
 

--- a/src/lisp/regression-tests/mp.lisp
+++ b/src/lisp/regression-tests/mp.lisp
@@ -253,3 +253,66 @@
         (spam-processes nthreads (lambda () (mp:atomic-push nil (car place))))
         (car place))
       ((nil nil nil nil nil nil nil)))
+
+;;; MP:CAS has no expansion for an FFI place (clasp-developers/clasp#1835), so a word of
+;;; foreign memory is swapped with the CLASP-FFI:%CAS-MEM-* functions.
+
+(defmacro with-foreign-word ((address size) &body body)
+  (let ((fd (gensym "FD")))
+    `(let* ((,fd (clasp-ffi:%foreign-alloc ,size))
+            (,address (clasp-ffi:%foreign-data-address ,fd)))
+       (unwind-protect (progn ,@body)
+         (clasp-ffi:%foreign-free ,fd)))))
+
+(defun cas-mem-contention (setter reader casser nthreads per-thread)
+  (with-foreign-word (a 16)
+    (funcall setter a 0)
+    (spam-processes nthreads
+                    (lambda ()
+                      (dotimes (i per-thread)
+                        (loop for old = (funcall reader a)
+                              until (eql old (funcall casser a old (1+ old)))))))
+    (funcall reader a)))
+
+(test cas-mem-uint32-semantics
+      (with-foreign-word (a 8)
+        (clasp-ffi:%mem-set-uint32 a 5)
+        (list (clasp-ffi:%cas-mem-uint32 a 5 6) (clasp-ffi:%mem-ref-uint32 a)
+              (clasp-ffi:%cas-mem-uint32 a 99 7) (clasp-ffi:%mem-ref-uint32 a)))
+      ((5 6 6 6)))
+
+(test cas-mem-uint64-semantics
+      (with-foreign-word (a 8)
+        (clasp-ffi:%mem-set-uint64 a #x1234567800000005)
+        (list (clasp-ffi:%cas-mem-uint64 a #x1234567800000005 #x1234567800000006)
+              (clasp-ffi:%mem-ref-uint64 a)
+              (clasp-ffi:%cas-mem-uint64 a 99 7)
+              (clasp-ffi:%mem-ref-uint64 a)))
+      ((#x1234567800000005 #x1234567800000006 #x1234567800000006 #x1234567800000006)))
+
+(test cas-mem-uint32-contended
+      (cas-mem-contention #'clasp-ffi:%mem-set-uint32 #'clasp-ffi:%mem-ref-uint32
+                          #'clasp-ffi:%cas-mem-uint32 4 10000)
+      (40000))
+
+(test cas-mem-uint64-contended
+      (cas-mem-contention #'clasp-ffi:%mem-set-uint64 #'clasp-ffi:%mem-ref-uint64
+                          #'clasp-ffi:%cas-mem-uint64 4 10000)
+      (40000))
+
+;;; A 32-bit swap must leave the words on either side of it alone.
+(test cas-mem-uint32-width
+      (with-foreign-word (a 12)
+        (clasp-ffi:%mem-set-uint32 a #xaaaaaaaa)
+        (clasp-ffi:%mem-set-uint32 (+ a 4) 0)
+        (clasp-ffi:%mem-set-uint32 (+ a 8) #xbbbbbbbb)
+        (clasp-ffi:%cas-mem-uint32 (+ a 4) 0 #xffffffff)
+        (list (clasp-ffi:%mem-ref-uint32 a) (clasp-ffi:%mem-ref-uint32 (+ a 4))
+              (clasp-ffi:%mem-ref-uint32 (+ a 8))))
+      ((#xaaaaaaaa #xffffffff #xbbbbbbbb)))
+
+;;; An unaligned word cannot be swapped atomically, so it is refused rather than swapped anyway.
+(test-expect-error cas-mem-unaligned
+                   (with-foreign-word (a 16)
+                     (clasp-ffi:%cas-mem-uint32 (+ a 1) 0 1))
+                   :type program-error)


### PR DESCRIPTION
Fixes #1835.

`MP:CAS` signals `MP:NOT-ATOMIC` for every FFI accessor, and the specialised-array
workaround does not exist either (`CORE:ACAS` is transformed only for element type `T`
and rank 1, `cleavir/primop.lisp:673`), so there is currently no way to compare-and-swap
a word of foreign memory on Clasp.

This adds `CLASP-FFI:%CAS-MEM-UINT32` and `CLASP-FFI:%CAS-MEM-UINT64`.

### Why typed functions rather than an `MP:CAS` place

As noted in the issue, `MP:CAS` matches with `EQ` while the FFI accessors box their
results, so a `uint64` above the fixnum range would compare two distinct bignums and
never swap; and `%MEM-REF` dispatches on a runtime type keyword, while choosing a swap
width needs the C type at compile time. A typed function sidesteps both. `MP:CAS` support
for the constant-type case can be layered on top later — I am happy to follow up with it
if you would prefer that shape.

Deliberately a `CL_DEFUN` rather than a new `cc-blir:cas` producer: the bytecode VM has no
atomic opcode, so a compiler-only route would leave `EVAL`, the REPL and every
`--build-mode=bytecode` build on a different path.

### Contract

Returns the **prior word**, so the swap happened iff that value is `=` to the expected one
— the same contract `MP:CAS` has, and the same as SBCL's
`(sb-ext:cas (sb-sys:sap-ref-32 sap off) old new)`. It falls out of
`__atomic_compare_exchange_n`, which overwrites `expected` with the word it saw.

An address that is not aligned for its width is refused with an error rather than swapped
non-atomically, and a `static_assert` fails the build if either width would need a
libatomic lock. Compiler builtins rather than `std::atomic_ref` because Darwin builds
`-stdlib=libc++`, which only gained `atomic_ref` in LLVM 19.

### Tests

Six, in `regression-tests/mp.lisp`: semantics for both widths, 4 threads × 10000
CAS-increments per width, a neighbouring-word check that catches a wrong swap width, and
the unaligned refusal.

Verified on macOS arm64, boehmprecise, native: full suite **2013** successes against a
**2007** baseline taken on this same base immediately before the change — +6 is exactly
the new tests, with the same 5 expected failures and no unexpected failures.

Cross-process check outside the suite, 4 processes × 50000 increments of one word of POSIX
shared memory behind a start barrier: **200000/200000** with the CAS, **114669/200000**
with a plain read-modify-write control.
