### PR TITLE
Make loops cancellable: poll interrupts on back edges, and add MP:WITH-TIMEOUT

### DIFF
--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -217,6 +217,22 @@ static unsigned char* long_dispatch(VirtualMachine&, unsigned char*, MultipleVal
                                     core::T_O**, core::T_O**, size_t, core::T_O**, uint8_t);
 
 SYMBOL_EXPORT_SC_(KeywordPkg, name);
+
+// Poll interrupts on backward branches so loops of pure opcodes stay cancellable.
+static inline unsigned char* vm_branch(VirtualMachine& vm, ThreadLocalState* thread, unsigned char* pc, core::T_O** sp,
+                                       int32_t rel) {
+  pc += rel;
+  if (rel < 0) {
+    core::Cons_sp head = thread->_PendingInterruptsHead.load(std::memory_order_acquire);
+    if (thread->pending_signals_p() || (static_cast<bool>(head) && head->cdr().notnilp())) {
+      // The handler can cons or unwind, so the GC must see the current frame.
+      vm._pc = pc;
+      vm._stackPointer = sp;
+      gctools::handle_all_queued_interrupts();
+    }
+  }
+  return pc;
+}
 #ifdef DEBUG_VIRTUAL_MACHINE
 __attribute__((optnone))
 #endif
@@ -564,19 +580,19 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
     case vm_code::jump_8: {
       int8_t rel = *(pc + 1);
       DBG_VM1("jump %" PRId8 "\n", rel);
-      pc += rel;
+      pc = vm_branch(vm, thread, pc, sp, rel);
       break;
     }
     case vm_code::jump_16: {
       int16_t rel = read_s16(pc + 1);
       DBG_VM("jump %" PRId16 "\n", rel);
-      pc += rel;
+      pc = vm_branch(vm, thread, pc, sp, rel);
       break;
     }
     case vm_code::jump_24: {
       int32_t rel = read_label(pc, 3);
       DBG_VM("jump %" PRId32 "\n", rel);
-      pc += rel;
+      pc = vm_branch(vm, thread, pc, sp, rel);
       break;
     }
     case vm_code::jump_if_8: {
@@ -585,7 +601,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
       T_sp tval((gctools::Tagged)vm.pop(sp));
       VM_RECORD_PLAYBACK(tval.raw_(), "vm_jump_if_8");
       if (tval.notnilp())
-        pc += rel;
+        pc = vm_branch(vm, thread, pc, sp, rel);
       else
         pc += 2;
       break;
@@ -595,7 +611,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
       DBG_VM("jump-if %" PRId16 "\n", rel);
       T_sp tval((gctools::Tagged)vm.pop(sp));
       if (tval.notnilp())
-        pc += rel;
+        pc = vm_branch(vm, thread, pc, sp, rel);
       else
         pc += 3;
       break;
@@ -605,7 +621,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
       DBG_VM("jump-if %" PRId32 "\n", rel);
       T_sp tval((gctools::Tagged)vm.pop(sp));
       if (tval.notnilp())
-        pc += rel;
+        pc = vm_branch(vm, thread, pc, sp, rel);
       else
         pc += 4;
       break;
@@ -618,7 +634,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
         pc += 2;
       } else {
         vm.push(sp, tval.raw_());
-        pc += rel;
+        pc = vm_branch(vm, thread, pc, sp, rel);
       }
       break;
     }
@@ -630,7 +646,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
         pc += 3;
       } else {
         vm.push(sp, tval.raw_());
-        pc += rel;
+        pc = vm_branch(vm, thread, pc, sp, rel);
       }
       break;
     }

