### PR TITLE
Restore the park state when a parked thunk unwinds

### DIFF
--- a/include/clasp/gctools/park.h
+++ b/include/clasp/gctools/park.h
@@ -33,38 +33,52 @@ int begin_park(void*);
 void end_park(int);
 void* end_park_temporarily();
 
+// Restores the park state on any exit. A parked thread that unwinds -- which is
+// exactly what a cancelled blocking call does -- would otherwise keep running
+// Lisp while still marked GC-safe and blocking.
+struct ParkGuard {
+  int _OldState;
+  explicit ParkGuard(void* sp) : _OldState(begin_park(sp)) {}
+  ~ParkGuard() { end_park(_OldState); }
+  ParkGuard(const ParkGuard&) = delete;
+  ParkGuard& operator=(const ParkGuard&) = delete;
+};
+
 template <std::invocable<> F>
 requires (!std::same_as<void, std::invoke_result_t<F>>)
 decltype(auto) call_parked(F f) {
-  int oldstate = begin_park(__builtin_frame_address(0));
-  decltype(auto) result = f();
-  end_park(oldstate);
-  return result;
+  ParkGuard guard(__builtin_frame_address(0));
+  return f();
 }
 
 template <std::invocable<> F>
 requires (std::same_as<void, std::invoke_result_t<F>>)
 void call_parked(F f) {
-  int oldstate = begin_park(__builtin_frame_address(0));
+  ParkGuard guard(__builtin_frame_address(0));
   f();
-  end_park(oldstate);
 }
 
 // While parked, temporarily unpark (blocking if needed) to call a thunk.
 // This is used in interrupt.cc for wakeups.
+// Mirror of ParkGuard: re-parks on any exit, including an unwind.
+struct UnparkGuard {
+  void* _Old;
+  UnparkGuard() : _Old(end_park_temporarily()) {}
+  ~UnparkGuard() { begin_park(_Old); }
+  UnparkGuard(const UnparkGuard&) = delete;
+  UnparkGuard& operator=(const UnparkGuard&) = delete;
+};
+
 template <std::invocable<> F>
 requires (!std::same_as<void, std::invoke_result_t<F>>)
 decltype(auto) call_unparked(F f) {
-  void* old = end_park_temporarily();
-  decltype(auto) result = f();
-  begin_park(old);
-  return result;
+  UnparkGuard guard;
+  return f();
 }
 template <std::invocable<> F>
 requires std::same_as<void, std::invoke_result_t<F>>
 void call_unparked(F f) {
-  void* old = end_park_temporarily();
+  UnparkGuard guard;
   f();
-  begin_park(old);
 }
 };


### PR DESCRIPTION
`gctools::call_parked` saves the old park state, calls the thunk, then restores it:

```cpp
int oldstate = begin_park(__builtin_frame_address(0));
decltype(auto) result = f();
end_park(oldstate);
```

A thunk that exits non-locally skips the restore. The thread then resumes running Lisp while still marked **GC-safe and blocking** — racing the collector, and reporting `blockingp()` forever after, which is what `Process_O::interrupt` uses to decide whether to `pthread_kill(SIGCONT)`. `call_unparked` has the mirror-image flaw.

This is not an edge case. **Cancelling a thread blocked in a syscall is precisely a non-local exit out of a parked region**, and `handle_SIGCONT` is built to do exactly that — it calls `handle_queued_interrupts()` from inside the handler, and its own comment ("Nothing jumped out of there, so we're back to blocking") anticipates that something can jump out.

It is reachable today: a thread cancelled while in `safe_open`, `clasp_musleep`, or `ConditionVariable::wait`/`timed_wait` takes this path.

Both now restore through a destructor, so any exit — normal return, C++ exception, or a Lisp non-local exit — puts the thread back.

### Caveat worth stating

This assumes unwinding runs destructors. That holds for ordinary Lisp non-local exits, but **not** for the SJLJ routing used on macOS arm64 (where `_longjmp` has no unwind tables). A `longjmp` past a park would still skip the restore. Fixing that properly needs the park state restored by the unwinder itself rather than by a C++ destructor; this change is a strict improvement over the status quo, not a complete guarantee.

### How it was found

While making blocking syscalls cancellable (#1843). Once `accept`, `read` and `select` park, cancelling them exercises this path constantly rather than rarely. It is independent of that work, applies to `main` as-is, and is worth taking on its own.

No behaviour change on the normal path: the guard compiles to the same two calls in the same places.
