### PR TITLE
Report whether an interrupt was enqueued, and stop implying a forceful kill

### DIFF
--- a/include/clasp/core/mpPackage.h
+++ b/include/clasp/core/mpPackage.h
@@ -136,7 +136,7 @@ public:
   string __repr__() const override;
   inline ProcessPhase phase() const { return _Phase.load(std::memory_order_acquire); }
   string phase_as_string() const;
-  void interrupt(core::T_sp interrupt);
+  bool interrupt(core::T_sp interrupt);
   void suspend();
   void resume();
 private:

--- a/src/core/mpPackage.cc
+++ b/src/core/mpPackage.cc
@@ -245,7 +245,7 @@ int Process_O::startProcess() {
   return result;
 }
 
-void Process_O::interrupt(core::T_sp interrupt) {
+bool Process_O::interrupt(core::T_sp interrupt) {
    /*
    * Lifted from the ECL source code.  meister 2017
    * We first ensure that the process is active and running
@@ -266,9 +266,9 @@ void Process_O::interrupt(core::T_sp interrupt) {
           // FIXME?: We could use pthread_sigqueue to stick in some extra info
           // in order to disambiguate our wakeups from others' a bit.
           pthread_kill(_TheThread._value, SIGCONT);
-        return;
+        return true;
       }
-    case Exited: return; // we were too slow! oh well, who cares.
+    case Exited: return false; // we were too slow, and the caller may care.
     case Nascent: SIMPLE_ERROR("Cannot interrupt unstarted process.");
     case Booting: waitPhase(p);
     }
@@ -448,10 +448,14 @@ CL_DEFUN core::T_sp mp__process_preset(Process_sp process, core::T_sp function, 
   return process;
 }
 
-CL_DOCSTRING(R"dx(Internal. Enqueue the given interrupt to the thread's pending interrupt list. Returns no values.")dx");
+CL_DOCSTRING(R"dx(Internal. Enqueue the given interrupt on the process's pending interrupt list.
+
+Returns true if the interrupt was enqueued on a live process, and false if the process had already
+exited, in which case the interrupt is discarded. A true value does NOT mean the interrupt has run:
+delivery is asynchronous, and happens when the process next reaches a safepoint.)dx");
 DOCGROUP(clasp);
-CL_DEFUN void mp__enqueue_interrupt(Process_sp process, core::T_sp interrupt) {
-  process->interrupt(interrupt);
+CL_DEFUN bool mp__enqueue_interrupt(Process_sp process, core::T_sp interrupt) {
+  return process->interrupt(interrupt);
 }
 
 SYMBOL_EXPORT_SC_(MpPkg, posix_interrupt);

--- a/src/lisp/kernel/clos/conditions.lisp
+++ b/src/lisp/kernel/clos/conditions.lisp
@@ -1453,19 +1453,36 @@ Interrupts are implicitly blocked while signaling an interrupt, and while unwind
 
 ;;; for backward compatibility (e.g. bordeaux)
 (defun mp:interrupt-process (process function)
+  "Request that PROCESS call FUNCTION at its next safepoint.
+Returns true if the request was enqueued on a live process, false if PROCESS had already exited. A
+true value does not mean FUNCTION has run: delivery is asynchronous."
   (check-type process mp:process)
   (check-type function function)
   (mp:interrupt process 'mp:call-interrupt :function function))
 
+;;; PROCESS-KILL and PROCESS-CANCEL are deliberately the same request. A forceful
+;;; kill is not offered because there is no safe one: terminating a thread
+;;; asynchronously in a garbage-collected runtime abandons whatever locks and heap
+;;; invariants it held. Other implementations reach the same conclusion; SBCL's
+;;; TERMINATE-THREAD is cooperative too.
 (defun mp:process-kill (process)
-  ;; FIXME: This function should maybe be the more chaotic SIGKILL version,
-  ;; while cancel-thread (cancel-process?) is the nicer interrupt.
+  "Request that PROCESS abort at its next safepoint. Synonym of PROCESS-CANCEL.
+Returns true if the request was enqueued on a live process, false if PROCESS had already exited.
+
+A true value does NOT mean PROCESS has died. Cancellation is cooperative: it is delivered at a
+safepoint, so a process that reaches none -- a loop of pure opcodes with no back edge polling, or a
+foreign call made without parking -- may not stop at all. Use PROCESS-ACTIVE-P or PROCESS-JOIN to
+learn whether it actually stopped."
   (mp:interrupt process 'mp:cancellation-interrupt))
 
-(defun mp:process-cancel (process) ; the nicer version.
+(defun mp:process-cancel (process)
+  "Request that PROCESS abort at its next safepoint. Synonym of PROCESS-KILL; see that function for
+the return value and for why cancellation is cooperative."
   (mp:interrupt process 'mp:cancellation-interrupt))
 
 (defun mp:process-suspend (process)
+  "Request that PROCESS pause at its next safepoint.
+Returns true if the request was enqueued on a live process, false if PROCESS had already exited."
   (mp:interrupt process 'mp:suspension-interrupt))
 
 (defmethod mp:service-interrupt ((i ext:interactive-interrupt))

--- a/src/lisp/regression-tests/mp.lisp
+++ b/src/lisp/regression-tests/mp.lisp
@@ -253,3 +253,29 @@
         (spam-processes nthreads (lambda () (mp:atomic-push nil (car place))))
         (car place))
       ((nil nil nil nil nil nil nil)))
+
+;;; The return value must distinguish "enqueued on a live process" from "the
+;;; process was already gone". Previously both answered NIL, so the value carried
+;;; no information at all -- which is what sent a bug report after the wrong
+;;; function entirely.
+;;; Blocks in SLEEP rather than spinning: this must not depend on back-edge
+;;; safepoints, and an uncancellable spinner would burn a core for the rest of
+;;; the run.
+(test-true process-kill-returns-true-when-enqueued
+           (let ((p (mp:process-run-function nil (lambda () (sleep 30)))))
+             (loop repeat 200 until (mp:process-active-p p) do (sleep 0.01))
+             (prog1 (and (mp:process-kill p) t)
+               (loop repeat 300 while (mp:process-active-p p) do (sleep 0.01)))))
+
+(test-true process-kill-returns-false-when-already-exited
+           (let ((p (mp:process-run-function nil (lambda () t))))
+             (mp:process-join p)
+             (loop repeat 300 while (mp:process-active-p p) do (sleep 0.01))
+             (not (mp:process-kill p))))
+
+;;; PROCESS-CANCEL is the same request and answers the same way.
+(test-true process-cancel-returns-false-when-already-exited
+           (let ((p (mp:process-run-function nil (lambda () t))))
+             (mp:process-join p)
+             (loop repeat 300 while (mp:process-active-p p) do (sleep 0.01))
+             (not (mp:process-cancel p))))


### PR DESCRIPTION
`MP:PROCESS-KILL`, `MP:PROCESS-CANCEL`, `MP:INTERRUPT-PROCESS` and `MP:PROCESS-SUSPEND` all answer `NIL` whether or not they did anything, because `Process_O::interrupt` returns `void`. The information exists and is thrown away:

```cpp
case Exited: return; // we were too slow! oh well, who cares.
```

The caller does care. `NIL` currently means both *"enqueued on a live process"* and *"the process was already gone"*, so the return value carries no information at all.

That is not hypothetical. A bug report reached me reasoning from exactly this — *"`MP:PROCESS-KILL` and `MP:INTERRUPT-PROCESS` both answer NIL"* — and concluded cancellation was broken. It wasn't; `NIL` is simply what success looks like too. The real defect was elsewhere, and the misleading return value is what pointed at the wrong function.

### What changes

`Process_O::interrupt` returns **true** when the interrupt was enqueued on a live process and **false** when the process had exited and the interrupt was discarded. It propagates through `MP:ENQUEUE-INTERRUPT` and `MP:INTERRUPT` to all four entry points, each of which is a one-liner returning the next.

```
                      live process   exited process
  before                   NIL             NIL
  after                    T               NIL
```

### What the docstrings now say

The four functions had no docstrings. They now state the limit the old behaviour hid: **a true value does not mean the process died.** Delivery is asynchronous and lands at a safepoint, so a process that reaches none may never stop, and `PROCESS-ACTIVE-P` / `PROCESS-JOIN` are how you find out whether it did.

### On the FIXME

`PROCESS-KILL` and `PROCESS-CANCEL` remain the same request, and I have removed the FIXME proposing that `KILL` become "the more chaotic SIGKILL version" rather than leaving it standing.

There is no safe forceful thread kill in a garbage-collected runtime: terminating a thread asynchronously abandons whatever locks and heap invariants it held. SBCL's `TERMINATE-THREAD` is cooperative for the same reason. If you would rather keep the FIXME as an open question I will restore it — but an open FIXME implying the option is coming seems worse than documenting that the two are synonyms and why.

### Also

A stray unbalanced `"` was leaking into `MP:ENQUEUE-INTERRUPT`'s docstring. `MP:FENCE` has the same defect at `mpPackage.cc:598`, not touched here.

### Testing

Three tests: true when enqueued on a live process, false for an already-exited one, and the same for `PROCESS-CANCEL`. The live-process test blocks in `SLEEP` rather than spinning, so it does not depend on a loop being cancellable and cannot leave a thread burning a core.

Regression suite 2026 → 2029 on macOS arm64, boehmprecise, with the same expected failures by name. Verified as a behaviour change against a build without the patch, where both cases still answer `NIL`.