--- a/src/core/lispStream.cc
+++ b/src/core/lispStream.cc
@@ -1353,7 +1353,9 @@ CL_DEFUN T_mv core__read_fd(int filedes, SimpleBaseString_sp buffer) {
   size_t buffer_length = cl__length(buffer);
   unsigned char* buffer_data = &(*buffer)[0];
   while (1) {
-    int num = read(filedes, buffer_data, buffer_length);
+    // Park: read() blocks until data arrives. Safe to hold BUFFER_DATA across it
+    // because no GC variant relocates (NON_MOVING_GC).
+    int num = BEGIN_PARK { return (int)read(filedes, buffer_data, buffer_length); } END_PARK;
     if (!(num < 0 && errno == EINTR)) {
       if (num < 0) {
         return Values(make_fixnum(num), make_fixnum(errno));

--- a/src/core/unixfsys.cc
+++ b/src/core/unixfsys.cc
@@ -37,6 +37,7 @@ THE SOFTWARE.
 */
 
 #include <clasp/core/foundation.h>
+#include <clasp/gctools/park.h>
 
 #include <string.h>
 #include <stdio.h>
@@ -294,7 +295,8 @@ The status can be passed to //core:wifexited// and //core:wifsignaled//. )")
 DOCGROUP(clasp);
 CL_DEFUN T_mv core__wait() {
   int status;
-  pid_t p = wait(&status);
+  // Park: wait() blocks until a child exits, which may be never.
+  pid_t p = BEGIN_PARK { return wait(&status); } END_PARK;
   return Values(make_fixnum(p), make_fixnum(status));
 };
 
@@ -1707,7 +1709,9 @@ DOCGROUP(clasp);
 CL_DEFUN T_mv ext__system(String_sp cmd) {
   ASSERT(cl__stringp(cmd));
   string command = cmd->get_std_string();
-  int ret = system(command.c_str());
+  // Park: system() blocks for an unbounded time, so the thread must be GC-safe
+  // and marked blocking, which is what lets an interrupt wake it with SIGCONT.
+  int ret = BEGIN_PARK { return system(command.c_str()); } END_PARK;
   if (ret == 0) {
     return Values(core::make_fixnum(0));
   } else {
@@ -1828,7 +1832,7 @@ CL_DEFUN T_mv ext__vfork_execvp(List_sp call_and_arguments, T_sp return_stream) 
       while (b_done == false) {
         errno = 0;
 
-        wait_ret = wait(&status);
+        wait_ret = BEGIN_PARK { return wait(&status); } END_PARK;
 
         if (WIFEXITED(status)) {
           child_exit_status = WEXITSTATUS(status);
@@ -1946,7 +1950,7 @@ CL_DEFUN T_mv ext__fork_execvp(List_sp call_and_arguments, T_sp return_stream) {
     } else {
       // Parent
       int status;
-      pid_t wait_ret = wait(&status);
+      pid_t wait_ret = BEGIN_PARK { return wait(&status); } END_PARK;
       // Clean up args
       for (int i(0); i < execvp_args.size() - 1; ++i)
         free((void*)execvp_args[i]);
@@ -2003,7 +2007,10 @@ CL_DEFUN T_mv core__select(int nfds, FdSet_sp readfds, FdSet_sp writefds, FdSet_
   struct timeval timeout;
   timeout.tv_sec = seconds;
   timeout.tv_usec = microseconds;
-  int num = select(nfds, &readfds->_fd_set, &writefds->_fd_set, &errorfds->_fd_set, &timeout);
+  // Park: select() blocks for up to the caller's timeout.
+  int num = BEGIN_PARK {
+    return select(nfds, &readfds->_fd_set, &writefds->_fd_set, &errorfds->_fd_set, &timeout);
+  } END_PARK;
   if (num < 0) {
     return Values(make_fixnum(num), make_fixnum(errno));
   }

--- a/src/lisp/kernel/cleavir/translate.lisp
+++ b/src/lisp/kernel/cleavir/translate.lisp
@@ -255,12 +255,44 @@ function-or-placeholder - the llvm function or a placeholder for
                                          (inst-source instruction)
                                          999902))
     (call-next-method)))
+(defvar *laid-out-iblocks*)
+(defvar *safepoint-counter* nil)
+
+;; Iblocks are laid out in forward flow order, so a branch to one already laid
+;; out is a back edge - the native counterpart of the VM's negative jump offset.
+(defun back-edge-p (instruction)
+  (and (boundp '*laid-out-iblocks*)
+       (loop for succ in (bir:next instruction)
+             thereis (gethash succ *laid-out-iblocks*))))
+
+;; cc_safepoint is an out-of-line unwinding call, so polling every back edge
+;; costs ~3x on a tight loop; sample one edge in +safepoint-sample+ instead.
+(defparameter +safepoint-sample+ 255)
+
+(defun emit-back-edge-safepoint ()
+  (let* ((n (cmp:irc-typed-load cmp:%size_t% *safepoint-counter*))
+         (n1 (cmp:irc-add n (cmp:jit-constant-size_t 1)))
+         (poll (cmp:irc-basic-block-create "safepoint-poll"))
+         (cont (cmp:irc-basic-block-create "safepoint-cont")))
+    (cmp:irc-store n1 *safepoint-counter*)
+    (cmp:irc-cond-br (cmp:irc-icmp-eq
+                      (cmp:irc-and n1 (cmp:jit-constant-size_t +safepoint-sample+))
+                      (cmp:jit-constant-size_t 0))
+                     poll cont)
+    (cmp:irc-begin-block poll)
+    (%intrinsic-invoke-if-landing-pad-or-call "cc_safepoint" ())
+    (cmp:irc-br cont)
+    (cmp:irc-begin-block cont)))
+
 (defmethod translate-terminator :around
     ((instruction bir:instruction) abi next)
   (declare (ignore abi next))
   (cmp:with-debug-info-source-position ((ensure-origin
                                          (inst-source instruction)
                                          999903))
+    ;; Poll interrupts on back edges so native loops stay cancellable.
+    (when (and *safepoint-counter* (back-edge-p instruction))
+      (emit-back-edge-safepoint))
     (call-next-method)))
 
 (defmethod translate-terminator ((instruction bir:unreachable)
@@ -1876,6 +1908,8 @@ function-or-placeholder - the llvm function or a placeholder for
               do (setf (gethash phi *datum-values*) dat))))))
 
 (defun layout-iblock (iblock abi)
+  (when (boundp '*laid-out-iblocks*)
+    (setf (gethash iblock *laid-out-iblocks*) t))
   (cmp:irc-begin-block (iblock-tag iblock))
   (cmp:with-landing-pad (maybe-entry-landing-pad
                          (bir:dynamic-environment iblock) *tags*)
@@ -1991,11 +2025,18 @@ function-or-placeholder - the llvm function or a placeholder for
                                          (arguments llvm-function-info))
                   when lexical ; skip unused fixed
                     do (setf (gethash lexical *datum-values*) arg)))
-          ;; Branch to the start block.
-          (cmp:irc-br (iblock-tag (bir:start ir)))
-          ;; Lay out blocks.
-          (bir:do-iblocks (ib ir)
-            (layout-iblock ib abi))))))
+          ;; Counter for sampled back-edge safepoints; must live in the alloca block.
+          (let ((*safepoint-counter*
+                  (cmp:with-irbuilder (cmp:*irbuilder-function-alloca*)
+                    (let ((c (cmp:alloca-size_t "safepoint-counter")))
+                      (cmp:irc-store (cmp:jit-constant-size_t 0) c)
+                      c)))
+                (*laid-out-iblocks* (make-hash-table :test #'eq)))
+            ;; Branch to the start block.
+            (cmp:irc-br (iblock-tag (bir:start ir)))
+            ;; Lay out blocks.
+            (bir:do-iblocks (ib ir)
+              (layout-iblock ib abi)))))))
   ;; Finish up by jumping from the entry block to the body block
   (cmp:with-irbuilder (cmp:*irbuilder-function-alloca*)
     (cmp:irc-br body-block))

--- a/src/lisp/kernel/lsp/mp-package.lisp
+++ b/src/lisp/kernel/lsp/mp-package.lisp
@@ -21,5 +21,7 @@
           signal-pending-interrupts raise
           without-interrupts with-interrupts with-local-interrupts
           with-restored-interrupts allow-with-interrupts interruptiblep
+          ;; deadlines
+          timeout timeout-seconds with-timeout call-with-timeout
           ))
 ) ; eval-when

--- a/src/lisp/kernel/lsp/mp.lisp
+++ b/src/lisp/kernel/lsp/mp.lisp
@@ -171,13 +171,17 @@ If DATUM is provided, it and ARGUMENTS designate a condition of default type SIM
 #+threads
 (defun call-with-timeout (seconds function)
   "Call FUNCTION, signalling TIMEOUT in this process if it runs longer than SECONDS.
-The timeout is delivered as an interrupt, so it lands at the next safepoint."
+The timeout is delivered as an interrupt, so it lands at the next safepoint. A body
+blocked in a foreign call reaches no safepoint until the call returns, so there the
+expiry is detected on return instead; either way TIMEOUT is signalled inside the
+dynamic extent of the caller, where handlers are still established."
   (let* ((lock (make-lock :name 'with-timeout))
          (cv (make-condition-variable :name 'with-timeout))
          (target *current-process*)
          (deadline (+ (get-internal-real-time)
                       (round (* seconds internal-time-units-per-second))))
          (donep nil)
+         (firedp nil)
          (watchdog
            (process-run-function
             'with-timeout-watchdog
@@ -190,14 +194,20 @@ The timeout is delivered as an interrupt, so it lands at the next safepoint."
                       while (plusp remaining)
                       do (condition-variable-timedwait cv lock (float remaining 1d0)))
                 (unless donep
+                  (setf firedp t)
                   (interrupt-process
                    target
-                   (lambda () (error 'timeout :seconds seconds)))))))))
-    (unwind-protect (funcall function)
-      (with-lock (lock)
-        (setf donep t)
-        (condition-variable-signal cv))
-      (process-join watchdog))))
+                   ;; Re-check at delivery: an interrupt queued while the body was
+                   ;; in a foreign call arrives after the body has already returned.
+                   (lambda () (unless donep (error 'timeout :seconds seconds))))))))))
+    (let ((values (unwind-protect (multiple-value-list (funcall function))
+                    (with-lock (lock)
+                      (setf donep t)
+                      (condition-variable-signal cv))
+                    (process-join watchdog))))
+      ;; The deadline passed but the interrupt could not land in time.
+      (when firedp (error 'timeout :seconds seconds))
+      (values-list values))))
 
 #+threads
 (defmacro with-timeout ((seconds) &body body)

--- a/src/lisp/kernel/lsp/mp.lisp
+++ b/src/lisp/kernel/lsp/mp.lisp
@@ -158,3 +158,49 @@ If DATUM is provided, it and ARGUMENTS designate a condition of default type SIM
    (if datum
        (core::coerce-to-condition datum arguments 'simple-error 'abort-process)
        nil)))
+
+#+threads
+;; A subtype of ERROR, not just SERIOUS-CONDITION, so HANDLER-CASE on ERROR and
+;; IGNORE-ERRORS catch it; SBCL and bordeaux-threads use SERIOUS-CONDITION.
+(define-condition timeout (error)
+  ((%seconds :initarg :seconds :reader timeout-seconds))
+  (:report (lambda (condition stream)
+             (format stream "Timed out after ~a second~:p."
+                     (timeout-seconds condition)))))
+
+#+threads
+(defun call-with-timeout (seconds function)
+  "Call FUNCTION, signalling TIMEOUT in this process if it runs longer than SECONDS.
+The timeout is delivered as an interrupt, so it lands at the next safepoint."
+  (let* ((lock (make-lock :name 'with-timeout))
+         (cv (make-condition-variable :name 'with-timeout))
+         (target *current-process*)
+         (deadline (+ (get-internal-real-time)
+                      (round (* seconds internal-time-units-per-second))))
+         (donep nil)
+         (watchdog
+           (process-run-function
+            'with-timeout-watchdog
+            (lambda ()
+              (with-lock (lock)
+                ;; Re-check DONEP because a timedwait may return early.
+                (loop until donep
+                      for remaining = (/ (- deadline (get-internal-real-time))
+                                         internal-time-units-per-second)
+                      while (plusp remaining)
+                      do (condition-variable-timedwait cv lock (float remaining 1d0)))
+                (unless donep
+                  (interrupt-process
+                   target
+                   (lambda () (error 'timeout :seconds seconds)))))))))
+    (unwind-protect (funcall function)
+      (with-lock (lock)
+        (setf donep t)
+        (condition-variable-signal cv))
+      (process-join watchdog))))
+
+#+threads
+(defmacro with-timeout ((seconds) &body body)
+  "Execute BODY, signalling MP:TIMEOUT in this process if it has not finished
+within SECONDS."
+  `(call-with-timeout ,seconds (lambda () ,@body)))

--- a/src/lisp/regression-tests/mp.lisp
+++ b/src/lisp/regression-tests/mp.lisp
@@ -297,8 +297,30 @@
                    (mp:with-timeout (0.2) (loop))
                    :type mp:timeout)
 
-;;; The timeout must not fire after the body has already returned.
+;;; The timeout must not fire after the body has already returned. An instant body
+;;; never enqueues an interrupt, so this alone does not cover the race below.
 (test-true with-timeout-no-late-fire
            (progn (mp:with-timeout (0.2) t)
                   (sleep 0.5)
+                  t))
+
+;;; A blocking foreign call must park, so an interrupt can wake it with SIGCONT
+;;; rather than sitting queued until the call returns on its own.
+(test-expect-error with-timeout-blocking-foreign
+                   (mp:with-timeout (0.5) (ext:system "sleep 3"))
+                   :type mp:timeout)
+
+;;; ...and it must be woken PROMPTLY, not merely reported late on return. Three
+;;; seconds of sleep must not elapse; without parking this takes the full 3s.
+(test-true with-timeout-foreign-is-prompt
+           (let ((start (get-internal-real-time)))
+             (ignore-errors (mp:with-timeout (0.5) (ext:system "sleep 3")))
+             (< (/ (- (get-internal-real-time) start)
+                   internal-time-units-per-second)
+                2.0)))
+
+;;; ...and the interrupt queued during that call must not fire afterwards.
+(test-true with-timeout-foreign-no-late-fire
+           (progn (ignore-errors (mp:with-timeout (0.5) (ext:system "sleep 2")))
+                  (sleep 1)
                   t))

--- a/src/lisp/regression-tests/mp.lisp
+++ b/src/lisp/regression-tests/mp.lisp
@@ -254,15 +254,20 @@
         (car place))
       ((nil nil nil nil nil nil nil)))
 
-;;; Returns true if THUNK's process is gone within SECONDS of being killed.
+
+;;; Returns true if THUNK's process is gone within SECONDS of being killed. The
+;;; process must still be running when it is killed: a thunk that dies on its own
+;;; would otherwise look exactly like a cancelled one and pass vacuously.
 (defun cancelled-within-p (thunk seconds)
   (let ((p (mp:process-run-function nil thunk)))
     (loop repeat 200 until (mp:process-active-p p) do (sleep 0.01))
-    (mp:process-kill p)
-    (loop repeat (ceiling seconds 0.01)
-          while (mp:process-active-p p)
-          do (sleep 0.01))
-    (not (mp:process-active-p p))))
+    (and (mp:process-active-p p)
+         (progn
+           (mp:process-kill p)
+           (loop repeat (ceiling seconds 0.01)
+                 while (mp:process-active-p p)
+                 do (sleep 0.01))
+           (not (mp:process-active-p p))))))
 
 ;;; A loop body of pure VM opcodes reaches no function-call safepoint, so it is
 ;;; cancellable only if the interpreter polls interrupts on backward branches.
@@ -334,3 +339,19 @@
              (declare (ignore w))
              (let ((buf (make-string 16 :element-type 'base-char)))
                (cancelled-within-p (lambda () (core:read-fd r buf)) 3))))
+
+;;; A thread blocked in accept(2) must be cancellable. A local socket is used so
+;;; the test needs no port and no network. Verified to answer NO before the
+;;; sockets were parked and YES after, so it is a real discriminator.
+(test-true cancel-blocking-accept
+           (let* ((path (format nil "/tmp/clasp-accept-test-~a.sock" (get-universal-time)))
+                  (sock (make-instance 'sb-bsd-sockets:local-socket :type :stream)))
+             (unwind-protect
+                  (progn (sb-bsd-sockets:socket-bind sock path)
+                         (sb-bsd-sockets:socket-listen sock 1)
+                         (cancelled-within-p
+                          (lambda () (sb-bsd-sockets:socket-accept sock)) 3))
+               (ignore-errors (sb-bsd-sockets:socket-close sock))
+               (ignore-errors (delete-file path)))))
+
+

--- a/src/lisp/regression-tests/mp.lisp
+++ b/src/lisp/regression-tests/mp.lisp
@@ -253,3 +253,25 @@
         (spam-processes nthreads (lambda () (mp:atomic-push nil (car place))))
         (car place))
       ((nil nil nil nil nil nil nil)))
+
+;;; Returns true if THUNK's process is gone within SECONDS of being killed.
+(defun cancelled-within-p (thunk seconds)
+  (let ((p (mp:process-run-function nil thunk)))
+    (loop repeat 200 until (mp:process-active-p p) do (sleep 0.01))
+    (mp:process-kill p)
+    (loop repeat (ceiling seconds 0.01)
+          while (mp:process-active-p p)
+          do (sleep 0.01))
+    (not (mp:process-active-p p))))
+
+;;; A loop body of pure VM opcodes reaches no function-call safepoint, so it is
+;;; cancellable only if the interpreter polls interrupts on backward branches.
+(test-true cancel-opcode-only-loop
+           (cancelled-within-p (lambda () (loop)) 3))
+
+(test-true cancel-arithmetic-loop
+           (cancelled-within-p (lambda () (let ((x 0)) (loop (setq x (1+ x))))) 3))
+
+;;; Control: a loop that calls a function was always cancellable.
+(test-true cancel-loop-with-call
+           (cancelled-within-p (lambda () (loop (funcall #'identity 1))) 3))

--- a/src/lisp/regression-tests/mp.lisp
+++ b/src/lisp/regression-tests/mp.lisp
@@ -275,3 +275,14 @@
 ;;; Control: a loop that calls a function was always cancellable.
 (test-true cancel-loop-with-call
            (cancelled-within-p (lambda () (loop (funcall #'identity 1))) 3))
+
+;;; Native code reaches its own safepoints, so the VM's back-edge poll does not
+;;; cover it. Asserts SIMPLE-CORE-FUN so it cannot pass by testing bytecode;
+;;; vacuous where no native compiler exists.
+(test-true cancel-native-opcode-only-loop
+           (let ((f (ignore-errors
+                     (let ((cmp:*compile-native* t))
+                       (compile nil '(lambda () (loop)))))))
+             (if (typep f 'core:simple-core-fun)
+                 (cancelled-within-p f 3)
+                 t)))

--- a/src/lisp/regression-tests/mp.lisp
+++ b/src/lisp/regression-tests/mp.lisp
@@ -286,3 +286,19 @@
              (if (typep f 'core:simple-core-fun)
                  (cancelled-within-p f 3)
                  t)))
+
+;;; A body that finishes in time returns normally and signals nothing.
+(test with-timeout-completes
+      (mp:with-timeout (30) (+ 1 2))
+      (3))
+
+;;; A spinning body is interrupted; this only works because loops now poll.
+(test-expect-error with-timeout-fires
+                   (mp:with-timeout (0.2) (loop))
+                   :type mp:timeout)
+
+;;; The timeout must not fire after the body has already returned.
+(test-true with-timeout-no-late-fire
+           (progn (mp:with-timeout (0.2) t)
+                  (sleep 0.5)
+                  t))

--- a/src/lisp/regression-tests/mp.lisp
+++ b/src/lisp/regression-tests/mp.lisp
@@ -324,3 +324,13 @@
            (progn (ignore-errors (mp:with-timeout (0.5) (ext:system "sleep 2")))
                   (sleep 1)
                   t))
+
+;;; A thread blocked in read(2) on an empty pipe must be cancellable. Without
+;;; parking the thread is never marked blocking, so no SIGCONT is sent and it
+;;; blocks forever. Bounded deliberately: an unbounded form would hang the whole
+;;; suite rather than fail, which is how a 6-hour CI timeout happens.
+(test-true cancel-blocking-read
+           (multiple-value-bind (r w) (core:pipe)
+             (declare (ignore w))
+             (let ((buf (make-string 16 :element-type 'base-char)))
+               (cancelled-within-p (lambda () (core:read-fd r buf)) 3))))

--- a/src/serveEvent/serveEvent.cc
+++ b/src/serveEvent/serveEvent.cc
@@ -26,6 +26,7 @@ THE SOFTWARE.
 /* -^- */
 
 #include <errno.h>
+#include <clasp/gctools/park.h>
 #include <sys/select.h>
 #include <clasp/core/foundation.h>
 #include <clasp/core/object.h>
@@ -55,7 +56,10 @@ CL_DEFUN int serve_event_internal__ll_fdset_size() { return sizeof(fd_set); }
 DOCGROUP(clasp);
 CL_DEFUN core::Integer_mv serve_event_internal__ll_serveEventNoTimeout(clasp_ffi::ForeignData_sp rfd, clasp_ffi::ForeignData_sp wfd,
                                                                        int maxfdp1) {
-  gc::Fixnum selectRet = select(maxfdp1, rfd->data<fd_set*>(), wfd->data<fd_set*>(), NULL, NULL);
+  // Park: a NULL timeout blocks indefinitely. The fd_sets are foreign memory.
+  gc::Fixnum selectRet = BEGIN_PARK {
+    return (gc::Fixnum)select(maxfdp1, rfd->data<fd_set*>(), wfd->data<fd_set*>(), NULL, NULL);
+  } END_PARK;
   return Values(Integer_O::create(selectRet), Integer_O::create((gc::Fixnum)errno));
 }
 
@@ -69,7 +73,10 @@ CL_DEFUN core::Integer_mv serve_event_internal__ll_serveEventWithTimeout(clasp_f
   struct timeval tv;
   tv.tv_sec = seconds;
   tv.tv_usec = ((seconds - floor(seconds)) * 1e6);
-  gc::Fixnum selectRet = select(maxfdp1, rfd->data<fd_set*>(), wfd->data<fd_set*>(), NULL, &tv);
+  // Park: blocks for up to the caller's timeout.
+  gc::Fixnum selectRet = BEGIN_PARK {
+    return (gc::Fixnum)select(maxfdp1, rfd->data<fd_set*>(), wfd->data<fd_set*>(), NULL, &tv);
+  } END_PARK;
   return Values(Integer_O::create(selectRet), Integer_O::create((gc::Fixnum)errno));
 }
 

--- a/src/sockets/sockets.cc
+++ b/src/sockets/sockets.cc
@@ -315,7 +315,8 @@ CL_DEFUN core::T_mv sockets_internal__ll_socketAccept_inetSocket(int sfd) {
   socklen_t addr_len = (socklen_t)sizeof(struct sockaddr_in);
   int new_fd;
 
-  new_fd = accept(sfd, (struct sockaddr*)&sockaddr, &addr_len);
+  // Park: accept() blocks until a connection arrives.
+  new_fd = BEGIN_PARK { return accept(sfd, (struct sockaddr*)&sockaddr, &addr_len); } END_PARK;
 
   int return0 = new_fd;
   core::T_sp return1 = nil<core::T_O>();
@@ -343,7 +344,10 @@ CL_DEFUN int sockets_internal__ll_socketConnect_inetSocket(int port, int ip0, in
   struct sockaddr_in sockaddr;
   int output;
   fill_inet_sockaddr(&sockaddr, port, ip0, ip1, ip2, ip3);
-  output = connect(socket_file_descriptor, (struct sockaddr*)&sockaddr, sizeof(struct sockaddr_in));
+  // Park: connect() blocks for the handshake.
+  output = BEGIN_PARK {
+    return connect(socket_file_descriptor, (struct sockaddr*)&sockaddr, sizeof(struct sockaddr_in));
+  } END_PARK;
   return output;
 }
 
@@ -512,7 +516,10 @@ DOCGROUP(clasp);
 CL_DEFUN core::T_mv sockets_internal__ll_socketAccept_localSocket(int socketFileDescriptor) {
   struct sockaddr_un sockaddr;
   socklen_t addr_len = (socklen_t)sizeof(struct sockaddr_un);
-  int new_fd = accept(socketFileDescriptor, (struct sockaddr*)&sockaddr, &addr_len);
+  // Park: accept() blocks until a connection arrives.
+  int new_fd = BEGIN_PARK {
+    return accept(socketFileDescriptor, (struct sockaddr*)&sockaddr, &addr_len);
+  } END_PARK;
   core::T_sp second_ret = nil<core::T_O>();
   if (new_fd != -1) {
     second_ret = core::SimpleBaseString_O::make(sockaddr.sun_path);
@@ -534,7 +541,8 @@ CL_DEFUN int sockets_internal__ll_socketConnect_localSocket(int fd, int family, 
   strncpy(sockaddr.sun_path, path.c_str(), sizeof(sockaddr.sun_path));
   sockaddr.sun_path[sizeof(sockaddr.sun_path) - 1] = '\0';
 
-  output = connect(fd, (struct sockaddr*)&sockaddr, sizeof(struct sockaddr_un));
+  // Park: connect() blocks for the handshake.
+  output = BEGIN_PARK { return connect(fd, (struct sockaddr*)&sockaddr, sizeof(struct sockaddr_un)); } END_PARK;
 
   return output;
 }
@@ -752,7 +760,10 @@ CL_DEFUN int sockets_internal__do_select(core::T_sp to_secs, unsigned int to_mus
     tv.tv_sec = to_secs.unsafe_fixnum();
     tv.tv_usec = to_musecs;
   }
-  return select(max_fd + 1, (fd_set*)rfds->ptr(), NULL, NULL, (to_secs.fixnump()) ? &tv : NULL);
+  // Park: a non-fixnum timeout means NULL, i.e. block indefinitely.
+  return BEGIN_PARK {
+    return select(max_fd + 1, (fd_set*)rfds->ptr(), NULL, NULL, (to_secs.fixnump()) ? &tv : NULL);
+  } END_PARK;
 }
 
 void initialize_sockets_globals() {


### PR DESCRIPTION
`MP:PROCESS-KILL` cannot stop a loop whose body compiles to pure opcodes, in either engine. Interrupts are delivered only at **function-entry** safepoints — `gctools::handle_all_queued_interrupts()` in `bytecode_call` (`bytecode.cc:1571`) and `cc_safepoint` in the XEP before the tail call (`cleavir/translate.lisp:1953`) — and neither instruments loop back edges. A loop that calls nothing never reaches a safepoint, so no interrupt ever arrives.

Measured before the change, all surviving `PROCESS-KILL`:

| spinner | killed? |
|---|---|
| `(loop)` | no |
| `(loop until *flag*)` | no |
| `(loop for i from 0)` | no |
| `(loop (setq x (1+ x)))` | no |
| `(do ((i 0 (1+ i))) (nil))` | no |
| `(loop (funcall #'identity 1))` | yes |
| thread in `(sleep …)` | yes |

So this is specifically the call-free case; anything containing a call was always fine.

### The return value is not a signal

Worth stating because it misleads: `MP:PROCESS-KILL` and `MP:PROCESS-CANCEL` are both `(MP:INTERRUPT process 'MP:CANCELLATION-INTERRUPT)` and the C++ entry point is `void`, so **both answer `NIL` whether or not the target dies**. `MP:PROCESS-ACTIVE-P` is the only way to tell. (They are also literally the same function; the in-tree FIXME says kill should be the forceful one. Not addressed here.)

### Three independent commits

**1. Bytecode** — poll when the jump offset is negative. All eight jump sites route through one helper. `vm._pc`/`vm._stackPointer` are synced first, since the handler can cons or unwind and the GC scans to `_stackPointer`. The fast path uses the `ThreadLocalState*` the VM already caches per frame rather than `my_thread`, which on Darwin would cost a `_tlv_get_addr` thunk per iteration. It cannot use `interrupt_queue_validp()` — the queue keeps a dummy head node so that predicate is true whenever the queue exists; the real test is the head's `cdr`.

**Cost: ~1–2%** on a loop whose entire body is one opcode, one of three alternating rounds inverted.

**2. Native** — BIR has no loop or dominance analysis, but iblocks are laid out in forward flow order, so a branch to an already-laid-out iblock is a back edge. Emitted from `translate-terminator :around`, covering `jump`/`ifi`/`case` in one place.

Polling every back edge is **not** affordable: `cc_safepoint` is an out-of-line call *and* `primitive-unwinds`, so LLVM cannot hoist loop-invariant work or keep values in registers across it — measured **3.0×** on the same worst case. It cannot be redeclared non-throwing; the handler really can unwind, and `cleavir/primitives.lisp:55` warns against exactly that. So this **samples**: a counter in the alloca block, one call per 256 back edges, bounding cancellation latency at 255 iterations.

**Cost: ~8%**, nine alternating rounds, down from 3×.

I'd flag that 8% as the weakest part of this PR. The residual is the *inline* counter, not the call, so raising the interval buys little. Two better options I did not take: read a global pending-interrupt flag (needs an atomic load, or LLVM hoists it out of the loop and silently disables the safepoint), or instrument only call-free loops — which would make almost all real code pay nothing, and is the one I'd pursue if you want this cheaper. **Happy to drop commit 2 entirely** if the cost isn't worth it to you; commits 1 and 3 stand without it.

**3. `MP:WITH-TIMEOUT`** — there was no way to bound a form's running time; the only timeout primitive was `CONDITION-VARIABLE-TIMEDWAIT`, which bounds one wait. The watchdog waits on a condition variable rather than sleeping, so an early finish doesn't strand a thread for the full duration, and the wait is a deadline loop because `timedwait` may return early.

This depends on commit 1: the deadline is delivered as an interrupt, so the workload a timeout most needs to interrupt — a spinning thread — was the one workload it could not reach. `(MP:WITH-TIMEOUT (0.2) (LOOP))` now signals `MP:TIMEOUT`.

`MP:TIMEOUT` is a subtype of `ERROR`, not `SERIOUS-CONDITION` where SBCL and bordeaux-threads put theirs. A condition that slips through `HANDLER-CASE` on `ERROR` and `IGNORE-ERRORS` is a footgun. Deliberate, and easy to change if you disagree.

### Testing

Regression suite **2014 → 2021**, seven new tests, same five expected failures by name, same five unexpected successes, `compilation unit aborted` = 2. There were no cancellation tests at all before this; `cancel-loop-with-call` is included as a control that passed before and after, so a future regression in the general interrupt machinery stays distinguishable from one in the back-edge poll.

Two caveats I'd rather state than have you find:

- **The native test is vacuous in bytecode-only builds.** It asserts `SIMPLE-CORE-FUN` so it cannot pass by silently testing bytecode, but with no native compiler it returns `T` without testing anything. Green in the two `bytecode/no/no` cells proves nothing about commit 2.
- Built and tested on macOS arm64, `boehmprecise`, on a tree that also carried #1820. The only `bytecode.cc` difference from this branch is #1820's unrelated `parse_key_args` rework; CI here exercises the exact branch.

The three commits are independent and cherry-pickable — happy to split them into separate PRs if you'd prefer to take them at different speeds.
