### PR TITLE
Various MMTk improvements/changes

### DIFF
--- a/include/clasp/core/array_int8.h
+++ b/include/clasp/core/array_int8.h
@@ -37,10 +37,11 @@ public:
   SimpleVector_byte8_t_O(size_t length, R&& initialContents)
     : TemplatedBase(initialContents) { (void)length; };
 
+  template <gctools::GCInfo_policy Policy = gctools::normal>
   static smart_ptr_type make(size_t length, value_type initialElement = value_type(), bool initialElementSupplied = false,
                              size_t initialContentsSize = 0, const value_type* initialContents = NULL,
                              bool static_vector_p = false) {
-    auto bs = gctools::GC<my_type>::allocate_container<gctools::RuntimeStage>(
+    auto bs = gctools::GC<my_type>::allocate_container<gctools::RuntimeStage, Policy>(
         static_vector_p, length, initialElement, initialElementSupplied, initialContentsSize, initialContents);
     return bs;
   }

--- a/include/clasp/core/array_t.h
+++ b/include/clasp/core/array_t.h
@@ -37,9 +37,10 @@ public:
   // the length was computed by make below from the range anyway.
   SimpleVector_O(size_t length, R&& initialContents)
     : TemplatedBase(initialContents) { (void)length; };
+  template <gctools::GCInfo_policy Policy = gctools::normal>
   static SimpleVector_sp make(size_t length, T_sp initialElement = nil<T_O>(), bool initialElementSupplied = true,
                               size_t initialContentsSize = 0, const T_sp* initialContents = NULL, bool static_vector_p = false) {
-    auto bs = gctools::GC<SimpleVector_O>::allocate_container<gctools::RuntimeStage>(
+    auto bs = gctools::GC<SimpleVector_O>::allocate_container<gctools::RuntimeStage, Policy>(
         static_vector_p, length, initialElement, initialElementSupplied, initialContentsSize, initialContents);
     return bs;
   }

--- a/include/clasp/core/fli.h
+++ b/include/clasp/core/fli.h
@@ -68,6 +68,18 @@ THE SOFTWARE.
 
 #if defined(__cplusplus)
 
+template <> struct gctools::GCInfo<clasp_ffi::ForeignData_O> {
+  static bool constexpr NeedsInitialization = false;
+  static bool constexpr NeedsFinalization = true;
+  static GCInfo_policy constexpr Policy = normal;
+};
+
+template <> struct gctools::GCInfo<clasp_ffi::ForeignTypeSpec_O> {
+  static bool constexpr NeedsInitialization = false;
+  static bool constexpr NeedsFinalization = false;
+  static GCInfo_policy constexpr Policy = normal;
+};
+
 // ---------------------------------------------------------------------------
 //   NAMESPACE
 // ---------------------------------------------------------------------------
@@ -217,13 +229,6 @@ DOCGROUP(clasp)
 CL_DEFUN core::T_sp PERCENTdlsym(core::T_sp library, core::String_sp name);
 
 }; // namespace clasp_ffi
-
-// GC Policy Info for ForeignPataPtr_O instances
-template <> struct gctools::GCInfo<clasp_ffi::ForeignData_O> {
-  static bool constexpr NeedsInitialization = false;
-  static bool constexpr NeedsFinalization = true;
-  static GCInfo_policy constexpr Policy = normal;
-};
 
 namespace clasp_ffi {
 // FOREIGN MEMORY DIRECT ACCESS - MEM REF
@@ -531,13 +536,6 @@ CL_DEFUN core::T_mv PERCENTget_section_data(core::String_sp segment_name, core::
 // platform.
 
 }; // namespace clasp_ffi
-
-// GC Policy Info for ForeignTypeSpec_O instances
-template <> struct gctools::GCInfo<clasp_ffi::ForeignTypeSpec_O> {
-  static bool constexpr NeedsInitialization = false;
-  static bool constexpr NeedsFinalization = false;
-  static GCInfo_policy constexpr Policy = normal;
-};
 
 // ---------------------------------------------------------------------------
 //   END OF FILE

--- a/include/clasp/core/hashTableCustom.h
+++ b/include/clasp/core/hashTableCustom.h
@@ -31,6 +31,12 @@ THE SOFTWARE.
 #include <clasp/core/symbolTable.h>
 #include <clasp/core/corePackage.fwd.h>
 
+template <> struct gctools::GCInfo<core::HashTableCustom_O> {
+  static bool constexpr NeedsInitialization = false;
+  static bool constexpr NeedsFinalization = false;
+  static GCInfo_policy constexpr Policy = normal;
+};
+
 namespace core {
 
 FORWARD(HashTableCustom);
@@ -61,8 +67,3 @@ public: // Functions here
 };
 
 }; // namespace core
-template <> struct gctools::GCInfo<core::HashTableCustom_O> {
-  static bool constexpr NeedsInitialization = false;
-  static bool constexpr NeedsFinalization = false;
-  static GCInfo_policy constexpr Policy = normal;
-};

--- a/include/clasp/core/hashTableEq.h
+++ b/include/clasp/core/hashTableEq.h
@@ -31,6 +31,12 @@ THE SOFTWARE.
 #include <clasp/core/symbolTable.h>
 #include <clasp/core/corePackage.fwd.h>
 
+template <> struct gctools::GCInfo<core::HashTableEq_O> {
+  static bool constexpr NeedsInitialization = false;
+  static bool constexpr NeedsFinalization = false;
+  static GCInfo_policy constexpr Policy = normal;
+};
+
 namespace core {
 
 FORWARD(HashTableEq);
@@ -56,8 +62,3 @@ public: // Functions here
 };
 
 }; // namespace core
-template <> struct gctools::GCInfo<core::HashTableEq_O> {
-  static bool constexpr NeedsInitialization = false;
-  static bool constexpr NeedsFinalization = false;
-  static GCInfo_policy constexpr Policy = normal;
-};

--- a/include/clasp/core/hashTableEql.h
+++ b/include/clasp/core/hashTableEql.h
@@ -31,6 +31,12 @@ THE SOFTWARE.
 #include <clasp/core/symbolTable.h>
 #include <clasp/core/corePackage.fwd.h>
 
+template <> struct gctools::GCInfo<core::HashTableEql_O> {
+  static bool constexpr NeedsInitialization = false;
+  static bool constexpr NeedsFinalization = false;
+  static GCInfo_policy constexpr Policy = normal;
+};
+
 namespace core {
 
 FORWARD(HashTableEql);
@@ -56,8 +62,3 @@ public: // Functions here
 };
 
 }; // namespace core
-template <> struct gctools::GCInfo<core::HashTableEql_O> {
-  static bool constexpr NeedsInitialization = false;
-  static bool constexpr NeedsFinalization = false;
-  static GCInfo_policy constexpr Policy = normal;
-};

--- a/include/clasp/core/hashTableEqual.h
+++ b/include/clasp/core/hashTableEqual.h
@@ -31,6 +31,12 @@ THE SOFTWARE.
 #include <clasp/core/hashTable.h>
 #include <clasp/core/corePackage.fwd.h>
 
+template <> struct gctools::GCInfo<core::HashTableEqual_O> {
+  static bool constexpr NeedsInitialization = false;
+  static bool constexpr NeedsFinalization = false;
+  static GCInfo_policy constexpr Policy = normal;
+};
+
 namespace core {
 
 FORWARD(HashTableEqual);
@@ -56,8 +62,3 @@ public: // Functions here
 };
 
 }; // namespace core
-template <> struct gctools::GCInfo<core::HashTableEqual_O> {
-  static bool constexpr NeedsInitialization = false;
-  static bool constexpr NeedsFinalization = false;
-  static GCInfo_policy constexpr Policy = normal;
-};

--- a/include/clasp/core/hashTableEqualp.h
+++ b/include/clasp/core/hashTableEqualp.h
@@ -31,6 +31,12 @@ THE SOFTWARE.
 #include <clasp/core/symbolTable.h>
 #include <clasp/core/corePackage.fwd.h>
 
+template <> struct gctools::GCInfo<core::HashTableEqualp_O> {
+  static bool constexpr NeedsInitialization = false;
+  static bool constexpr NeedsFinalization = false;
+  static GCInfo_policy constexpr Policy = normal;
+};
+
 namespace core {
 
 FORWARD(HashTableEqualp);
@@ -56,8 +62,3 @@ public: // Functions here
 };
 
 }; // namespace core
-template <> struct gctools::GCInfo<core::HashTableEqualp_O> {
-  static bool constexpr NeedsInitialization = false;
-  static bool constexpr NeedsFinalization = false;
-  static GCInfo_policy constexpr Policy = normal;
-};

--- a/include/clasp/core/object.h
+++ b/include/clasp/core/object.h
@@ -488,22 +488,18 @@ CL_DECLARE();
 CL_DOCSTRING("eql")
 DOCGROUP(clasp)
 inline CL_DEFUN bool cl__eql(T_sp x, T_sp y) {
-  if (x.fixnump()) {
-    return x.raw_() == y.raw_();
-  } else if (x.single_floatp()) {
+  if (x.raw_() ==  y.raw_()) return true;
+  else if (x.fixnump()) return false; // raws would have been eql
+  else if (x.single_floatp()) {
     if (!y.single_floatp())
       return false;
     single_float_t xf = x.unsafe_single_float();
     single_float_t yf = y.unsafe_single_float();
     // signbit is included in the comparison because (EQL 0.0 -0.0) is non-NIL.
     return xf == yf && std::signbit(xf) == std::signbit(yf);
-  } else if (x.characterp()) {
-    return y.characterp() && x.unsafe_character() == y.unsafe_character();
-  } else if (x.consp()) {
-    return x.raw_() == y.raw_();
-  } else if (x.generalp()) {
-    if (x.raw_() == y.raw_())
-      return true;
+  } else if (x.characterp()) return false; //raws would have been eql
+  else if (x.consp()) return false; // raws would have been eql
+  else if (x.generalp()) {
     General_O* general = x.unsafe_general();
     return general->eql_(y);
   }

--- a/include/clasp/core/sourceFileInfo.h
+++ b/include/clasp/core/sourceFileInfo.h
@@ -34,6 +34,12 @@ THE SOFTWARE.
 #include <clasp/core/symbolTable.h>
 #include <clasp/core/sourceFileInfo.fwd.h>
 
+template <> struct gctools::GCInfo<core::SourcePosInfo_O> {
+  static bool constexpr NeedsInitialization = false;
+  static bool constexpr NeedsFinalization = false;
+  static GCInfo_policy constexpr Policy = normal;
+};
+
 namespace core {
 
 class Scope_O : public General_O {
@@ -156,11 +162,6 @@ inline core::Fixnum safe_column(T_sp spi) {
 // Pass all arguments to a FunctionClosure
 #define SOURCE_POS_INFO_FIELDS(spi) safe_fileId(spi), safe_filepos(spi), safe_lineno(spi), safe_column(spi)
 }; // namespace core
-template <> struct gctools::GCInfo<core::SourcePosInfo_O> {
-  static bool constexpr NeedsInitialization = false;
-  static bool constexpr NeedsFinalization = false;
-  static GCInfo_policy constexpr Policy = normal;
-};
 
 namespace core {
 

--- a/include/clasp/gctools/gc_boot.h
+++ b/include/clasp/gctools/gc_boot.h
@@ -180,10 +180,17 @@ struct Stamp_layout {
   Container_layout* container_layout = nullptr;
 };
 
+// In addition to all the above, we maintain global_stamp_bitmaps which is an
+// array of just the Stamp_layout class_field_pointer_bitmaps, so that the GC's
+// scanner doesn't need to index into the entire huge Stamp_layout array.
+// The bitmap is set to ~0 if there is a container layout with pointers,
+// or COMPLEX_SCAN, so that the scanner knows to fall back to the more exact scan.
+
 extern Layout_code* get_stamp_layout_codes();
 extern size_t global_stamp_max;
 extern Stamp_layout* global_stamp_layout;
 extern Field_layout* global_field_layout;
+extern uintptr_t* global_stamp_bitmaps;
 
 typedef enum { precise_info, lldb_info } WalkKind;
 void walk_stamp_field_layout_tables(WalkKind walk, std::ostream& stream);

--- a/include/clasp/gctools/gcalloc.h
+++ b/include/clasp/gctools/gcalloc.h
@@ -314,9 +314,9 @@ public:
   typedef /*gctools::*/ smart_ptr<OT> smart_pointer_type;
 
 public:
-  template <typename Stage = RuntimeStage, typename... ARGS> static smart_pointer_type allocate(ARGS&&... args) {
+  template <typename Stage = RuntimeStage, GCInfo_policy Policy = GCInfo<OT>::Policy, typename... ARGS> static smart_pointer_type allocate(ARGS&&... args) {
     auto kind = Header_s::StampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag);
-    return GCObjectAllocator<OT>::template allocate_kind<Stage>(kind, std::forward<ARGS>(args)...);
+    return GCObjectAllocator<OT>::template allocate_kind<Stage, Policy>(kind, std::forward<ARGS>(args)...);
   }
 
   /*! Allocate enough space for capacity elements, but set the length to length */
@@ -324,7 +324,7 @@ public:
   // Allocates an object with proper header and everything.
   // Uses the underlying constructor. Like, GC<SimpleVector_O>::allocate_container(...)
   // ends up passing the ... to the SimpleVector_O constructor.
-  template <typename Stage, typename... ARGS>
+  template <typename Stage, GCInfo_policy Policy = GCInfo<OT>::Policy, typename... ARGS>
   static smart_pointer_type allocate_container(bool static_container_p, int64_t length, ARGS&&... args) {
     size_t capacity = std::abs(length);
     size_t size = sizeof_container_with_header<OT>(capacity);
@@ -332,11 +332,11 @@ public:
       return GCObjectAllocator<OT>::template allocate_kind_variable<Stage, unmanaged>(Header_s::BadgeStampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag), size, length,
                                                                                       std::forward<ARGS>(args)...);
     else
-      return GCObjectAllocator<OT>::template allocate_kind_variable<Stage>(Header_s::BadgeStampWtagMtag(OT::static_ValueStampWtagMtag), size,
+      return GCObjectAllocator<OT>::template allocate_kind_variable<Stage, Policy>(Header_s::BadgeStampWtagMtag(OT::static_ValueStampWtagMtag), size,
                                                                            length, std::forward<ARGS>(args)...);
   }
 
-  template <typename Stage, typename... ARGS>
+  template <typename Stage, GCInfo_policy Policy = GCInfo<OT>::Policy, typename... ARGS>
   static smart_pointer_type allocate_container_null_terminated_string(bool static_container_p, size_t length, ARGS&&... args) {
     size_t capacity = length + 1;
     size_t size = sizeof_container_with_header<OT>(capacity);
@@ -345,14 +345,14 @@ public:
           Header_s::BadgeStampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag), size, length,
           std::forward<ARGS>(args)...);
     else
-      return GCObjectAllocator<OT>::template allocate_kind_variable<Stage>(
+      return GCObjectAllocator<OT>::template allocate_kind_variable<Stage, Policy>(
           Header_s::BadgeStampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag), size, length,
           std::forward<ARGS>(args)...);
   }
 
   /*! Allocate enough space for capacity elements, but set the length to length */
 
-  template <typename... ARGS>
+  template <GCInfo_policy Policy = GCInfo<OT>::Policy, typename... ARGS>
   static smart_pointer_type allocate_bitunit_container(bool static_container_p, size_t length, ARGS&&... args) {
     size_t size = sizeof_bitunit_container_with_header<OT>(length);
     smart_pointer_type result;
@@ -360,7 +360,7 @@ public:
       result = GCObjectAllocator<OT>::template allocate_kind_variable<RuntimeStage, unmanaged>(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
                                                                                       std::forward<ARGS>(args)...);
     else
-      result = GCObjectAllocator<OT>::template allocate_kind_variable<RuntimeStage>(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
+      result = GCObjectAllocator<OT>::template allocate_kind_variable<RuntimeStage, Policy>(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
                                                                            std::forward<ARGS>(args)...);
 
     return result;

--- a/include/clasp/gctools/gcalloc.h
+++ b/include/clasp/gctools/gcalloc.h
@@ -212,11 +212,35 @@ private:
     }
   }
 
+  template <typename Stage = RuntimeStage, GCInfo_policy Policy = GCInfo<OT>::Policy,
+            size_t Size = sizeof_with_header<OT>()>
+  static Header_s* raw_allocate(const Header_s::BadgeStampWtagMtag& the_header) {
+    if constexpr(Policy == normal) {
+      DO_DRAG_GENERAL_ALLOCATION();
+      return do_general_allocation<Stage, Size>(the_header);
+    } else if constexpr(Policy == collectable_immobile) {
+      return do_immobile_allocation<Stage, Size>(the_header);
+    } else if constexpr(Policy == atomic) {
+      return do_atomic_allocation<Stage, Size>(the_header);
+    } else { // unmanaged
+      return do_uncollectable_allocation<Size>(the_header);
+    }
+  }
+
   template <typename Stage, GCInfo_policy Policy = GCInfo<OT>::Policy,
             typename... ARGS>
-  static OT_sp allocate_in_appropriate_pool_kind(const Header_s::BadgeStampWtagMtag& the_header, size_t size,
-                                                 ARGS&&... args) {
+  static OT_sp allocate_in_appropriate_pool_kind_variable(const Header_s::BadgeStampWtagMtag& the_header, size_t size,
+                                                          ARGS&&... args) {
     Header_s* base = raw_allocate<Stage, Policy>(the_header, size);
+    OT* ptr = HeaderPtrToGeneralPtr<OT>(base);
+    new (ptr) OT(std::forward<ARGS>(args)...);
+    return OT_sp(ptr);
+  }
+  template <typename Stage, GCInfo_policy Policy = GCInfo<OT>::Policy,
+            size_t Size = sizeof_with_header<OT>(), typename... ARGS>
+  static OT_sp allocate_in_appropriate_pool_kind(const Header_s::BadgeStampWtagMtag& the_header,
+                                                 ARGS&&... args) {
+    Header_s* base = raw_allocate<Stage, Policy, Size>(the_header);
     OT* ptr = HeaderPtrToGeneralPtr<OT>(base);
     new (ptr) OT(std::forward<ARGS>(args)...);
     return OT_sp(ptr);
@@ -225,12 +249,20 @@ private:
 public:
   template <typename Stage, GCInfo_policy Policy = GCInfo<OT>::Policy,
             typename... ARGS>
-  static OT_sp allocate_kind(const Header_s::BadgeStampWtagMtag& the_header, size_t size, ARGS&&... args) {
+  static OT_sp allocate_kind_variable(const Header_s::BadgeStampWtagMtag& the_header, size_t size, ARGS&&... args) {
     OT_sp sp =
-      allocate_in_appropriate_pool_kind<Stage, GCInfo<OT>::Policy>(the_header, size, std::forward<ARGS>(args)...);
+      allocate_in_appropriate_pool_kind_variable<Stage, GCInfo<OT>::Policy>(the_header, size, std::forward<ARGS>(args)...);
     initializeIfNeeded(sp);
     finalizeIfNeeded(sp);
-    //            printf("%s:%d About to return allocate result ptr@%p\n", __FILE__, __LINE__, sp.px_ref());
+    return sp;
+  };
+  template <typename Stage, GCInfo_policy Policy = GCInfo<OT>::Policy,
+            size_t Size = sizeof_with_header<OT>(), typename... ARGS>
+  static OT_sp allocate_kind(const Header_s::BadgeStampWtagMtag& the_header, ARGS&&... args) {
+    OT_sp sp =
+      allocate_in_appropriate_pool_kind<Stage, GCInfo<OT>::Policy, Size>(the_header, std::forward<ARGS>(args)...);
+    initializeIfNeeded(sp);
+    finalizeIfNeeded(sp);
     return sp;
   };
 
@@ -247,7 +279,7 @@ public:
   static OT_sp copy_kind(const Header_s::BadgeStampWtagMtag& the_header, size_t size, const OT& that) {
     // Copied objects must be allocated in the appropriate pool
     OT_sp sp =
-      allocate_in_appropriate_pool_kind<RuntimeStage, GCInfo<OT>::Policy>(the_header, size, that);
+      allocate_in_appropriate_pool_kind_variable<RuntimeStage, GCInfo<OT>::Policy>(the_header, size, that);
     // Copied objects are not initialized.
     // Copied objects are finalized if necessary
     finalizeIfNeeded(sp);
@@ -287,8 +319,7 @@ public:
 public:
   template <typename Stage = RuntimeStage, typename... ARGS> static smart_pointer_type allocate(ARGS&&... args) {
     auto kind = Header_s::StampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag);
-    size_t size = sizeof_with_header<OT>();
-    return GCObjectAllocator<OT>::template allocate_kind<Stage>(kind, size, std::forward<ARGS>(args)...);
+    return GCObjectAllocator<OT>::template allocate_kind<Stage>(kind, std::forward<ARGS>(args)...);
   }
 
   /*! Allocate enough space for capacity elements, but set the length to length */
@@ -301,12 +332,11 @@ public:
     size_t capacity = std::abs(length);
     size_t size = sizeof_container_with_header<OT>(capacity);
     if (static_container_p)
-      return GCObjectAllocator<OT>::template allocate_kind<Stage, unmanaged>(
-          Header_s::BadgeStampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag), size, length,
-          std::forward<ARGS>(args)...);
+      return GCObjectAllocator<OT>::template allocate_kind_variable<Stage, unmanaged>(Header_s::BadgeStampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag), size, length,
+                                                                                      std::forward<ARGS>(args)...);
     else
-      return GCObjectAllocator<OT>::template allocate_kind<Stage>(Header_s::BadgeStampWtagMtag(OT::static_ValueStampWtagMtag), size,
-                                                                  length, std::forward<ARGS>(args)...);
+      return GCObjectAllocator<OT>::template allocate_kind_variable<Stage>(Header_s::BadgeStampWtagMtag(OT::static_ValueStampWtagMtag), size,
+                                                                           length, std::forward<ARGS>(args)...);
   }
 
   template <typename Stage, typename... ARGS>
@@ -314,11 +344,11 @@ public:
     size_t capacity = length + 1;
     size_t size = sizeof_container_with_header<OT>(capacity);
     if (static_container_p)
-      return GCObjectAllocator<OT>::template allocate_kind<Stage, unmanaged>(
+      return GCObjectAllocator<OT>::template allocate_kind_variable<Stage, unmanaged>(
           Header_s::BadgeStampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag), size, length,
           std::forward<ARGS>(args)...);
     else
-      return GCObjectAllocator<OT>::template allocate_kind<Stage>(
+      return GCObjectAllocator<OT>::template allocate_kind_variable<Stage>(
           Header_s::BadgeStampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag), size, length,
           std::forward<ARGS>(args)...);
   }
@@ -333,10 +363,10 @@ public:
 #endif
     smart_pointer_type result;
     if (static_container_p)
-      result = GCObjectAllocator<OT>::template allocate_kind<RuntimeStage, unmanaged>(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
+      result = GCObjectAllocator<OT>::template allocate_kind_variable<RuntimeStage, unmanaged>(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
                                                                                       std::forward<ARGS>(args)...);
     else
-      result = GCObjectAllocator<OT>::template allocate_kind<RuntimeStage>(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
+      result = GCObjectAllocator<OT>::template allocate_kind_variable<RuntimeStage>(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
                                                                            std::forward<ARGS>(args)...);
 #if DEBUG_BITUNIT_CONTAINER
     {

--- a/include/clasp/gctools/gcalloc.h
+++ b/include/clasp/gctools/gcalloc.h
@@ -355,9 +355,6 @@ public:
   template <typename... ARGS>
   static smart_pointer_type allocate_bitunit_container(bool static_container_p, size_t length, ARGS&&... args) {
     size_t size = sizeof_bitunit_container_with_header<OT>(length);
-#ifdef DEBUG_BITUNIT_CONTAINER
-    printf("%s:%d  In allocate_bitunit_container length = %lu  size= %lu\n", __FILE__, __LINE__, length, size);
-#endif
     smart_pointer_type result;
     if (static_container_p)
       result = GCObjectAllocator<OT>::template allocate_kind_variable<RuntimeStage, unmanaged>(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
@@ -365,12 +362,6 @@ public:
     else
       result = GCObjectAllocator<OT>::template allocate_kind_variable<RuntimeStage>(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
                                                                            std::forward<ARGS>(args)...);
-#if DEBUG_BITUNIT_CONTAINER
-    {
-      printf("%s:%d allocate_bitunit_container \n", __FILE__, __LINE__);
-      printf("            Allocated object tagged ptr = %p\n", (void*)result.raw_());
-    }
-#endif
 
     return result;
   }

--- a/include/clasp/gctools/gcalloc.h
+++ b/include/clasp/gctools/gcalloc.h
@@ -95,13 +95,10 @@ namespace gctools {
 
 /*! Allocate regular C++ classes that are considered roots */
 template <class T> struct RootClassAllocator {
-  template <class... ARGS> static gctools::tagged_pointer<T> allocate(ARGS&&... args) {
-    return allocate_kind(Header_s::StampWtagMtag::make<T>(), sizeof_with_header<T>(), std::forward<ARGS>(args)...);
-  };
-
   template <class... ARGS>
-  static gctools::tagged_pointer<T> allocate_kind(const Header_s::StampWtagMtag& the_header, size_t size, ARGS&&... args) {
-    Header_s* base = do_uncollectable_allocation(the_header, size);
+  static gctools::tagged_pointer<T> allocate(ARGS&&... args) {
+    const Header_s::StampWtagMtag& the_header = Header_s::StampWtagMtag::make<T>();
+    Header_s* base = do_uncollectable_allocation<sizeof_with_header<T>()>(the_header);
     T* obj = HeaderPtrToGeneralPtr<T>(base);
     new (obj) T(std::forward<ARGS>(args)...);
     gctools::tagged_pointer<T> tagged_obj(obj);
@@ -118,8 +115,8 @@ template <class Stage, class Cons> struct ConsAllocator {
   static smart_ptr<Cons>
   allocate(ARGS&&... args) {
     DO_DRAG_CONS_ALLOCATION();
-    size_t cons_size = AlignUp(sizeof(Cons) + sizeof(ConsHeader_s));
-    ConsHeader_s* header = do_cons_allocation<Stage, Cons>(cons_size);
+    constexpr size_t cons_size = AlignUp(sizeof(Cons) + sizeof(ConsHeader_s));
+    ConsHeader_s* header = do_cons_allocation<Stage, Cons, cons_size>();
     Cons* cons = (Cons*)HeaderPtrToConsPtr(header);
     new (cons) Cons(std::forward<ARGS>(args)...);
     return smart_ptr<Cons>((Tagged)tag_cons(cons));
@@ -127,7 +124,7 @@ template <class Stage, class Cons> struct ConsAllocator {
 
 #ifdef USE_PRECISE_GC
   static smart_ptr<Cons> snapshot_save_load_allocate(Header_s::BadgeStampWtagMtag& the_header, core::T_sp car, core::T_sp cdr) {
-    ConsHeader_s* header = do_cons_allocation<SnapshotLoadStage, Cons>(AlignUp(sizeof(ConsHeader_s) + sizeof(Cons)));
+    ConsHeader_s* header = do_cons_allocation<SnapshotLoadStage, Cons, AlignUp(sizeof(ConsHeader_s) + sizeof(Cons))>();
     header->_badge_stamp_wtag_mtag._header_badge.store(the_header._header_badge.load());
     header->_badge_stamp_wtag_mtag._value = the_header._value;
     Cons* cons = (Cons*)HeaderPtrToConsPtr(header);

--- a/include/clasp/gctools/gcalloc.h
+++ b/include/clasp/gctools/gcalloc.h
@@ -200,9 +200,11 @@ private:
 
   template <typename Stage = RuntimeStage, GCInfo_policy Policy = normal>
   static Header_s* raw_allocate(const Header_s::BadgeStampWtagMtag& the_header, size_t size) {
-    if constexpr(Policy == normal || Policy == collectable_immobile) {
+    if constexpr(Policy == normal) {
       DO_DRAG_GENERAL_ALLOCATION();
       return do_general_allocation<Stage>(the_header, size);
+    } else if constexpr(Policy == collectable_immobile) {
+      return do_immobile_allocation<Stage>(the_header, size);
     } else if constexpr(Policy == atomic) {
       return do_atomic_allocation<Stage>(the_header, size);
     } else { // unmanaged

--- a/include/clasp/gctools/gcalloc.h
+++ b/include/clasp/gctools/gcalloc.h
@@ -285,11 +285,6 @@ public:
   typedef /*gctools::*/ smart_ptr<OT> smart_pointer_type;
 
 public:
-  template <typename... ARGS> static smart_pointer_type allocate_kind(const Header_s::BadgeStampWtagMtag& kind, ARGS&&... args) {
-    size_t size = sizeof_with_header<OT>();
-    return GCObjectAllocator<OT>::allocate_kind(kind, size, std::forward<ARGS>(args)...);
-  }
-
   template <typename Stage = RuntimeStage, typename... ARGS> static smart_pointer_type allocate(ARGS&&... args) {
     auto kind = Header_s::StampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag);
     size_t size = sizeof_with_header<OT>();

--- a/include/clasp/gctools/gcalloc.h
+++ b/include/clasp/gctools/gcalloc.h
@@ -198,7 +198,7 @@ template <class OT> class GCObjectAllocator {
 private:
   typedef smart_ptr<OT> OT_sp;
 
-  template <typename Stage = RuntimeStage, GCInfo_policy Policy = normal>
+  template <typename Stage = RuntimeStage, GCInfo_policy Policy = GCInfo<OT>::Policy>
   static Header_s* raw_allocate(const Header_s::BadgeStampWtagMtag& the_header, size_t size) {
     if constexpr(Policy == normal) {
       DO_DRAG_GENERAL_ALLOCATION();
@@ -212,7 +212,7 @@ private:
     }
   }
 
-  template <typename Stage, GCInfo_policy Policy = normal,
+  template <typename Stage, GCInfo_policy Policy = GCInfo<OT>::Policy,
             typename... ARGS>
   static OT_sp allocate_in_appropriate_pool_kind(const Header_s::BadgeStampWtagMtag& the_header, size_t size,
                                                  ARGS&&... args) {
@@ -223,7 +223,8 @@ private:
   }
 
 public:
-  template <typename Stage, typename... ARGS>
+  template <typename Stage, GCInfo_policy Policy = GCInfo<OT>::Policy,
+            typename... ARGS>
   static OT_sp allocate_kind(const Header_s::BadgeStampWtagMtag& the_header, size_t size, ARGS&&... args) {
     OT_sp sp =
       allocate_in_appropriate_pool_kind<Stage, GCInfo<OT>::Policy>(the_header, size, std::forward<ARGS>(args)...);
@@ -240,14 +241,6 @@ public:
     // No initializer
     finalizeIfNeeded(sp);
     //            printf("%s:%d About to return allocate result ptr@%p\n", __FILE__, __LINE__, sp.px_ref());
-    return sp;
-  };
-
-  template <typename... ARGS>
-  static OT_sp static_allocate_kind(const Header_s::BadgeStampWtagMtag& the_header, size_t size, ARGS&&... args) {
-    OT_sp sp = allocate_in_appropriate_pool_kind<RuntimeStage, unmanaged>(the_header, size, std::forward<ARGS>(args)...);
-    initializeIfNeeded(sp);
-    finalizeIfNeeded(sp);
     return sp;
   };
 
@@ -313,11 +306,12 @@ public:
     size_t capacity = std::abs(length);
     size_t size = sizeof_container_with_header<OT>(capacity);
     if (static_container_p)
-      return GCObjectAllocator<OT>::static_allocate_kind(
+      return GCObjectAllocator<OT>::template allocate_kind<Stage, unmanaged>(
           Header_s::BadgeStampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag), size, length,
           std::forward<ARGS>(args)...);
-    return GCObjectAllocator<OT>::template allocate_kind<Stage>(Header_s::BadgeStampWtagMtag(OT::static_ValueStampWtagMtag), size,
-                                                                length, std::forward<ARGS>(args)...);
+    else
+      return GCObjectAllocator<OT>::template allocate_kind<Stage>(Header_s::BadgeStampWtagMtag(OT::static_ValueStampWtagMtag), size,
+                                                                  length, std::forward<ARGS>(args)...);
   }
 
   template <typename Stage, typename... ARGS>
@@ -325,7 +319,7 @@ public:
     size_t capacity = length + 1;
     size_t size = sizeof_container_with_header<OT>(capacity);
     if (static_container_p)
-      return GCObjectAllocator<OT>::static_allocate_kind(
+      return GCObjectAllocator<OT>::template allocate_kind<Stage, unmanaged>(
           Header_s::BadgeStampWtagMtag::make_StampWtagMtag(OT::static_ValueStampWtagMtag), size, length,
           std::forward<ARGS>(args)...);
     else
@@ -344,8 +338,8 @@ public:
 #endif
     smart_pointer_type result;
     if (static_container_p)
-      result = GCObjectAllocator<OT>::static_allocate_kind(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
-                                                           std::forward<ARGS>(args)...);
+      result = GCObjectAllocator<OT>::template allocate_kind<RuntimeStage, unmanaged>(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
+                                                                                      std::forward<ARGS>(args)...);
     else
       result = GCObjectAllocator<OT>::template allocate_kind<RuntimeStage>(Header_s::BadgeStampWtagMtag::make<OT>(), size, length,
                                                                            std::forward<ARGS>(args)...);

--- a/include/clasp/gctools/gcalloc_boehm.h
+++ b/include/clasp/gctools/gcalloc_boehm.h
@@ -91,6 +91,12 @@ inline Header_s* do_general_allocation(const Header_s::StampWtagMtag& the_header
   return header;
 };
 
+template <typename Stage = RuntimeStage>
+inline Header_s* do_immobile_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
+  // Boehm never moves anything.
+  return do_general_allocation<Stage>(the_header, size);
+}
+
 inline Header_s* do_uncollectable_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
   size_t true_size = size;
 #ifdef DEBUG_GUARD

--- a/include/clasp/gctools/gcalloc_boehm.h
+++ b/include/clasp/gctools/gcalloc_boehm.h
@@ -61,6 +61,10 @@ inline Header_s* do_atomic_allocation(const Header_s::StampWtagMtag& the_header,
 #endif
   return header;
 };
+template <typename Stage = RuntimeStage, size_t Size>
+inline Header_s* do_atomic_allocation(const Header_s::StampWtagMtag& the_header) {
+  return do_atomic_allocation<Stage>(the_header, Size);
+}
 
 template <typename Stage = RuntimeStage>
 inline Header_s* do_general_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
@@ -91,10 +95,20 @@ inline Header_s* do_general_allocation(const Header_s::StampWtagMtag& the_header
   return header;
 };
 
+// Boehm doesn't get anything useful from constant sizes.
+template <typename Stage = RuntimeStage, size_t Size>
+inline Header_s* do_general_allocation(const Header_s::StampWtagMtag& the_header) {
+  return do_general_allocation<Stage>(the_header, Size);
+}
+
 template <typename Stage = RuntimeStage>
 inline Header_s* do_immobile_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
   // Boehm never moves anything.
   return do_general_allocation<Stage>(the_header, size);
+}
+template <typename Stage = RuntimeStage, size_t Size>
+inline Header_s* do_immobile_allocation(const Header_s::StampWtagMtag& the_header) {
+  return do_immobile_allocation<Stage>(the_header, Size);
 }
 
 inline Header_s* do_uncollectable_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
@@ -121,6 +135,11 @@ inline Header_s* do_uncollectable_allocation(const Header_s::StampWtagMtag& the_
 #endif
   return header;
 };
+
+template <size_t Size>
+inline Header_s* do_uncollectable_allocation(const Header_s::StampWtagMtag& the_header) {
+  return do_uncollectable_allocation(the_header, Size);
+}
 
 // Allocate a blank T_O* vector. This is used for the bytecode VM.
 inline void* do_allocate_zero(size_t num) {

--- a/include/clasp/gctools/gcalloc_boehm.h
+++ b/include/clasp/gctools/gcalloc_boehm.h
@@ -20,20 +20,21 @@
 #endif
 
 namespace gctools {
-template <typename Stage, typename Cons> inline ConsHeader_s* do_cons_allocation(size_t size) {
+template <typename Stage, typename Cons, size_t Size>
+inline ConsHeader_s* do_cons_allocation() {
   RAIIDisableInterrupts disable_interrupts;
 #ifdef USE_PRECISE_GC
   ConsHeader_s* header = reinterpret_cast<ConsHeader_s*>(
-      ALIGNED_GC_MALLOC_KIND(size, global_cons_kind)); // wasMTAG
+      ALIGNED_GC_MALLOC_KIND(Size, global_cons_kind)); // wasMTAG
 #ifdef DEBUG_BOEHMPRECISE_ALLOC
   printf("%s:%d:%s cons = %p\n", __FILE__, __LINE__, __FUNCTION__, cons);
 #endif
 #else
-  ConsHeader_s* header = reinterpret_cast<ConsHeader_s*>(ALIGNED_GC_MALLOC(size));
+  ConsHeader_s* header = reinterpret_cast<ConsHeader_s*>(ALIGNED_GC_MALLOC(Size));
 #endif
   const ConsHeader_s::StampWtagMtag stamp(ConsHeader_s::BadgeStampWtagMtag::make<Cons>());
   new (header) ConsHeader_s(stamp);
-  my_thread_low_level->_Allocations.registerAllocation(STAMPWTAG_CONS, size);
+  my_thread_low_level->_Allocations.registerAllocation(STAMPWTAG_CONS, Size);
   return header;
 }
 

--- a/include/clasp/gctools/gcalloc_mmtk.h
+++ b/include/clasp/gctools/gcalloc_mmtk.h
@@ -57,11 +57,32 @@ static inline Header_s* do_generic_slow_allocation(const Header_s::StampWtagMtag
   return header;
 }
 
+template <size_t Size>
+static inline Header_s* do_generic_slow_allocation(const Header_s::StampWtagMtag& the_header, MMTkClaspAllocSemantics semantics) {
+#ifdef DEBUG_GUARD
+  // size is variable, give up
+  return do_generic_slow_allocation(the_header, Size, semantics);
+#else
+  RAIIDisableInterrupts disable_interrupts;
+  void* alloc_start;
+  alloc_start = mmtk_alloc_raw(Size, semantics);
+  mmtk_post_alloc(alloc_start, Size, semantics);
+  Header_s* header = reinterpret_cast<Header_s*>(alloc_start);
+  my_thread_low_level->_Allocations.registerAllocation(the_header.unshifted_stamp(), Size);
+  new (header) Header_s(the_header);
+  return header;
+#endif
+}
+
 // --- Atomic allocation (no pointer fields) ---
 
 template <typename Stage = RuntimeStage>
 inline Header_s* do_atomic_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
   return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_DEFAULT);
+}
+template <typename Stage = RuntimeStage, size_t Size>
+inline Header_s* do_atomic_allocation(const Header_s::StampWtagMtag& the_header) {
+  return do_generic_slow_allocation<Size>(the_header, MMTK_CLASP_ALLOC_DEFAULT);
 }
 
 // --- General allocation (contains pointers) ---
@@ -70,17 +91,29 @@ template <typename Stage = RuntimeStage>
 inline Header_s* do_general_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
   return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_DEFAULT);
 }
+template <typename Stage = RuntimeStage, size_t Size>
+inline Header_s* do_general_allocation(const Header_s::StampWtagMtag& the_header) {
+  return do_generic_slow_allocation<Size>(the_header, MMTK_CLASP_ALLOC_DEFAULT);
+}
 
 // --- Non-moving allocation ---
 template <typename Stage = RuntimeStage>
 inline Header_s* do_immobile_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
   return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_NON_MOVING);
 }
+template <typename Stage = RuntimeStage, size_t Size>
+inline Header_s* do_immobile_allocation(const Header_s::StampWtagMtag& the_header) {
+  return do_generic_slow_allocation<Size>(the_header, MMTK_CLASP_ALLOC_NON_MOVING);
+}
 
 // --- Uncollectable & non-moving allocation ---
 
 inline Header_s* do_uncollectable_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
   return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_IMMORTAL);
+}
+template <size_t Size>
+inline Header_s* do_uncollectable_allocation(const Header_s::StampWtagMtag& the_header) {
+  return do_generic_slow_allocation<Size>(the_header, MMTK_CLASP_ALLOC_IMMORTAL);
 }
 
 // --- Zero-initialised allocation for the bytecode VM root vector ---

--- a/include/clasp/gctools/gcalloc_mmtk.h
+++ b/include/clasp/gctools/gcalloc_mmtk.h
@@ -11,49 +11,55 @@
 
 namespace gctools {
 
-inline void* mmtk_alloc_raw(size_t size, MMTkClaspAllocSemantics semantics) {
-  return mmtk_clasp_alloc(my_thread_low_level->_mmtk_mutator, size, CLASP_ALIGNMENT, semantics);
+inline void* mmtk_alloc_raw(ThreadLocalStateLowLevel* thread_ll,
+                            size_t size, MMTkClaspAllocSemantics semantics) {
+  return mmtk_clasp_alloc(thread_ll->_mmtk_mutator,
+                          size, CLASP_ALIGNMENT, semantics);
 }
 
-inline void mmtk_post_alloc(void* alloc_start, size_t size, MMTkClaspAllocSemantics semantics,
+inline void mmtk_post_alloc(ThreadLocalStateLowLevel* thread_ll,
+                            void* alloc_start, size_t size, MMTkClaspAllocSemantics semantics,
                              size_t header_size = sizeof(Header_s)) {
   void* client = reinterpret_cast<char*>(alloc_start) + header_size;
-  mmtk_clasp_post_alloc(my_thread_low_level->_mmtk_mutator, client, size, semantics);
+  mmtk_clasp_post_alloc(thread_ll->_mmtk_mutator, client, size, semantics);
 }
 
 // --- Cons allocation ---
 
 template <typename Stage, typename Cons, size_t Size>
 inline ConsHeader_s* do_cons_allocation() {
-  RAIIDisableInterrupts disable_interrupts;
+  // TLS access is expensive so we want to do as little of it as we can.
+  ThreadLocalStateLowLevel* thread_ll = my_thread_low_level;
+  RAIIDisableInterrupts disable_interrupts(thread_ll);
   void* alloc_start;
-  alloc_start = mmtk_alloc_raw(Size, MMTK_CLASP_ALLOC_DEFAULT);
+  alloc_start = mmtk_alloc_raw(thread_ll, Size, MMTK_CLASP_ALLOC_DEFAULT);
   ConsHeader_s* header = reinterpret_cast<ConsHeader_s*>(alloc_start);
   const ConsHeader_s::StampWtagMtag stamp(ConsHeader_s::BadgeStampWtagMtag::make<Cons>());
   new (header) ConsHeader_s(stamp);
-  my_thread_low_level->_Allocations.registerAllocation(STAMPWTAG_CONS, Size);
-  mmtk_post_alloc(alloc_start, Size, MMTK_CLASP_ALLOC_DEFAULT, sizeof(ConsHeader_s));
+  thread_ll->_Allocations.registerAllocation(STAMPWTAG_CONS, Size);
+  mmtk_post_alloc(thread_ll, alloc_start, Size, MMTK_CLASP_ALLOC_DEFAULT, sizeof(ConsHeader_s));
   return header;
 }
 
 static inline Header_s* do_generic_slow_allocation(const Header_s::StampWtagMtag& the_header, size_t size, MMTkClaspAllocSemantics semantics) {
-  RAIIDisableInterrupts disable_interrupts;
+  ThreadLocalStateLowLevel* thread_ll = my_thread_low_level;
+  RAIIDisableInterrupts disable_interrupts(thread_ll);
   size_t true_size = size;
 #ifdef DEBUG_GUARD
   size_t tail_size = ((rand() % 8) + 1) * Alignment();
   true_size += tail_size;
 #endif
   void* alloc_start;
-  alloc_start = mmtk_alloc_raw(true_size, semantics);
+  alloc_start = mmtk_alloc_raw(thread_ll, true_size, semantics);
   Header_s* header = reinterpret_cast<Header_s*>(alloc_start);
-  my_thread_low_level->_Allocations.registerAllocation(the_header.unshifted_stamp(), true_size);
+  thread_ll->_Allocations.registerAllocation(the_header.unshifted_stamp(), true_size);
 #ifdef DEBUG_GUARD
   memset(header, 0x00, true_size);
   new (header) Header_s(the_header, size, tail_size, true_size);
 #else
   new (header) Header_s(the_header);
 #endif
-  mmtk_post_alloc(alloc_start, true_size, semantics);
+  mmtk_post_alloc(thread_ll, alloc_start, true_size, semantics);
   return header;
 }
 
@@ -63,13 +69,14 @@ static inline Header_s* do_generic_slow_allocation(const Header_s::StampWtagMtag
   // size is variable, give up
   return do_generic_slow_allocation(the_header, Size, semantics);
 #else
-  RAIIDisableInterrupts disable_interrupts;
+  ThreadLocalStateLowLevel* thread_ll = my_thread_low_level;
+  RAIIDisableInterrupts disable_interrupts(thread_ll);
   void* alloc_start;
-  alloc_start = mmtk_alloc_raw(Size, semantics);
+  alloc_start = mmtk_alloc_raw(thread_ll, Size, semantics);
   Header_s* header = reinterpret_cast<Header_s*>(alloc_start);
-  my_thread_low_level->_Allocations.registerAllocation(the_header.unshifted_stamp(), Size);
+  thread_ll->_Allocations.registerAllocation(the_header.unshifted_stamp(), Size);
   new (header) Header_s(the_header);
-  mmtk_post_alloc(alloc_start, Size, semantics);
+  mmtk_post_alloc(thread_ll, alloc_start, Size, semantics);
   return header;
 #endif
 }

--- a/include/clasp/gctools/gcalloc_mmtk.h
+++ b/include/clasp/gctools/gcalloc_mmtk.h
@@ -23,16 +23,16 @@ inline void mmtk_post_alloc(void* alloc_start, size_t size, MMTkClaspAllocSemant
 
 // --- Cons allocation ---
 
-template <typename Stage, typename Cons>
-inline ConsHeader_s* do_cons_allocation(size_t size) {
+template <typename Stage, typename Cons, size_t Size>
+inline ConsHeader_s* do_cons_allocation() {
   RAIIDisableInterrupts disable_interrupts;
   void* alloc_start;
-  alloc_start = mmtk_alloc_raw(size, MMTK_CLASP_ALLOC_DEFAULT);
-  mmtk_post_alloc(alloc_start, size, MMTK_CLASP_ALLOC_DEFAULT, sizeof(ConsHeader_s));
+  alloc_start = mmtk_alloc_raw(Size, MMTK_CLASP_ALLOC_DEFAULT);
+  mmtk_post_alloc(alloc_start, Size, MMTK_CLASP_ALLOC_DEFAULT, sizeof(ConsHeader_s));
   ConsHeader_s* header = reinterpret_cast<ConsHeader_s*>(alloc_start);
   const ConsHeader_s::StampWtagMtag stamp(ConsHeader_s::BadgeStampWtagMtag::make<Cons>());
   new (header) ConsHeader_s(stamp);
-  my_thread_low_level->_Allocations.registerAllocation(STAMPWTAG_CONS, size);
+  my_thread_low_level->_Allocations.registerAllocation(STAMPWTAG_CONS, Size);
   return header;
 }
 

--- a/include/clasp/gctools/gcalloc_mmtk.h
+++ b/include/clasp/gctools/gcalloc_mmtk.h
@@ -36,10 +36,7 @@ inline ConsHeader_s* do_cons_allocation(size_t size) {
   return header;
 }
 
-// --- Atomic allocation (no pointer fields) ---
-
-template <typename Stage = RuntimeStage>
-inline Header_s* do_atomic_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
+static inline Header_s* do_generic_slow_allocation(const Header_s::StampWtagMtag& the_header, size_t size, MMTkClaspAllocSemantics semantics) {
   RAIIDisableInterrupts disable_interrupts;
   size_t true_size = size;
 #ifdef DEBUG_GUARD
@@ -47,8 +44,8 @@ inline Header_s* do_atomic_allocation(const Header_s::StampWtagMtag& the_header,
   true_size += tail_size;
 #endif
   void* alloc_start;
-  alloc_start = mmtk_alloc_raw(true_size, MMTK_CLASP_ALLOC_DEFAULT);
-  mmtk_post_alloc(alloc_start, true_size, MMTK_CLASP_ALLOC_DEFAULT);
+  alloc_start = mmtk_alloc_raw(true_size, semantics);
+  mmtk_post_alloc(alloc_start, true_size, semantics);
   Header_s* header = reinterpret_cast<Header_s*>(alloc_start);
   my_thread_low_level->_Allocations.registerAllocation(the_header.unshifted_stamp(), true_size);
 #ifdef DEBUG_GUARD
@@ -58,51 +55,32 @@ inline Header_s* do_atomic_allocation(const Header_s::StampWtagMtag& the_header,
   new (header) Header_s(the_header);
 #endif
   return header;
+}
+
+// --- Atomic allocation (no pointer fields) ---
+
+template <typename Stage = RuntimeStage>
+inline Header_s* do_atomic_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
+  return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_DEFAULT);
 }
 
 // --- General allocation (contains pointers) ---
 
 template <typename Stage = RuntimeStage>
 inline Header_s* do_general_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
-  RAIIDisableInterrupts disable_interrupts;
-  size_t true_size = size;
-#ifdef DEBUG_GUARD
-  size_t tail_size = ((rand() % 8) + 1) * Alignment();
-  true_size += tail_size;
-#endif
-  void* alloc_start;
-  alloc_start = mmtk_alloc_raw(true_size, MMTK_CLASP_ALLOC_DEFAULT);
-  mmtk_post_alloc(alloc_start, true_size, MMTK_CLASP_ALLOC_DEFAULT);
-  Header_s* header = reinterpret_cast<Header_s*>(alloc_start);
-  my_thread_low_level->_Allocations.registerAllocation(the_header.unshifted_stamp(), true_size);
-#ifdef DEBUG_GUARD
-  memset(header, 0x00, true_size);
-  new (header) Header_s(the_header, size, tail_size, true_size);
-#else
-  new (header) Header_s(the_header);
-#endif
-  return header;
+  return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_DEFAULT);
 }
 
-// --- Uncollectable / non-moving allocation ---
+// --- Non-moving allocation ---
+template <typename Stage = RuntimeStage>
+inline Header_s* do_immobile_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
+  return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_NON_MOVING);
+}
+
+// --- Uncollectable & non-moving allocation ---
 
 inline Header_s* do_uncollectable_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
-  size_t true_size = size;
-#ifdef DEBUG_GUARD
-  size_t tail_size = ((rand() % 8) + 1) * Alignment();
-  true_size += tail_size;
-#endif
-  void* alloc_start = mmtk_alloc_raw(true_size, MMTK_CLASP_ALLOC_NON_MOVING);
-  mmtk_post_alloc(alloc_start, true_size, MMTK_CLASP_ALLOC_NON_MOVING);
-  Header_s* header = reinterpret_cast<Header_s*>(alloc_start);
-  my_thread_low_level->_Allocations.registerAllocation(the_header.unshifted_stamp(), true_size);
-#ifdef DEBUG_GUARD
-  memset(header, 0x00, true_size);
-  new (header) Header_s(the_header, size, tail_size, true_size);
-#else
-  new (header) Header_s(the_header);
-#endif
-  return header;
+  return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_IMMORTAL);
 }
 
 // --- Zero-initialised allocation for the bytecode VM root vector ---

--- a/include/clasp/gctools/gcalloc_mmtk.h
+++ b/include/clasp/gctools/gcalloc_mmtk.h
@@ -28,11 +28,11 @@ inline ConsHeader_s* do_cons_allocation() {
   RAIIDisableInterrupts disable_interrupts;
   void* alloc_start;
   alloc_start = mmtk_alloc_raw(Size, MMTK_CLASP_ALLOC_DEFAULT);
-  mmtk_post_alloc(alloc_start, Size, MMTK_CLASP_ALLOC_DEFAULT, sizeof(ConsHeader_s));
   ConsHeader_s* header = reinterpret_cast<ConsHeader_s*>(alloc_start);
   const ConsHeader_s::StampWtagMtag stamp(ConsHeader_s::BadgeStampWtagMtag::make<Cons>());
   new (header) ConsHeader_s(stamp);
   my_thread_low_level->_Allocations.registerAllocation(STAMPWTAG_CONS, Size);
+  mmtk_post_alloc(alloc_start, Size, MMTK_CLASP_ALLOC_DEFAULT, sizeof(ConsHeader_s));
   return header;
 }
 
@@ -45,7 +45,6 @@ static inline Header_s* do_generic_slow_allocation(const Header_s::StampWtagMtag
 #endif
   void* alloc_start;
   alloc_start = mmtk_alloc_raw(true_size, semantics);
-  mmtk_post_alloc(alloc_start, true_size, semantics);
   Header_s* header = reinterpret_cast<Header_s*>(alloc_start);
   my_thread_low_level->_Allocations.registerAllocation(the_header.unshifted_stamp(), true_size);
 #ifdef DEBUG_GUARD
@@ -54,6 +53,7 @@ static inline Header_s* do_generic_slow_allocation(const Header_s::StampWtagMtag
 #else
   new (header) Header_s(the_header);
 #endif
+  mmtk_post_alloc(alloc_start, true_size, semantics);
   return header;
 }
 
@@ -66,10 +66,10 @@ static inline Header_s* do_generic_slow_allocation(const Header_s::StampWtagMtag
   RAIIDisableInterrupts disable_interrupts;
   void* alloc_start;
   alloc_start = mmtk_alloc_raw(Size, semantics);
-  mmtk_post_alloc(alloc_start, Size, semantics);
   Header_s* header = reinterpret_cast<Header_s*>(alloc_start);
   my_thread_low_level->_Allocations.registerAllocation(the_header.unshifted_stamp(), Size);
   new (header) Header_s(the_header);
+  mmtk_post_alloc(alloc_start, Size, semantics);
   return header;
 #endif
 }

--- a/include/clasp/gctools/gcalloc_mmtk.h
+++ b/include/clasp/gctools/gcalloc_mmtk.h
@@ -126,21 +126,25 @@ inline Header_s* do_general_allocation(const Header_s::StampWtagMtag& the_header
 // --- Non-moving allocation ---
 template <typename Stage = RuntimeStage>
 inline Header_s* do_immobile_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
-  return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_NON_MOVING);
+  MMTkClaspAllocSemantics semantics = semantics_or(MMTK_CLASP_ALLOC_NON_MOVING, size);
+  return do_generic_slow_allocation(the_header, size, semantics);
 }
 template <typename Stage = RuntimeStage, size_t Size>
 inline Header_s* do_immobile_allocation(const Header_s::StampWtagMtag& the_header) {
-  return do_generic_slow_allocation<Size>(the_header, MMTK_CLASP_ALLOC_NON_MOVING);
+  MMTkClaspAllocSemantics semantics = semantics_or(MMTK_CLASP_ALLOC_NON_MOVING, Size);
+  return do_generic_slow_allocation<Size>(the_header, semantics);
 }
 
 // --- Uncollectable & non-moving allocation ---
 
 inline Header_s* do_uncollectable_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
-  return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_IMMORTAL);
+  MMTkClaspAllocSemantics semantics = semantics_or(MMTK_CLASP_ALLOC_IMMORTAL, size);
+  return do_generic_slow_allocation(the_header, size, semantics);
 }
 template <size_t Size>
 inline Header_s* do_uncollectable_allocation(const Header_s::StampWtagMtag& the_header) {
-  return do_generic_slow_allocation<Size>(the_header, MMTK_CLASP_ALLOC_IMMORTAL);
+  MMTkClaspAllocSemantics semantics = semantics_or(MMTK_CLASP_ALLOC_IMMORTAL, Size);
+  return do_generic_slow_allocation<Size>(the_header, semantics);
 }
 
 // --- Zero-initialised allocation for the bytecode VM root vector ---

--- a/include/clasp/gctools/gcalloc_mmtk.h
+++ b/include/clasp/gctools/gcalloc_mmtk.h
@@ -11,17 +11,32 @@
 
 namespace gctools {
 
+// defined in mmtkGarbageCollection.cc
+extern size_t max_non_los_default_alloc_bytes;
+
 inline void* mmtk_alloc_raw(ThreadLocalStateLowLevel* thread_ll,
                             size_t size, MMTkClaspAllocSemantics semantics) {
-  return mmtk_clasp_alloc(thread_ll->_mmtk_mutator,
-                          size, CLASP_ALIGNMENT, semantics);
+  if (semantics == MMTK_CLASP_ALLOC_DEFAULT)
+    return mmtk_clasp_alloc_immix(thread_ll->_mmtk_mutator,
+                                  thread_ll->_mmtk_default_allocator_offset,
+                                  size, CLASP_ALIGNMENT);
+  return mmtk_clasp_alloc(thread_ll->_mmtk_mutator, size, CLASP_ALIGNMENT, semantics);
 }
 
 inline void mmtk_post_alloc(ThreadLocalStateLowLevel* thread_ll,
                             void* alloc_start, size_t size, MMTkClaspAllocSemantics semantics,
-                             size_t header_size = sizeof(Header_s)) {
+                            size_t header_size = sizeof(Header_s)) {
   void* client = reinterpret_cast<char*>(alloc_start) + header_size;
-  mmtk_clasp_post_alloc(thread_ll->_mmtk_mutator, client, size, semantics);
+  if (semantics == MMTK_CLASP_ALLOC_DEFAULT)
+    mmtk_clasp_post_alloc_immix(thread_ll->_mmtk_mutator, client, size);
+  else
+    mmtk_clasp_post_alloc(thread_ll->_mmtk_mutator, client, size, semantics);
+}
+
+inline MMTkClaspAllocSemantics semantics_or(MMTkClaspAllocSemantics semantics, size_t size) {
+  if (size < max_non_los_default_alloc_bytes)
+    return semantics;
+  else return MMTK_CLASP_ALLOC_LOS;
 }
 
 // --- Cons allocation ---
@@ -31,13 +46,14 @@ inline ConsHeader_s* do_cons_allocation() {
   // TLS access is expensive so we want to do as little of it as we can.
   ThreadLocalStateLowLevel* thread_ll = my_thread_low_level;
   RAIIDisableInterrupts disable_interrupts(thread_ll);
+  MMTkClaspAllocSemantics semantics = semantics_or(MMTK_CLASP_ALLOC_DEFAULT, Size);
   void* alloc_start;
-  alloc_start = mmtk_alloc_raw(thread_ll, Size, MMTK_CLASP_ALLOC_DEFAULT);
+  alloc_start = mmtk_alloc_raw(thread_ll, Size, semantics);
   ConsHeader_s* header = reinterpret_cast<ConsHeader_s*>(alloc_start);
   const ConsHeader_s::StampWtagMtag stamp(ConsHeader_s::BadgeStampWtagMtag::make<Cons>());
   new (header) ConsHeader_s(stamp);
   thread_ll->_Allocations.registerAllocation(STAMPWTAG_CONS, Size);
-  mmtk_post_alloc(thread_ll, alloc_start, Size, MMTK_CLASP_ALLOC_DEFAULT, sizeof(ConsHeader_s));
+  mmtk_post_alloc(thread_ll, alloc_start, Size, semantics, sizeof(ConsHeader_s));
   return header;
 }
 
@@ -85,22 +101,26 @@ static inline Header_s* do_generic_slow_allocation(const Header_s::StampWtagMtag
 
 template <typename Stage = RuntimeStage>
 inline Header_s* do_atomic_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
-  return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_DEFAULT);
+  MMTkClaspAllocSemantics semantics = semantics_or(MMTK_CLASP_ALLOC_DEFAULT, size);
+  return do_generic_slow_allocation(the_header, size, semantics);
 }
 template <typename Stage = RuntimeStage, size_t Size>
 inline Header_s* do_atomic_allocation(const Header_s::StampWtagMtag& the_header) {
-  return do_generic_slow_allocation<Size>(the_header, MMTK_CLASP_ALLOC_DEFAULT);
+  MMTkClaspAllocSemantics semantics = semantics_or(MMTK_CLASP_ALLOC_DEFAULT, Size);
+  return do_generic_slow_allocation<Size>(the_header, semantics);
 }
 
 // --- General allocation (contains pointers) ---
 
 template <typename Stage = RuntimeStage>
 inline Header_s* do_general_allocation(const Header_s::StampWtagMtag& the_header, size_t size) {
-  return do_generic_slow_allocation(the_header, size, MMTK_CLASP_ALLOC_DEFAULT);
+  MMTkClaspAllocSemantics semantics = semantics_or(MMTK_CLASP_ALLOC_DEFAULT, size);
+  return do_generic_slow_allocation(the_header, size, semantics);
 }
 template <typename Stage = RuntimeStage, size_t Size>
 inline Header_s* do_general_allocation(const Header_s::StampWtagMtag& the_header) {
-  return do_generic_slow_allocation<Size>(the_header, MMTK_CLASP_ALLOC_DEFAULT);
+  MMTkClaspAllocSemantics semantics = semantics_or(MMTK_CLASP_ALLOC_DEFAULT, Size);
+  return do_generic_slow_allocation<Size>(the_header, semantics);
 }
 
 // --- Non-moving allocation ---

--- a/include/clasp/gctools/gcbitarray.h
+++ b/include/clasp/gctools/gcbitarray.h
@@ -79,23 +79,12 @@ public:
     // Initialize the contents from an array - but it has to be bit_array_word aligned
     // if you need other than word aligned add another parameter to this constructor
     size_t numWords = nwords_for_length(length);
-#ifdef DEBUG_BITUNIT_CONTAINER
-    printf("%s:%d ctor for GCBitUnitArray_moveable _Data[0] @%p\n", __FILE__, __LINE__, (void*)&this->_Data[0]);
-    printf("%s:%d      initialContentsSize = %lu\n", __FILE__, __LINE__, initialContentsSize);
-    printf("%s:%d                 numWords = %lu\n", __FILE__, __LINE__, numWords);
-#endif
     size_t idx;
     idx = 0;
     for (; idx < initialContentsSize; ++idx)
       this->_Data[idx] = initialContents[idx];
     for (; idx < numWords; ++idx)
       this->_Data[idx] = initialValue;
-#ifdef DEBUG_BITUNIT_CONTAINER
-    printf("%s:%d done initialization of data in ctor for GCBitUnitArray_moveable _Data[0] @%p\n", __FILE__, __LINE__,
-           (void*)&this->_Data[0]);
-    printf("%s:%d      final value of idx = %lu\n", __FILE__, __LINE__, idx);
-    printf("%s:%d      wrote up to address: %p\n", __FILE__, __LINE__, (void*)&this->_Data[idx]);
-#endif
   }
   GCBitUnitArray_moveable(size_t length, bit_array_word* initialContents) : _Length(length) {
     for (size_t i = 0; i < nwords_for_length(length); ++i)
@@ -109,12 +98,6 @@ public:
   static size_t sizeof_for_length(size_t length) {
     size_t numWords = (length + number_of_bit_units_in_word - 1) / number_of_bit_units_in_word;
     size_t numBytes = numWords * sizeof(bit_array_word);
-#ifdef DEBUG_BITUNIT_CONTAINER
-    printf("%s:%d length = %lu\n", __FILE__, __LINE__, length);
-    printf("%s:%d number_of_bit_units_in_word = %lu\n", __FILE__, __LINE__, number_of_bit_units_in_word);
-    printf("%s:%d numWords = %lu\n", __FILE__, __LINE__, numWords);
-    printf("%s:%d numBytes = %lu\n", __FILE__, __LINE__, numBytes);
-#endif
     return numBytes;
   }
   // Given an initial element, replicate it into a bit_array_word. E.g. 01 becomes 01010101...01

--- a/include/clasp/gctools/memoryManagement.h
+++ b/include/clasp/gctools/memoryManagement.h
@@ -207,7 +207,7 @@ typedef uintptr_t UnshiftedStamp; // first 62 bits
 typedef uintptr_t ShiftedStamp;   // High 62 bits
 extern std::atomic<UnshiftedStamp> global_NextUnshiftedStamp;
 
-template <class T> inline size_t sizeof_with_header();
+template <class T> constexpr size_t sizeof_with_header();
 
 // ----------------------------------------------------------------------
 // ----------------------------------------------------------------------
@@ -889,7 +889,7 @@ namespace gctools {
 
 // ----------------------------------------------------------------------
 //! Calculate the size of an object + header for allocation
-template <class T> inline size_t sizeof_with_header() { return AlignUp(sizeof(T)) + sizeof(Header_s); }
+template <class T> constexpr size_t sizeof_with_header() { return AlignUp(sizeof(T)) + sizeof(Header_s); }
 
 /*! Size of containers given the number of elements */
 template <typename Cont_impl> size_t sizeof_container(size_t n) {

--- a/include/clasp/gctools/memoryManagement.h
+++ b/include/clasp/gctools/memoryManagement.h
@@ -921,12 +921,6 @@ template <typename Cont_impl> size_t sizeof_bitunit_container(size_t n) {
   size_t dataSz = Cont_impl::bitunit_array_type::sizeof_for_length(n);
   size_t totalSz = classSz + dataSz;
   size_t aligned_totalSz = AlignUp(totalSz);
-#ifdef DEBUG_BITUNIT_CONTAINER
-  printf("%s:%d classSz = %lu\n", __FILE__, __LINE__, classSz);
-  printf("%s:%d dataSz = %lu\n", __FILE__, __LINE__, dataSz);
-  printf("%s:%d totalSz = %lu\n", __FILE__, __LINE__, totalSz);
-  printf("%s:%d aligned_totalSz = %lu\n", __FILE__, __LINE__, aligned_totalSz);
-#endif
   return aligned_totalSz;
 };
 
@@ -934,12 +928,6 @@ template <class T> inline size_t sizeof_bitunit_container_with_header(size_t num
   size_t size_bitunit_container = sizeof_bitunit_container<T>(num);
   size_t size_header = sizeof(Header_s);
   size_t sum = size_bitunit_container + size_header;
-#ifdef DEBUG_BITUNIT_CONTAINER
-  printf("%s:%d  In sizeof_bitunit_container_with_header  num = %lu\n", __FILE__, __LINE__, num);
-  printf("%s:%d  In sizeof_bitunit_container_with_header   size_bitunit_container = %lu\n", __FILE__, __LINE__,
-         size_bitunit_container);
-  printf("%s:%d  In sizeof_bitunit_container_with_header   sum = %lu\n", __FILE__, __LINE__, sum);
-#endif
   return sum;
 };
 

--- a/include/clasp/gctools/memoryManagement.h
+++ b/include/clasp/gctools/memoryManagement.h
@@ -189,10 +189,6 @@ inline constexpr uintptr_t AlignDown(uintptr_t size, size_t alignment) { return 
 
 }; // namespace gctools
 
-namespace gctools {
-class ThreadLocalState;
-};
-
 /*! Declare this in the top namespace */
 extern THREAD_LOCAL core::ThreadLocalState* my_thread;
 

--- a/include/clasp/gctools/memoryManagement.h
+++ b/include/clasp/gctools/memoryManagement.h
@@ -292,52 +292,51 @@ template <class T> constexpr size_t sizeof_with_header();
 
 class BaseHeader_s {
 public:
-  // fixme2022
-  static const size_t mtag_shift = 3; // mtags are 3 bits wide
-  static const tagged_stamp_t mtag_mask = 0b111;
+  static constexpr size_t mtag_shift = 3; // mtags are 3 bits wide
+  static constexpr tagged_stamp_t mtag_mask = 0b111;
 #if 1
-  static const size_t general_mtag_width = mtag_shift;
-  static const tagged_stamp_t general_mtag_mask = 0b111;
+  static constexpr size_t general_mtag_width = mtag_shift;
+  static constexpr tagged_stamp_t general_mtag_mask = 0b111;
 #else
-  static const size_t general_mtag_width = 2;
-  static const tagged_stamp_t general_mtag_mask = 0b11;
+  static constexpr size_t general_mtag_width = 2;
+  static constexpr tagged_stamp_t general_mtag_mask = 0b11;
 #endif
-  static const size_t general_mtag_shift = general_mtag_width; // MUST ALWAYS BE >=2 to match Fixnum shift
-  static const tagged_stamp_t general_mtag = 0b000;
-  //static const tagged_stamp_t invalid_mtag = 0b001;
-  //static const tagged_stamp_t invalid_mtag = 0b010;
-  //static const tagged_stamp_t invalid_mtag = 0b011;
-  //static const tagged_stamp_t invalid_mtag = 0b100;
-  static const tagged_stamp_t fwd_mtag = 0b101;
-  //static const tagged_stamp_t invalid_mtag = 0b110;
-  //static const tagged_stamp_t invalid_mtag = 0b111;
-  static const tagged_stamp_t stamp_mtag = general_mtag;
-  static const tagged_stamp_t stamp_mask = ~(tagged_stamp_t)general_mtag_mask; // 0b11...111111111111000;
-  static const tagged_stamp_t where_mask = 0b11 << general_mtag_shift;
+  static constexpr size_t general_mtag_shift = general_mtag_width; // MUST ALWAYS BE >=2 to match Fixnum shift
+  static constexpr tagged_stamp_t general_mtag = 0b000;
+  //static constexpr tagged_stamp_t invalid_mtag = 0b001;
+  //static constexpr tagged_stamp_t invalid_mtag = 0b010;
+  //static constexpr tagged_stamp_t invalid_mtag = 0b011;
+  //static constexpr tagged_stamp_t invalid_mtag = 0b100;
+  static constexpr tagged_stamp_t fwd_mtag = 0b101;
+  //static constexpr tagged_stamp_t invalid_mtag = 0b110;
+  //static constexpr tagged_stamp_t invalid_mtag = 0b111;
+  static constexpr tagged_stamp_t stamp_mtag = general_mtag;
+  static constexpr tagged_stamp_t stamp_mask = ~(tagged_stamp_t)general_mtag_mask; // 0b11...111111111111000;
+  static constexpr tagged_stamp_t where_mask = 0b11 << general_mtag_shift;
   // These MUST match the wtags used in clasp-analyzer.lisp and scraper/code-generator.lisp
-  static const tagged_stamp_t derivable_wtag = 0b00 << general_mtag_shift;
-  static const tagged_stamp_t rack_wtag = 0b01 << general_mtag_shift;
-  static const tagged_stamp_t wrapped_wtag = 0b10 << general_mtag_shift;
-  static const tagged_stamp_t header_wtag = 0b11 << general_mtag_shift;
-  static const tagged_stamp_t max_wtag = 0b11 << general_mtag_shift;
-  static const tagged_stamp_t wtag_width = 2;
-  static const size_t general_stamp_shift = general_mtag_width + wtag_width;
+  static constexpr tagged_stamp_t derivable_wtag = 0b00 << general_mtag_shift;
+  static constexpr tagged_stamp_t rack_wtag = 0b01 << general_mtag_shift;
+  static constexpr tagged_stamp_t wrapped_wtag = 0b10 << general_mtag_shift;
+  static constexpr tagged_stamp_t header_wtag = 0b11 << general_mtag_shift;
+  static constexpr tagged_stamp_t max_wtag = 0b11 << general_mtag_shift;
+  static constexpr tagged_stamp_t wtag_width = 2;
+  static constexpr size_t general_stamp_shift = general_mtag_width + wtag_width;
 
   // Must match the number of bits to describe where_mask from the 0th bit
   // This is the width of integer that llvm needs to represent the masked off part of a header stamp
-  static const tagged_stamp_t where_tag_width = wtag_width + general_mtag_width; // I'm not sure if this is right
+  static constexpr tagged_stamp_t where_tag_width = wtag_width + general_mtag_width; // I'm not sure if this is right
 
   // stamp_tag MUST be 00 so that stamps look like FIXNUMs
-  //    static const int stamp_shift = general_mtag_shift;
-  static const tagged_stamp_t largest_possible_stamp = stamp_mask >> general_mtag_shift;
+  //    static constexpr int stamp_shift = general_mtag_shift;
+  static constexpr tagged_stamp_t largest_possible_stamp = stamp_mask >> general_mtag_shift;
 
   //
   // Restrict stamps to specific ranges
   // Builtin classes are between 0...65536
   // clbind classes are between 65537...131072
   // Lisp classes are 131073 and higher
-  static const size_t max_builtin_stamp = 65536;
-  static const size_t max_clbind_stamp = 65536 + max_builtin_stamp;
+  static constexpr size_t max_builtin_stamp = 65536;
+  static constexpr size_t max_clbind_stamp = 65536 + max_builtin_stamp;
 
 public:
   //

--- a/include/clasp/gctools/mmtk_clasp.h
+++ b/include/clasp/gctools/mmtk_clasp.h
@@ -29,6 +29,7 @@ extern bool mmtk_clasp_set_fixed_heap_size(MMTkClaspBuilder builder, size_t heap
 extern bool mmtk_clasp_set_dynamic_heap_size(MMTkClaspBuilder builder, size_t min_heap, size_t max_heap);
 extern void mmtk_clasp_init(MMTkClaspBuilder builder);
 extern void mmtk_clasp_initialize_collection(void* tls);
+extern size_t mmtk_clasp_max_default_alloc_bytes();
 
 // Fork support. Call mmtk_clasp_prepare_to_fork() in the parent before fork();
 // it stops the GC worker threads and blocks until they have exited. Call
@@ -49,6 +50,17 @@ extern void* mmtk_clasp_alloc(MMTkClaspMutator mutator, size_t size, size_t alig
                               MMTkClaspAllocSemantics semantics);
 extern void mmtk_clasp_post_alloc(MMTkClaspMutator mutator, void* object_ref, size_t bytes,
                                   MMTkClaspAllocSemantics semantics);
+
+// Fast-path allocation for Default (Immix) semantics.
+// mmtk_clasp_get_default_allocator_offset() returns the byte offset from a Mutator
+// pointer to its Immix allocator; this value is constant for all mutators — compute
+// it once when binding each mutator and cache it.  Pass it to mmtk_clasp_alloc_immix
+// and mmtk_clasp_post_alloc_immix to bypass AllocationSemantics dispatch on every call.
+extern size_t mmtk_clasp_get_default_allocator_offset(void);
+extern void*  mmtk_clasp_alloc_immix(MMTkClaspMutator mutator, size_t immix_offset,
+                                     size_t size, size_t align);
+extern void   mmtk_clasp_post_alloc_immix(MMTkClaspMutator mutator, void* object_ref,
+                                          size_t bytes);
 
 // Heap statistics
 extern size_t mmtk_clasp_used_bytes(void);

--- a/include/clasp/gctools/scan.h
+++ b/include/clasp/gctools/scan.h
@@ -31,15 +31,8 @@ public:
   template <std::invocable<core::T_O**> Fixer>
   static void cons(core::Cons_O* client, Fixer&& fix) {
     gctools::ConsHeader_s& header = *(gctools::ConsHeader_s*)gctools::ConsPtrToHeaderPtr(client);
-    if (header._badge_stamp_wtag_mtag.consObjectP()) {
-      fix((core::T_O**)&client->_Car);
-      fix((core::T_O**)&client->_Cdr);
-    } else if (!header._badge_stamp_wtag_mtag.fwdP()) {
-      printf("%s:%d CONS in cons_scan client=%p\n(it's not a CONS or any of fwd car=%p "
-           "cdr=%p\n",
-             __FILE__, __LINE__, (void*)client, client->car().raw_(), client->cdr().raw_());
-      truly_abort();
-    }
+    fix((core::T_O**)&client->_Car);
+    fix((core::T_O**)&client->_Cdr);
   }
   
   template <std::invocable<core::T_O**> Fixer,

--- a/include/clasp/gctools/scan.h
+++ b/include/clasp/gctools/scan.h
@@ -56,54 +56,52 @@ public:
     case gctools::Header_s::general_mtag: {
       gctools::GCStampEnum stamp_wtag = header._badge_stamp_wtag_mtag.stamp_wtag();
       const gctools::Stamp_layout& stamp_layout = gctools::global_stamp_layout[stamp_index];
-      // Basic fields
-      if (stamp_layout.field_layout_start) {
 #ifdef USE_PRECISE_GC
-        if (stamp_layout.flags & gctools::COMPLEX_SCAN) {
-          // This object is too big for the bitmap, or has something weird in it
-          // like weak references. Scan by iterating over the fields.
-          int num_fields = stamp_layout.number_of_fields;
-          const gctools::Field_layout* field_layout_cur = stamp_layout.field_layout_start;
-          for (int i = 0; i < num_fields; ++i, ++field_layout_cur) {
-            void* field = (void*)((const char*)client + field_layout_cur->offset);
-            switch (field_layout_cur->type) {
+      // Basic (non-container) fields
+      if (stamp_layout.flags & gctools::COMPLEX_SCAN) [[unlikely]] {
+        // This object is too big for the bitmap, or has something weird in it
+        // like weak references. Scan by iterating over the fields.
+        int num_fields = stamp_layout.number_of_fields;
+        const gctools::Field_layout* field_layout_cur = stamp_layout.field_layout_start;
+        for (int i = 0; i < num_fields; ++i, ++field_layout_cur) {
+          void* field = (void*)((const char*)client + field_layout_cur->offset);
+          switch (field_layout_cur->type) {
+            [[unlikely]]
+          case WEAK_PTR_OFFSET: weakfix((WeakPointer*)field); break;
               [[unlikely]]
-            case WEAK_PTR_OFFSET: weakfix((WeakPointer*)field); break;
-                [[unlikely]]
-            case QWEAK_OFFSET:
-                queueablefix((QueueableWeakReference*)field); break;
-                [[unlikely]]
-            case EPHEMERON_OFFSET: ephfix((Ephemeron*)field); break;
-                [[likely]] // normal field
-            default: fix((core::T_O**)field); break;
-            }
-          }
-        } else {
-          // Use pointer bitmaps
-          uintptr_t pointer_bitmap = stamp_layout.class_field_pointer_bitmap;
-          for (core::T_O** addr = (core::T_O**)client; pointer_bitmap;
-               addr++, pointer_bitmap <<= 1) {
-            if ((intptr_t)pointer_bitmap < 0) { // checking high bit
-              fix(addr);
-            }
+          case QWEAK_OFFSET:
+              queueablefix((QueueableWeakReference*)field); break;
+              [[unlikely]]
+          case EPHEMERON_OFFSET: ephfix((Ephemeron*)field); break;
+              [[likely]] // normal field
+          default: fix((core::T_O**)field); break;
           }
         }
-#endif // USE_PRECISE_GC
+      } else {
+        // Use pointer bitmaps
+        uintptr_t pointer_bitmap = stamp_layout.class_field_pointer_bitmap;
+        for (core::T_O** addr = (core::T_O**)client; pointer_bitmap;
+             addr++, pointer_bitmap <<= 1) {
+          if ((intptr_t)pointer_bitmap < 0) { // checking high bit
+            fix(addr);
+          }
+        }
       }
+#endif // USE_PRECISE_GC
       // Container fields
       if (stamp_layout.container_layout) {
         const gctools::Container_layout& container_layout = *stamp_layout.container_layout;
         size_t end = *(size_t*)((const char*)client + container_layout.end_offset);
         // Use new way with pointer bitmaps
         uintptr_t start_pointer_bitmap = container_layout.container_field_pointer_bitmap;
-        if (header._badge_stamp_wtag_mtag._value == DO_SHIFT_STAMP(gctools::STAMPWTAG_llvmo__ObjectFile_O)) {
+        if (header._badge_stamp_wtag_mtag._value == DO_SHIFT_STAMP(gctools::STAMPWTAG_llvmo__ObjectFile_O)) [[unlikely]] {
           llvmo::ObjectFile_O* code = (llvmo::ObjectFile_O*)client;
           core::T_O** addr = (core::T_O**)code->literalsStart();
           core::T_O** addrEnd = addr + (code->literalsSize() / sizeof(core::T_O*));
           for (; addr < addrEnd; addr++) {
             fix(addr);
           }
-        } else if (stamp_layout.flags & gctools::COMPLEX_SCAN) {
+        } else if (stamp_layout.flags & gctools::COMPLEX_SCAN) [[unlikely]] {
           const char* element = ((const char*)client + container_layout.data_offset);
           for (int i = 0; i < end; ++i, element += container_layout.element_size) {
             size_t nfields = container_layout.number_of_fields;

--- a/include/clasp/gctools/scan.h
+++ b/include/clasp/gctools/scan.h
@@ -56,11 +56,6 @@ public:
     case gctools::Header_s::general_mtag: {
       gctools::GCStampEnum stamp_wtag = header._badge_stamp_wtag_mtag.stamp_wtag();
       const gctools::Stamp_layout& stamp_layout = gctools::global_stamp_layout[stamp_index];
-      if (stamp_index == STAMP_UNSHIFT_WTAG(gctools::STAMPWTAG_core__DerivableCxxObject_O)) { // wasMTAG
-        // If this is true then I think we need to call virtual functions on the client
-        // to determine the Instance_O offset and the total size of the object.
-        printf("%s:%d Handle STAMP_core__DerivableCxxObject_O\n", __FILE__, __LINE__);
-      }
       // Basic fields
       if (stamp_layout.field_layout_start) {
 #ifdef USE_PRECISE_GC

--- a/include/clasp/gctools/scan.h
+++ b/include/clasp/gctools/scan.h
@@ -17,6 +17,7 @@
  * soon be invalid.
  */
 
+#include <bit>
 #include <concepts>
 #include <clasp/core/foundation.h>
 #include <clasp/core/object.h>
@@ -71,11 +72,13 @@ public:
     } else {
         // Use pointer bitmaps
       uintptr_t pointer_bitmap = stamp_layout.class_field_pointer_bitmap;
-      for (core::T_O** addr = (core::T_O**)client; pointer_bitmap;
-           addr++, pointer_bitmap <<= 1) {
-        if ((intptr_t)pointer_bitmap < 0) { // checking high bit
-          fix(addr);
-        }
+      core::T_O** addr = (core::T_O**)client;
+      while (pointer_bitmap) {
+        int pos = std::countl_zero(pointer_bitmap); // find first 1 bit (field)
+        fix(addr + pos); // scan it
+        // Then clear that bit so we can get the next field or exit.
+        pointer_bitmap
+          ^= (uintptr_t)1 << ((sizeof(uintptr_t)*CHAR_BIT) - 1 - pos);
       }
     }
 #endif // USE_PRECISE_GC
@@ -122,13 +125,15 @@ public:
         }
       } else {
         // Multiple fields we can scan with a bitmap
-        const char* element = ((const char*)client + container_layout.data_offset);
+        const char* element = (const char*)client + container_layout.data_offset;
         for (int i = 0; i < end; ++i, element += container_layout.element_size) {
+          core::T_O** addr = (core::T_O**)element;
           uintptr_t pointer_bitmap = start_pointer_bitmap;
-          for (core::T_O** addr = (core::T_O**)element; pointer_bitmap; addr++, pointer_bitmap <<= 1) {
-            if ((intptr_t)pointer_bitmap < 0) {
-              fix((core::T_O**)addr);
-            }
+          while (pointer_bitmap) {
+            int pos = std::countl_zero(pointer_bitmap);
+            fix(addr + pos);
+            pointer_bitmap
+              ^= (uintptr_t)1 << ((sizeof(uintptr_t)*CHAR_BIT) - 1 - pos);
           }
         }
       }

--- a/include/clasp/gctools/scan.h
+++ b/include/clasp/gctools/scan.h
@@ -35,7 +35,40 @@ public:
     fix((core::T_O**)&client->_Car);
     fix((core::T_O**)&client->_Cdr);
   }
-  
+
+private:
+  template <std::invocable<core::T_O**> Fixer>
+  static void fix_bitmap(core::T_O** base, uintptr_t bitmap, Fixer&& fix) {
+    while (bitmap) {
+      int pos = std::countl_zero(bitmap); // find first 1 bit (field)
+      // optimization note: based on the disassembly, it seems clang is smart enough
+      // to see that bitmap != 0 and so it can use bsr (on x86) no problem.
+      fix(base + pos); // scan it
+      // Then clear that bit so we can get the next field or exit.
+      bitmap ^= (uintptr_t)1 << ((sizeof(uintptr_t)*CHAR_BIT) - 1 - pos);
+    }
+  }
+
+  template <std::invocable<core::T_O**> Fixer,
+            std::invocable<WeakPointer*> WeakFixer,
+            std::invocable<QueueableWeakReference*> QueueableFixer,
+            std::invocable<Ephemeron*> EphFixer>
+  static void fix_complex(core::T_O** base, int num_fields,
+                          const gctools::Field_layout* field_layout,
+                          Fixer&& fix, WeakFixer&& weakfix,
+                          QueueableFixer&& queueablefix, EphFixer&& ephfix) {
+    for (int i = 0; i < num_fields; ++i, ++field_layout) {
+      void* field = (void*)((const char*)base + field_layout->offset);
+      switch (field_layout->type) {
+      case WEAK_PTR_OFFSET: weakfix((WeakPointer*)field); break;
+      case QWEAK_OFFSET: queueablefix((QueueableWeakReference*)field); break;
+      case EPHEMERON_OFFSET: ephfix((Ephemeron*)field); break;
+      default: fix((core::T_O**)field); break;
+      }
+    }
+  }
+
+public:
   template <std::invocable<core::T_O**> Fixer,
             std::invocable<WeakPointer*> WeakFixer,
             std::invocable<QueueableWeakReference*> QueueableFixer,
@@ -51,108 +84,68 @@ public:
     {
       uintptr_t fast_bitmap = gctools::global_stamp_bitmaps[stamp_index];
       if (fast_bitmap != ~(uintptr_t)0) [[likely]] {
-        core::T_O** addr = (core::T_O**)client;
-        while (fast_bitmap) {
-          int pos = std::countl_zero(fast_bitmap); // find first 1 bit (field)
-          fix(addr + pos); // scan it
-          // Then clear that bit so we can get the next field or exit.
-          fast_bitmap ^= (uintptr_t)1 << ((sizeof(uintptr_t)*CHAR_BIT) - 1 - pos);
-        }
+        fix_bitmap((core::T_O**)client, fast_bitmap, fix);
         return; // done!
       }
     }
 
     // Slightly slower path using the fuller stamp layouts.
-    // Ideally we can still use a bitmap but there might be a container.
+    // Ideally we can still use a bitmap, but there might be a container
+    // and/or weird fields.
     gctools::GCStampEnum stamp_wtag = header._badge_stamp_wtag_mtag.stamp_wtag();
     const gctools::Stamp_layout& stamp_layout = gctools::global_stamp_layout[stamp_index];
-#ifdef USE_PRECISE_GC
-      // Basic (non-container) fields
+
+    // First we check for complex scan. This is unusual so we don't care so much
+    // about its performance, we just want it out of the way so that the faster
+    // paths can be good.
+    // We only use complex scan when there are unusual fields (e.g. weak pointers)
+    // or if the object has too many fixed fields (> 63) to fit in a bitmap.
     if (stamp_layout.flags & gctools::COMPLEX_SCAN) [[unlikely]] {
-        // This object is too big for the bitmap, or has something weird in it
-        // like weak references. Scan by iterating over the fields.
-      int num_fields = stamp_layout.number_of_fields;
-      const gctools::Field_layout* field_layout_cur = stamp_layout.field_layout_start;
-      for (int i = 0; i < num_fields; ++i, ++field_layout_cur) {
-        void* field = (void*)((const char*)client + field_layout_cur->offset);
-        switch (field_layout_cur->type) {
-          [[unlikely]]
-        case WEAK_PTR_OFFSET: weakfix((WeakPointer*)field); break;
-            [[unlikely]]
-        case QWEAK_OFFSET:
-            queueablefix((QueueableWeakReference*)field); break;
-            [[unlikely]]
-        case EPHEMERON_OFFSET: ephfix((Ephemeron*)field); break;
-            [[likely]] // normal field
-        default: fix((core::T_O**)field); break;
-        }
+      fix_complex((core::T_O**)client, stamp_layout.number_of_fields,
+                  stamp_layout.field_layout_start,
+                  fix, weakfix, queueablefix, ephfix);
+      // now container fields.
+      if (stamp_layout.container_layout) {
+        const gctools::Container_layout& container_layout = *stamp_layout.container_layout;
+        size_t end = *(size_t*)((const char*)client + container_layout.end_offset);
+        const char* element = ((const char*)client + container_layout.data_offset);
+        for (int i = 0; i < end; ++i, element += container_layout.element_size)
+          fix_complex((core::T_O**)element, container_layout.number_of_fields,
+                      container_layout.field_layout_start,
+                      fix, weakfix, queueablefix, ephfix);
       }
     } else {
-        // Use pointer bitmaps
-      uintptr_t pointer_bitmap = stamp_layout.class_field_pointer_bitmap;
-      core::T_O** addr = (core::T_O**)client;
-      while (pointer_bitmap) {
-        int pos = std::countl_zero(pointer_bitmap); // find first 1 bit (field)
-        fix(addr + pos); // scan it
-        // Then clear that bit so we can get the next field or exit.
-        pointer_bitmap
-          ^= (uintptr_t)1 << ((sizeof(uintptr_t)*CHAR_BIT) - 1 - pos);
-      }
-    }
-#endif // USE_PRECISE_GC
-      // Container fields
-    if (stamp_layout.container_layout) {
-      const gctools::Container_layout& container_layout = *stamp_layout.container_layout;
-      size_t end = *(size_t*)((const char*)client + container_layout.end_offset);
-      // Use new way with pointer bitmaps
-      uintptr_t start_pointer_bitmap = container_layout.container_field_pointer_bitmap;
-      if (header._badge_stamp_wtag_mtag._value == DO_SHIFT_STAMP(gctools::STAMPWTAG_llvmo__ObjectFile_O)) [[unlikely]] {
-        llvmo::ObjectFile_O* code = (llvmo::ObjectFile_O*)client;
-        core::T_O** addr = (core::T_O**)code->literalsStart();
-        core::T_O** addrEnd = addr + (code->literalsSize() / sizeof(core::T_O*));
-        for (; addr < addrEnd; addr++) {
-          fix(addr);
+      // Use pointer bitmaps.
+      fix_bitmap((core::T_O**)client,
+                 stamp_layout.class_field_pointer_bitmap,
+                 fix);
+      if (stamp_layout.container_layout) {
+        // evil special case. FIXME
+        if (header._badge_stamp_wtag_mtag._value
+            == DO_SHIFT_STAMP(gctools::STAMPWTAG_llvmo__ObjectFile_O))
+          [[unlikely]] {
+          llvmo::ObjectFile_O* code = (llvmo::ObjectFile_O*)client;
+          core::T_O** addr = (core::T_O**)code->literalsStart();
+          core::T_O** addrEnd = addr + (code->literalsSize() / sizeof(core::T_O*));
+          for (; addr < addrEnd; addr++) fix(addr);
+          return;
         }
-      } else if (stamp_layout.flags & gctools::COMPLEX_SCAN) [[unlikely]] {
+        // back to normal case
+        const gctools::Container_layout& container_layout = *stamp_layout.container_layout;
+        size_t end = *(size_t*)((const char*)client + container_layout.end_offset);
         const char* element = ((const char*)client + container_layout.data_offset);
-        for (int i = 0; i < end; ++i, element += container_layout.element_size) {
-          size_t nfields = container_layout.number_of_fields;
-          const gctools::Field_layout* field_layout = container_layout.field_layout_start;
-          for (size_t j = 0; j < nfields; ++j, ++field_layout) {
-            void* field = (void*)(element + field_layout->offset);
-            switch (field_layout->type) {
-              [[unlikely]]
-            case WEAK_PTR_OFFSET: weakfix((WeakPointer*)field); break;
-                [[unlikely]]
-            case QWEAK_OFFSET:
-                queueablefix((QueueableWeakReference*)field); break;
-                [[unlikely]]
-            case EPHEMERON_OFFSET: ephfix((Ephemeron*)field); break;
-                [[likely]] // normal field
-            default: fix((core::T_O**)field); break;
-            }
-          }
-        }
-      } else if (!start_pointer_bitmap) {
-        // nothing to scan
-      } else if (!(start_pointer_bitmap << 1)) {
-        // Trivial case - there is a single pointer to fix in every element and its the only element
-        const char* element = ((const char*)client + container_layout.data_offset);
-        for (int i = 0; i < end; ++i, element += container_layout.element_size) {
-          fix((core::T_O**)element);
-        }
-      } else {
-        // Multiple fields we can scan with a bitmap
-        const char* element = (const char*)client + container_layout.data_offset;
-        for (int i = 0; i < end; ++i, element += container_layout.element_size) {
-          core::T_O** addr = (core::T_O**)element;
-          uintptr_t pointer_bitmap = start_pointer_bitmap;
-          while (pointer_bitmap) {
-            int pos = std::countl_zero(pointer_bitmap);
-            fix(addr + pos);
-            pointer_bitmap
-              ^= (uintptr_t)1 << ((sizeof(uintptr_t)*CHAR_BIT) - 1 - pos);
-          }
+        uintptr_t bitmap = container_layout.container_field_pointer_bitmap;
+        if (!bitmap) [[unlikely]] { // no fields, do nothing.
+          // note that this should be covered by fast bitmaps (above)
+          // and is only included here for correctness.
+        } else if (!(bitmap << 1)) [[likely]] {
+          // only one field, which is common enough (e.g. simple vector) that
+          // we try to handle it directly.
+          for (int i = 0; i < end; ++i, element += container_layout.element_size)
+            fix((core::T_O**)element);
+        } else {
+          for (int i = 0; i < end; ++i, element += container_layout.element_size)
+            fix_bitmap((core::T_O**)element, bitmap, fix);
         }
       }
     }

--- a/include/clasp/gctools/scan.h
+++ b/include/clasp/gctools/scan.h
@@ -137,6 +137,7 @@ public:
         uintptr_t bitmap = container_layout.container_field_pointer_bitmap;
         if (!bitmap) [[unlikely]] { // no fields, do nothing.
           // note that this should be covered by fast bitmaps (above)
+          // or the magical ObjectFile_O case
           // and is only included here for correctness.
         } else if (!(bitmap << 1)) [[likely]] {
           // only one field, which is common enough (e.g. simple vector) that

--- a/include/clasp/gctools/scan.h
+++ b/include/clasp/gctools/scan.h
@@ -44,99 +44,94 @@ public:
                       EphFixer&& ephfix) {
     const gctools::Header_s& header = *(const gctools::Header_s*)gctools::GeneralPtrToHeaderPtr(client);
     size_t stamp_index = header._badge_stamp_wtag_mtag.stamp_();
-    switch (header._badge_stamp_wtag_mtag.mtag()) {
-      [[likely]] // dunno why this is indenting stupidly
-    case gctools::Header_s::general_mtag: {
-      gctools::GCStampEnum stamp_wtag = header._badge_stamp_wtag_mtag.stamp_wtag();
-      const gctools::Stamp_layout& stamp_layout = gctools::global_stamp_layout[stamp_index];
+
+    gctools::GCStampEnum stamp_wtag = header._badge_stamp_wtag_mtag.stamp_wtag();
+    const gctools::Stamp_layout& stamp_layout = gctools::global_stamp_layout[stamp_index];
 #ifdef USE_PRECISE_GC
       // Basic (non-container) fields
-      if (stamp_layout.flags & gctools::COMPLEX_SCAN) [[unlikely]] {
+    if (stamp_layout.flags & gctools::COMPLEX_SCAN) [[unlikely]] {
         // This object is too big for the bitmap, or has something weird in it
         // like weak references. Scan by iterating over the fields.
-        int num_fields = stamp_layout.number_of_fields;
-        const gctools::Field_layout* field_layout_cur = stamp_layout.field_layout_start;
-        for (int i = 0; i < num_fields; ++i, ++field_layout_cur) {
-          void* field = (void*)((const char*)client + field_layout_cur->offset);
-          switch (field_layout_cur->type) {
+      int num_fields = stamp_layout.number_of_fields;
+      const gctools::Field_layout* field_layout_cur = stamp_layout.field_layout_start;
+      for (int i = 0; i < num_fields; ++i, ++field_layout_cur) {
+        void* field = (void*)((const char*)client + field_layout_cur->offset);
+        switch (field_layout_cur->type) {
+          [[unlikely]]
+        case WEAK_PTR_OFFSET: weakfix((WeakPointer*)field); break;
             [[unlikely]]
-          case WEAK_PTR_OFFSET: weakfix((WeakPointer*)field); break;
-              [[unlikely]]
-          case QWEAK_OFFSET:
-              queueablefix((QueueableWeakReference*)field); break;
-              [[unlikely]]
-          case EPHEMERON_OFFSET: ephfix((Ephemeron*)field); break;
-              [[likely]] // normal field
-          default: fix((core::T_O**)field); break;
-          }
-        }
-      } else {
-        // Use pointer bitmaps
-        uintptr_t pointer_bitmap = stamp_layout.class_field_pointer_bitmap;
-        for (core::T_O** addr = (core::T_O**)client; pointer_bitmap;
-             addr++, pointer_bitmap <<= 1) {
-          if ((intptr_t)pointer_bitmap < 0) { // checking high bit
-            fix(addr);
-          }
+        case QWEAK_OFFSET:
+            queueablefix((QueueableWeakReference*)field); break;
+            [[unlikely]]
+        case EPHEMERON_OFFSET: ephfix((Ephemeron*)field); break;
+            [[likely]] // normal field
+        default: fix((core::T_O**)field); break;
         }
       }
+    } else {
+        // Use pointer bitmaps
+      uintptr_t pointer_bitmap = stamp_layout.class_field_pointer_bitmap;
+      for (core::T_O** addr = (core::T_O**)client; pointer_bitmap;
+           addr++, pointer_bitmap <<= 1) {
+        if ((intptr_t)pointer_bitmap < 0) { // checking high bit
+          fix(addr);
+        }
+      }
+    }
 #endif // USE_PRECISE_GC
       // Container fields
-      if (stamp_layout.container_layout) {
-        const gctools::Container_layout& container_layout = *stamp_layout.container_layout;
-        size_t end = *(size_t*)((const char*)client + container_layout.end_offset);
-        // Use new way with pointer bitmaps
-        uintptr_t start_pointer_bitmap = container_layout.container_field_pointer_bitmap;
-        if (header._badge_stamp_wtag_mtag._value == DO_SHIFT_STAMP(gctools::STAMPWTAG_llvmo__ObjectFile_O)) [[unlikely]] {
-          llvmo::ObjectFile_O* code = (llvmo::ObjectFile_O*)client;
-          core::T_O** addr = (core::T_O**)code->literalsStart();
-          core::T_O** addrEnd = addr + (code->literalsSize() / sizeof(core::T_O*));
-          for (; addr < addrEnd; addr++) {
-            fix(addr);
-          }
-        } else if (stamp_layout.flags & gctools::COMPLEX_SCAN) [[unlikely]] {
-          const char* element = ((const char*)client + container_layout.data_offset);
-          for (int i = 0; i < end; ++i, element += container_layout.element_size) {
-            size_t nfields = container_layout.number_of_fields;
-            const gctools::Field_layout* field_layout = container_layout.field_layout_start;
-            for (size_t j = 0; j < nfields; ++j, ++field_layout) {
-              void* field = (void*)(element + field_layout->offset);
-              switch (field_layout->type) {
+    if (stamp_layout.container_layout) {
+      const gctools::Container_layout& container_layout = *stamp_layout.container_layout;
+      size_t end = *(size_t*)((const char*)client + container_layout.end_offset);
+      // Use new way with pointer bitmaps
+      uintptr_t start_pointer_bitmap = container_layout.container_field_pointer_bitmap;
+      if (header._badge_stamp_wtag_mtag._value == DO_SHIFT_STAMP(gctools::STAMPWTAG_llvmo__ObjectFile_O)) [[unlikely]] {
+        llvmo::ObjectFile_O* code = (llvmo::ObjectFile_O*)client;
+        core::T_O** addr = (core::T_O**)code->literalsStart();
+        core::T_O** addrEnd = addr + (code->literalsSize() / sizeof(core::T_O*));
+        for (; addr < addrEnd; addr++) {
+          fix(addr);
+        }
+      } else if (stamp_layout.flags & gctools::COMPLEX_SCAN) [[unlikely]] {
+        const char* element = ((const char*)client + container_layout.data_offset);
+        for (int i = 0; i < end; ++i, element += container_layout.element_size) {
+          size_t nfields = container_layout.number_of_fields;
+          const gctools::Field_layout* field_layout = container_layout.field_layout_start;
+          for (size_t j = 0; j < nfields; ++j, ++field_layout) {
+            void* field = (void*)(element + field_layout->offset);
+            switch (field_layout->type) {
+              [[unlikely]]
+            case WEAK_PTR_OFFSET: weakfix((WeakPointer*)field); break;
                 [[unlikely]]
-              case WEAK_PTR_OFFSET: weakfix((WeakPointer*)field); break;
-                  [[unlikely]]
-              case QWEAK_OFFSET:
-                  queueablefix((QueueableWeakReference*)field); break;
-                  [[unlikely]]
-              case EPHEMERON_OFFSET: ephfix((Ephemeron*)field); break;
-                  [[likely]] // normal field
-              default: fix((core::T_O**)field); break;
-              }
+            case QWEAK_OFFSET:
+                queueablefix((QueueableWeakReference*)field); break;
+                [[unlikely]]
+            case EPHEMERON_OFFSET: ephfix((Ephemeron*)field); break;
+                [[likely]] // normal field
+            default: fix((core::T_O**)field); break;
             }
           }
-        } else if (!start_pointer_bitmap) {
-          // nothing to scan
-        } else if (!(start_pointer_bitmap << 1)) {
-          // Trivial case - there is a single pointer to fix in every element and its the only element
-          const char* element = ((const char*)client + container_layout.data_offset);
-          for (int i = 0; i < end; ++i, element += container_layout.element_size) {
-            fix((core::T_O**)element);
-          }
-        } else {
-          // Multiple fields we can scan with a bitmap
-          const char* element = ((const char*)client + container_layout.data_offset);
-          for (int i = 0; i < end; ++i, element += container_layout.element_size) {
-            uintptr_t pointer_bitmap = start_pointer_bitmap;
-            for (core::T_O** addr = (core::T_O**)element; pointer_bitmap; addr++, pointer_bitmap <<= 1) {
-              if ((intptr_t)pointer_bitmap < 0) {
-                fix((core::T_O**)addr);
-              }
+        }
+      } else if (!start_pointer_bitmap) {
+        // nothing to scan
+      } else if (!(start_pointer_bitmap << 1)) {
+        // Trivial case - there is a single pointer to fix in every element and its the only element
+        const char* element = ((const char*)client + container_layout.data_offset);
+        for (int i = 0; i < end; ++i, element += container_layout.element_size) {
+          fix((core::T_O**)element);
+        }
+      } else {
+        // Multiple fields we can scan with a bitmap
+        const char* element = ((const char*)client + container_layout.data_offset);
+        for (int i = 0; i < end; ++i, element += container_layout.element_size) {
+          uintptr_t pointer_bitmap = start_pointer_bitmap;
+          for (core::T_O** addr = (core::T_O**)element; pointer_bitmap; addr++, pointer_bitmap <<= 1) {
+            if ((intptr_t)pointer_bitmap < 0) {
+              fix((core::T_O**)addr);
             }
           }
         }
       }
-    } break;
-    default: throw_hard_error_bad_client((void*)client);
     }
   }
 

--- a/include/clasp/gctools/scan.h
+++ b/include/clasp/gctools/scan.h
@@ -46,6 +46,24 @@ public:
     const gctools::Header_s& header = *(const gctools::Header_s*)gctools::GeneralPtrToHeaderPtr(client);
     size_t stamp_index = header._badge_stamp_wtag_mtag.stamp_();
 
+    // Try the fastest possible thing first - get the simple bitmap, and if it
+    // hasn't been set to ~0 it's valid (or is coincidentally ~0, but whatever).
+    {
+      uintptr_t fast_bitmap = gctools::global_stamp_bitmaps[stamp_index];
+      if (fast_bitmap != ~(uintptr_t)0) [[likely]] {
+        core::T_O** addr = (core::T_O**)client;
+        while (fast_bitmap) {
+          int pos = std::countl_zero(fast_bitmap); // find first 1 bit (field)
+          fix(addr + pos); // scan it
+          // Then clear that bit so we can get the next field or exit.
+          fast_bitmap ^= (uintptr_t)1 << ((sizeof(uintptr_t)*CHAR_BIT) - 1 - pos);
+        }
+        return; // done!
+      }
+    }
+
+    // Slightly slower path using the fuller stamp layouts.
+    // Ideally we can still use a bitmap but there might be a container.
     gctools::GCStampEnum stamp_wtag = header._badge_stamp_wtag_mtag.stamp_wtag();
     const gctools::Stamp_layout& stamp_layout = gctools::global_stamp_layout[stamp_index];
 #ifdef USE_PRECISE_GC

--- a/include/clasp/gctools/threadlocal.fwd.h
+++ b/include/clasp/gctools/threadlocal.fwd.h
@@ -46,6 +46,7 @@ struct ThreadLocalStateLowLevel {
   AllocationProfiler _Allocations;
 #ifdef USE_MMTK
   MMTkClaspMutator _mmtk_mutator;
+  size_t _mmtk_default_allocator_offset; // byte offset from mutator ptr to its Immix allocator; constant across mutators
 #endif
   // Time unwinds
   std::chrono::time_point<std::chrono::high_resolution_clock> _start_unwind;

--- a/include/clasp/gctools/threadlocal.h
+++ b/include/clasp/gctools/threadlocal.h
@@ -351,7 +351,11 @@ public:
   template <std::invocable<gctools::Tagged*> Walker>
   void walkVMStack(Walker&& walk) {
     for (core::T_O** ptr = _VM._stackBottom;
-         ptr < _VM._stackPointer; ++ptr)
+         // note the +1: *_stackPointer is an actual reference.
+         // If the thread has just started and _stackPointer = _stackBottom,
+         // the stack should be all zero, so the walker will just see a fixnum,
+         // which shouldn't be a problem.
+         ptr < _VM._stackPointer + 1; ++ptr)
       walk((gctools::Tagged*)ptr);
   }
   // Call a function on the addresses of objects in the control stack.

--- a/include/clasp/gctools/threadlocal.h
+++ b/include/clasp/gctools/threadlocal.h
@@ -323,6 +323,7 @@ public:
     return static_cast<bool>(_PendingInterruptsHead.load(std::memory_order_acquire));
   }
   core::T_sp dequeue_interrupt();
+  bool pending_interrupts_p();
   inline void block() { _GCState.store(GCState::Parked, std::memory_order_release); }
   inline void gcsafe() { _GCState.store(GCState::GCsafe, std::memory_order_release); }
   inline void unblock() { _GCState.store(GCState::Running, std::memory_order_release); }

--- a/include/clasp/llvmo/code.h
+++ b/include/clasp/llvmo/code.h
@@ -109,17 +109,17 @@ public:
   ObjectFile_O(core::SimpleBaseString_sp codename, std::unique_ptr<llvm::MemoryBuffer> buffer, size_t objectId,
                JITDylib_sp jitdylib)
       : _State(RunState), _CodeName(codename), _MemoryBuffer(std::move(buffer)), _ObjectId(objectId), _TheJITDylib(jitdylib),
-        _LiteralVectorStart(0), _CodeBlock(unbound<CodeBlock_O>()) {
+        _LiteralVectorStart(0), _LiteralVectorSizeBytes(0), _CodeBlock(unbound<CodeBlock_O>()) {
     DEBUG_OBJECT_FILES_PRINT(("%s:%d:%s   objectId = %lu\n", __FILE__, __LINE__, __FUNCTION__, objectId));
   };
   ObjectFile_O(core::SimpleBaseString_sp codename, JITDylib_sp jitdylib, size_t objectId)
       : _State(RunState), _CodeName(codename), _ObjectId(objectId), _TheJITDylib(jitdylib),
-        _LiteralVectorStart(0), _CodeBlock(unbound<CodeBlock_O>()) {
+        _LiteralVectorStart(0), _LiteralVectorSizeBytes(0), _CodeBlock(unbound<CodeBlock_O>()) {
     DEBUG_OBJECT_FILES_PRINT(("%s:%d:%s   codename = %s\n", __FILE__, __LINE__, __FUNCTION__, _rep_(codename).c_str()));
   };
   ObjectFile_O(core::SimpleBaseString_sp codename, CodeBlock_sp codeBlock, JITDylib_sp dylib, size_t objectId)
       : _State(RunState), _CodeName(codename), _ObjectId(objectId), _TheJITDylib(dylib), _TextSectionStart(0),
-        _TextSectionEnd(0), _LiteralVectorStart(0), _CodeBlock(codeBlock) {
+        _TextSectionEnd(0), _LiteralVectorStart(0), _LiteralVectorSizeBytes(0), _CodeBlock(codeBlock) {
     DEBUG_OBJECT_FILES_PRINT(("%s:%d:%s created with CodeBlock_sp   codename = %s CodeBlock = %s\n", __FILE__, __LINE__,
                               __FUNCTION__, _rep_(codename).c_str(), core::_rep_(codeBlock).c_str()));
   };

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -1272,7 +1272,7 @@ static void replace_bytecode(SimpleVector_byte8_t_sp dest, ComplexVector_byte8_t
 }
 
 SimpleVector_byte8_t_sp Module_O::create_bytecode() {
-  SimpleVector_byte8_t_sp bytecode = SimpleVector_byte8_t_O::make(this->bytecode_size());
+  SimpleVector_byte8_t_sp bytecode = SimpleVector_byte8_t_O::make<gctools::collectable_immobile>(this->bytecode_size());
   size_t index = 0;
   ComplexVector_T_sp cfunctions = this->cfunctions();
   for (auto const& tfunction : cfunctions) {
@@ -1366,7 +1366,7 @@ void Module_O::link_load(T_sp env) {
   SimpleVector_byte8_t_sp bytecode = cmodule->create_bytecode();
   ComplexVector_T_sp cmodule_literals = cmodule->literals();
   size_t literal_length = cmodule_literals->length();
-  SimpleVector_sp literals = SimpleVector_O::make(literal_length);
+  SimpleVector_sp literals = SimpleVector_O::make<gctools::collectable_immobile>(literal_length);
   SimpleVector_sp debug_info = cmodule->create_debug_info();
   BytecodeModule_sp bytecode_module = BytecodeModule_O::make(bytecode);
   ComplexVector_T_sp cfunctions = cmodule->cfunctions();

--- a/src/core/funcallableInstance.cc
+++ b/src/core/funcallableInstance.cc
@@ -510,11 +510,20 @@ GFBytecodeSimpleFun_sp GFBytecodeSimpleFun_O::make(Function_sp generic_function)
   T_sp name = generic_function->functionName();
   FunctionDescription_sp fdesc = makeFunctionDescription(name);
   T_mv compiled = eval::funcall(clos::_sym_bytecode_dtree_compile, generic_function);
-  SimpleVector_byte8_t_sp bytecode = gc::As<SimpleVector_byte8_t_sp>(compiled);
+  SimpleVector_byte8_t_sp src_bytecode = gc::As<SimpleVector_byte8_t_sp>(compiled);
   MultipleValues& mv = my_thread->_MultipleValues;
   // SimpleVector_sp entryPoints = mv.second(compiled.number_of_values());
-  SimpleVector_sp literals = gc::As<SimpleVector_sp>(mv.third(compiled.number_of_values()));
+  SimpleVector_sp src_literals = gc::As<SimpleVector_sp>(mv.third(compiled.number_of_values()));
   size_t specialized_length = mv.fourth(compiled.number_of_values()).unsafe_fixnum();
+  // prepare_vm holds raw C++ pointers into _Bytecode and _Literals across GC safepoints,
+  // so they must not move. Allocate immobile copies of the Lisp-returned vectors.
+  // FIXME: Have Lisp allocate the byte vectors immobile to begin with.
+  SimpleVector_byte8_t_sp bytecode =
+      SimpleVector_byte8_t_O::make<gctools::collectable_immobile>(src_bytecode->length());
+  std::copy(src_bytecode->begin(), src_bytecode->end(), bytecode->begin());
+  SimpleVector_sp literals =
+      SimpleVector_O::make<gctools::collectable_immobile>(src_literals->length());
+  std::copy(src_literals->begin(), src_literals->end(), literals->begin());
   auto obj = gctools::GC<GFBytecodeSimpleFun_O>::allocate(fdesc, 0, bytecode, literals, generic_function, specialized_length);
 
   // Replace _EntryPoints[0] (initially set by XepStereotype to the static
@@ -597,9 +606,9 @@ CL_DEFUN T_mv core__build_single_dispatch_bytecode(List_sp call_history, size_t 
   /* get reg|read stamp|miss +  4 bytes per call history entry */
   size_t nentries = cl__length(call_history);
   size_t bytecode_length = 3 + nentries * 5;
-  SimpleVector_byte8_t_sp bytecode = SimpleVector_byte8_t_O::make(bytecode_length);
+  SimpleVector_byte8_t_sp bytecode = SimpleVector_byte8_t_O::make<gctools::collectable_immobile>(bytecode_length);
   // stamp + effective method function
-  SimpleVector_sp literals = SimpleVector_O::make(nentries * 2);
+  SimpleVector_sp literals = SimpleVector_O::make<gctools::collectable_immobile>(nentries * 2);
   if (dispatch_argument_index >= 5)
     SIMPLE_ERROR("Not supported dispatching on args after DTREE_OP_FARG4");
   ASSERT(DTREE_OP_FARG0 == (DTREE_OP_FARG1 - 1) == (DTREE_OP_FARG2 - 2) == (DTREE_OP_FARG3 - 3) == (DTREE_OP_FARG4 - 4));

--- a/src/core/function.cc
+++ b/src/core/function.cc
@@ -675,14 +675,14 @@ CL_DEFUN void core__verify_global_entry_point(T_sp alist) {
 CL_LISPIFY_NAME(bytecode_closure/make);
 CL_DEF_CLASS_METHOD
 Closure_sp Closure_O::make_bytecode_closure(BytecodeSimpleFun_sp entryPoint, size_t closedOverSlots) {
-  Closure_sp closure = gctools::GC<core::Closure_O>::allocate_container<gctools::RuntimeStage>(false, closedOverSlots, entryPoint);
+  Closure_sp closure = gctools::GC<core::Closure_O>::allocate_container<gctools::RuntimeStage, gctools::collectable_immobile>(false, closedOverSlots, entryPoint);
   return closure;
 }
 
 CL_LAMBDA(sfun core:&va-rest closed);
 CL_DEFUN Closure_sp core__make_closure(SimpleFun_sp sfun, Vaslist_sp closed) {
   size_t nclosed = closed->nargs();
-  Closure_sp closure = gctools::GC<core::Closure_O>::allocate_container<gctools::RuntimeStage>(false, nclosed, sfun);
+  Closure_sp closure = gctools::GC<core::Closure_O>::allocate_container<gctools::RuntimeStage, gctools::collectable_immobile>(false, nclosed, sfun);
   for (size_t idx = 0; idx < nclosed; ++idx)
     closure[idx] = closed->next_arg();
   return closure;

--- a/src/core/loadltv.cc
+++ b/src/core/loadltv.cc
@@ -781,7 +781,7 @@ struct loadltv {
   void op_bcmod() {
     size_t index = next_index();
     uint32_t len = read_u32();
-    SimpleVector_byte8_t_sp bytes = SimpleVector_byte8_t_O::make(len);
+    SimpleVector_byte8_t_sp bytes = SimpleVector_byte8_t_O::make<gctools::collectable_immobile>(len);
     // Read the module bytecode straight into the vector through our buffer.
     read_bytes((unsigned char*)bytes->rowMajorAddressOfElement_(0), len);
     set_ltv(BytecodeModule_O::make(bytes), index);
@@ -790,7 +790,7 @@ struct loadltv {
   void op_slits() {
     BytecodeModule_sp mod = gc::As<BytecodeModule_sp>(get_ltv(read_index()));
     uint16_t len = read_u16();
-    SimpleVector_sp lits = SimpleVector_O::make(len);
+    SimpleVector_sp lits = SimpleVector_O::make<gctools::collectable_immobile>(len);
     mod->setf_literals(lits);
     for (size_t i = 0; i < len; ++i)
       lits[i] = get_ltv(read_index());

--- a/src/gctools/gcFunctions.cc
+++ b/src/gctools/gcFunctions.cc
@@ -1000,6 +1000,7 @@ std::string dump_stamp_info(size_t stamp) {
   fmt::format_to(out, "Size: {}\n", layout.size);
   // Fields
   fmt::format_to(out, "Bitmap: {:0<#16x}\n", layout.class_field_pointer_bitmap);
+  fmt::format_to(out, "Fast bitmap: {:0<#16x}\n", global_stamp_bitmaps[stamp]);
   if (layout.number_of_fields)
     fmt::format_to(out, "{} fields:\n", layout.number_of_fields);
   else fmt::format_to(out, "No fields.\n");

--- a/src/gctools/gc_boot.cc
+++ b/src/gctools/gc_boot.cc
@@ -301,6 +301,14 @@ void walk_stamp_field_layout_tables(WalkKind walk, std::ostream& fout) {
       GCTOOLS_ASSERT(cur_container_layout_idx <= number_of_containers);
       local_stamp_layout[cur_stamp].container_layout->data_offset = codes[idx].data2;
       container_variable_index = 0;
+      // KLUDGE: This should not be necessary since variable_field
+      // axes the fast bitmap if there's a scannable field.
+      // Unfortunately, ObjectFile_O is magical and needs to hit the
+      // slow path even though as far as the analyzer is concerned, it
+      // has no fixable fields.
+      // A better fix would be to make the analyzer smarter, or to make
+      // ObjectFile_O scanning less magical.
+      local_stamp_bitmaps[cur_stamp] = ~(uintptr_t)0;
       if (walk == lldb_info)
         fmt::print(fout, "{}Init__variable_array0( stamp={}, name=\"{}\", offset={} )\n", indent.c_str(), cur_stamp,
                    codes[idx].description, local_stamp_layout[cur_stamp].container_layout->data_offset);

--- a/src/gctools/gc_boot.cc
+++ b/src/gctools/gc_boot.cc
@@ -298,9 +298,6 @@ void walk_stamp_field_layout_tables(WalkKind walk, std::ostream& fout) {
     case variable_array0:
       DGC_PRINT("%s:%d   variable_array0 cur_stamp = %d\n", __FILE__, __LINE__, cur_stamp);
       local_stamp_layout[cur_stamp].container_layout = &local_container_layout[cur_container_layout_idx++];
-      // TODO: possible optimization: we can keep the fast scan iff the container
-      // layout lacks pointers.
-      local_stamp_bitmaps[cur_stamp] = ~(uintptr_t)0;
       GCTOOLS_ASSERT(cur_container_layout_idx <= number_of_containers);
       local_stamp_layout[cur_stamp].container_layout->data_offset = codes[idx].data2;
       container_variable_index = 0;
@@ -336,6 +333,9 @@ void walk_stamp_field_layout_tables(WalkKind walk, std::ostream& fout) {
                    container_variable_index++, // index,
                    data_type, field_name, field_offset);
       if (fixable_type_p(data_type)) {
+        // This is a variable array that actually contains pointers to scan,
+        // so mark the fast bitmap invalid to force the scanner to do that work.
+        local_stamp_bitmaps[cur_stamp] = ~(uintptr_t)0;
         int bit_index = bitmap_field_index(63, field_offset);
         uintptr_t field_bitmap = bitmap_field_bitmap(bit_index);
         GCTOOLS_ASSERT(cur_field_layout < max_field_layout);

--- a/src/gctools/gc_boot.cc
+++ b/src/gctools/gc_boot.cc
@@ -33,6 +33,7 @@ size_t global_stamp_max;
 Stamp_layout* global_stamp_layout;
 Field_layout* global_field_layout;
 Container_layout* global_container_layout;
+uintptr_t* global_stamp_bitmaps;
 
 void dump_data_types(std::ostream& fout, const std::string& indent) {
 #define DTNAME(_type_, _name_, _sz_)                                                                                               \
@@ -172,6 +173,8 @@ void walk_stamp_field_layout_tables(WalkKind walk, std::ostream& fout) {
       new Stamp_layout[local_stamp_max + 1]; // (Stamp_layout*)malloc(sizeof(Stamp_layout)*(local_stamp_max+1));
   Field_layout* local_field_layout =
       new Field_layout[number_of_fixable_fields]; // (Field_layout*)malloc(sizeof(Field_layout)*number_of_fixable_fields);
+  // {} so they're zero initialized.
+  uintptr_t* local_stamp_bitmaps = new uintptr_t[local_stamp_max + 1]{};
   Field_layout* cur_field_layout = local_field_layout;
   Field_layout* max_field_layout = (Field_layout*)((char*)local_field_layout + sizeof(Field_layout) * number_of_fixable_fields);
   Container_layout* local_container_layout =
@@ -231,10 +234,12 @@ void walk_stamp_field_layout_tables(WalkKind walk, std::ostream& fout) {
           // Alternately we have a weak reference that needs to be
           // scanned specially.
           local_stamp_layout[cur_stamp].flags |= COMPLEX_SCAN;
+          local_stamp_bitmaps[cur_stamp] = ~(uintptr_t)0;
         } else {
           // Otherwise (normal case) just put it in the bitmap.
           field_bitmap = bitmap_field_bitmap(bit_index);
           local_stamp_layout[cur_stamp].class_field_pointer_bitmap |= field_bitmap;
+          local_stamp_bitmaps[cur_stamp] |= field_bitmap;
         }
         
         if (local_stamp_layout[cur_stamp].field_layout_start == NULL)
@@ -293,6 +298,9 @@ void walk_stamp_field_layout_tables(WalkKind walk, std::ostream& fout) {
     case variable_array0:
       DGC_PRINT("%s:%d   variable_array0 cur_stamp = %d\n", __FILE__, __LINE__, cur_stamp);
       local_stamp_layout[cur_stamp].container_layout = &local_container_layout[cur_container_layout_idx++];
+      // TODO: possible optimization: we can keep the fast scan iff the container
+      // layout lacks pointers.
+      local_stamp_bitmaps[cur_stamp] = ~(uintptr_t)0;
       GCTOOLS_ASSERT(cur_container_layout_idx <= number_of_containers);
       local_stamp_layout[cur_stamp].container_layout->data_offset = codes[idx].data2;
       container_variable_index = 0;
@@ -510,6 +518,7 @@ void walk_stamp_field_layout_tables(WalkKind walk, std::ostream& fout) {
     global_stamp_layout = local_stamp_layout;
     global_field_layout = local_field_layout;
     global_container_layout = local_container_layout;
+    global_stamp_bitmaps = local_stamp_bitmaps;
   } else {
     printf("%s:%d Illegal walk %d\n", __FILE__, __LINE__, walk);
     abort();

--- a/src/gctools/interrupt.cc
+++ b/src/gctools/interrupt.cc
@@ -140,10 +140,9 @@ bool global_user_signal = false;
 
 // INTERRUPTS
 
-inline bool interrupts_disabled_p() {
-  return my_thread_low_level->_DisableInterrupts
-    || (my_thread->interrupt_queue_validp() // KLUDGE to not trigger problems if we do this early.
-        && core::_sym_STARinterrupts_enabledSTAR->symbolValue().nilp());
+inline bool interrupts_disabled_p(core::ThreadLocalState* thread) {
+  return thread->_LowLevel._DisableInterrupts
+    || core::_sym_STARinterrupts_enabledSTAR->symbolValue().nilp();
 }
 
 // Perform one action (presumably popped from the queue).
@@ -201,24 +200,33 @@ static void handle_pending_signals() {
 
 // Handle just interrupts and not signals. Used in the SIGCONT handler,
 // which checks if interrupts are disabled itself.
+// Make sure to check pending_interrupts_p first, since that also checks that
+// the thread interrupt queue is set up at all.
 static void handle_queued_interrupts() {
-  // Check that the queue has actually been created.
-  if (my_thread->interrupt_queue_validp()) {
-    while (true) {
-      core::T_sp i = my_thread->dequeue_interrupt();
-      if (i.nilp()) break;
-      handle_queued_interrupt(i);
-    }
+  while (true) {
+    core::T_sp i = my_thread->dequeue_interrupt();
+    if (i.nilp()) break;
+    handle_queued_interrupt(i);
   }
 }
 
 // Do all the queued actions, emptying the queue -
 // unless interrupts have been disabled.
 template <> void handle_all_queued_interrupts<RuntimeStage>() {
-  if (!interrupts_disabled_p()) {
-    if (my_thread->pending_signals_p())
-      handle_pending_signals();
-    handle_queued_interrupts();
+  // This function is called for basically every Lisp function call, so we want it
+  // to be very fast. So: we only check interrupts_disabled_p, which performs a
+  // relatively complicated operation (checking a dynamic variable), if there is
+  // actually anything to handle. Checking if there is anything to handle is a
+  // pretty quick operation since it's just loading from some atomics in the thread
+  // structure, none of which should be very contentious.
+  // We also make sure to only grab my_thread once in the common case of there
+  // being nothing to handle, because accessing TLS is a bit expensive.
+  core::ThreadLocalState* thread = my_thread;
+  bool signalsp = thread->pending_signals_p();
+  bool interruptsp = thread->pending_interrupts_p();
+  if ((signalsp || interruptsp) && !interrupts_disabled_p(thread)) {
+    if (signalsp) handle_pending_signals();
+    if (interruptsp) handle_queued_interrupts();
   }
 }
 
@@ -243,11 +251,12 @@ void handle_SIGUSR1(int sig) { global_user_signal = true; }
 // that are blocked on a syscall or whatever.
 void handle_SIGCONT(int sig) {
   if (my_thread) {
-    if (my_thread->blockingp() && !interrupts_disabled_p()) {
+    if (my_thread->blockingp() && !interrupts_disabled_p(my_thread)) {
       // Disable (most) async interrupts and wait for the world to be unstopped
       // before we call user code.
       call_unparked([&]() {
-        handle_queued_interrupts();
+        if (my_thread->pending_interrupts_p())
+          handle_queued_interrupts();
         handle_signal_now(sig); // pass on the SIGCONT, in case someone cares
       });
       // Nothing jumped out of there, so we're back to blocking.

--- a/src/gctools/interrupt.cc
+++ b/src/gctools/interrupt.cc
@@ -200,8 +200,6 @@ static void handle_pending_signals() {
 
 // Handle just interrupts and not signals. Used in the SIGCONT handler,
 // which checks if interrupts are disabled itself.
-// Make sure to check pending_interrupts_p first, since that also checks that
-// the thread interrupt queue is set up at all.
 static void handle_queued_interrupts() {
   while (true) {
     core::T_sp i = my_thread->dequeue_interrupt();

--- a/src/gctools/mmtkGarbageCollection.cc
+++ b/src/gctools/mmtkGarbageCollection.cc
@@ -81,26 +81,7 @@ CL_DEFUN size_t core__dynamic_usage() { return mmtk_clasp_total_bytes(); }
 // Uses scan::cons / scan::general.
 extern "C" void clasp_scan_object(void* client, ClaspPreciseRootCallback callback, void* data) {
   const gctools::BaseHeader_s* near = gctools::base_header_ptr(client);
-  auto scan = [&](core::T_O** field) {
-    gctools::Tagged thing = *(gctools::Tagged*)field;
-    switch (gctools::ptag(thing)) {
-    case gctools::general_tag: {
-      void* client = reinterpret_cast<void*>(thing & gctools::ptr_mask);
-      gctools::Header_s* header = (gctools::Header_s*)gctools::GeneralPtrToHeaderPtr(client);
-      if (header < (gctools::Header_s*)0x1000) gctools::wait_for_user_signal("bad object");
-      // isValidGeneralObject() cannot be checked here: with a moving GC (Immix),
-      // the object may have been evacuated and the old header overwritten with a
-      // forwarding word. MMTk's callback handles forwarding; we must not validate first.
-    } break;
-    case gctools::cons_tag: {
-      void* client = reinterpret_cast<void*>(thing & gctools::ptr_mask);
-      gctools::ConsHeader_s* header = (gctools::ConsHeader_s*)gctools::ConsPtrToHeaderPtr(client);
-      if (header < (gctools::ConsHeader_s*)0x1000) gctools::wait_for_user_signal("bad object");
-      // isValidConsObject() same caveat as isValidGeneralObject() above.
-    }
-    }
-    callback(static_cast<void*>(field), data);
-  };
+  auto scan = [&](core::T_O** field) { callback(static_cast<void*>(field), data); };
   if (near->_badge_stamp_wtag_mtag.consObjectP()) {
     gctools::scan::cons(static_cast<core::Cons_O*>(client), scan);
   } else {
@@ -161,37 +142,13 @@ extern "C" MMTkClaspMutator clasp_get_mutator(void* tls) {
 
 extern "C" void clasp_walk_global_roots(ClaspPreciseRootCallback callback, void* data) {
   gctools::walkGlobalRoots([&](gctools::Tagged* tp) {
-    void* client = reinterpret_cast<void*>(*tp & gctools::ptr_mask);
-    switch (gctools::ptag(*tp)) {
-    case gctools::general_tag:
-    case gctools::cons_tag: {
-      if (client < (void*)0x1000) gctools::wait_for_user_signal("bad object");
-    } break;
-    }
     callback(static_cast<void*>(tp), data);
   });
 }
 
 extern "C" void clasp_walk_thread_precise_roots(void* tls, ClaspPreciseRootCallback callback, void* data) {
   core::ThreadLocalState* ts = static_cast<core::ThreadLocalState*>(tls);
-  auto walk = [&](gctools::Tagged* tp) {
-    void* client = reinterpret_cast<void*>(*tp & gctools::ptr_mask);
-    switch (gctools::ptag(*tp)) {
-    case gctools::general_tag: {
-      gctools::Header_s* header = (gctools::Header_s*)gctools::GeneralPtrToHeaderPtr(client);
-      if (header > (gctools::Header_s*)0x1000)
-        callback(static_cast<void*>(tp), data);
-      else gctools::wait_for_user_signal("bad object");
-    } break;
-    case gctools::cons_tag: {
-      gctools::ConsHeader_s* header = (gctools::ConsHeader_s*)gctools::ConsPtrToHeaderPtr(client);
-      if (header > (gctools::ConsHeader_s*)0x1000)
-        callback(static_cast<void*>(tp), data);
-      else gctools::wait_for_user_signal("bad object");
-    } break;
-    }
-    //callback(static_cast<void*>(tp), data);
-  };
+  auto walk = [&](gctools::Tagged* tp) { callback(static_cast<void*>(tp), data); };
   ts->walkRoots(walk);
   ts->walkVMStack(walk);
 }

--- a/src/gctools/mmtkGarbageCollection.cc
+++ b/src/gctools/mmtkGarbageCollection.cc
@@ -156,10 +156,16 @@ extern "C" void clasp_walk_thread_precise_roots(void* tls, ClaspPreciseRootCallb
 extern "C" void clasp_walk_thread_conservative_roots(void* tls, ClaspConservativeRootCallback callback, void* data) {
   core::ThreadLocalState* ts = static_cast<core::ThreadLocalState*>(tls);
   ts->walkControlStack([&](gctools::Tagged* tp) {
-    // Strip all tag bits to get a potential client pointer.  Only aligned,
-    // non-null addresses can be MMTk object references.
-    void* client = reinterpret_cast<void*>(*tp & gctools::ptr_mask);
-    if (!client)
+    gctools::Tagged raw = *tp;
+    // Skip anything that's not a tagged cons or general object
+    if (((raw & gctools::ptag_mask) != gctools::general_tag)
+        && ((raw & gctools::ptag_mask) != gctools::cons_tag))
+      return;
+    void* client = reinterpret_cast<void*>(raw & gctools::ptr_mask);
+    // Skip some obviously non-object addresses, including NULL
+    // (the only address that mmtk_clasp_is_mmtk_object can't accept)
+    if ((uintptr_t)client < 0x1000
+        || (uintptr_t)client > 0x7fff'ffff'ffff)
       return;
     // The VO bit is the authoritative check: MMTk sets it at allocation and
     // clears it at reclamation, so it is reliable without inspecting headers.

--- a/src/gctools/mmtkGarbageCollection.cc
+++ b/src/gctools/mmtkGarbageCollection.cc
@@ -38,6 +38,9 @@ THE SOFTWARE.
 
 namespace gctools {
 
+// used in gcalloc_mmtk.h
+size_t max_non_los_default_alloc_bytes;
+
 __attribute__((noinline)) void initializeMmtk(ClaspInfo* claspInfo) {
   // Build and initialise the MMTk instance.
   MMTkClaspBuilder builder = mmtk_clasp_create_builder();
@@ -50,6 +53,10 @@ __attribute__((noinline)) void initializeMmtk(ClaspInfo* claspInfo) {
   my_thread = (core::ThreadLocalState*)malloc(sizeof(core::ThreadLocalState));
   new (my_thread) core::ThreadLocalState(false);
   my_thread_low_level = &my_thread->_LowLevel;
+
+  // Grab some parameters
+  max_non_los_default_alloc_bytes
+    = mmtk_clasp_max_default_alloc_bytes();
 
   // The mutator for this thread was bound by ThreadLocalState's ctor.
   mmtk_clasp_initialize_collection(my_thread);

--- a/src/gctools/skip.cc
+++ b/src/gctools/skip.cc
@@ -19,11 +19,6 @@ size_t general_skip(core::General_O* client) {
   case Header_s::general_mtag: {
     GCStampEnum stamp_wtag = header_value.stamp_wtag();
     size_t stamp_index = header_value.stamp_();
-    if (stamp_wtag == STAMPWTAG_core__DerivableCxxObject_O) {
-      // If this is true then I think we need to call virtual functions on the client
-      // to determine the Instance_O offset and the total size of the object.
-      printf("%s:%d Handle STAMP_core__DerivableCxxObject_O\n", __FILE__, __LINE__);
-    }
     const Stamp_layout& stamp_layout = global_stamp_layout[stamp_index];
     const Container_layout* container_layout = stamp_layout.container_layout;
     if (container_layout) {

--- a/src/gctools/skip.cc
+++ b/src/gctools/skip.cc
@@ -14,36 +14,29 @@ size_t cons_skip(core::Cons_O* client) {
 size_t general_skip(core::General_O* client) {
   const BaseHeader_s& header = *base_header_ptr(client);
   const BaseHeader_s::BadgeStampWtagMtag& header_value = header._badge_stamp_wtag_mtag;
-  switch (header_value.mtag()) {
-    [[likely]]
-  case Header_s::general_mtag: {
-    GCStampEnum stamp_wtag = header_value.stamp_wtag();
-    size_t stamp_index = header_value.stamp_();
-    const Stamp_layout& stamp_layout = global_stamp_layout[stamp_index];
-    const Container_layout* container_layout = stamp_layout.container_layout;
-    if (container_layout) {
-      // abs is there because for bignums, we use a negative length to
-      // indicate that the bignum is negative.
-      size_t capacity = std::abs(*(int64_t*)((const char*)client + container_layout->capacity_offset));
-      if (container_layout->bits_per_bitunit) { // sub-byte array
-        return AlignUp(bitunit_sizeof(container_layout->bits_per_bitunit, capacity) + container_layout->data_offset);
-      } else if (stamp_wtag == STAMPWTAG_core__SimpleBaseString_O) [[unlikely]] { // Account for the SimpleBaseString additional byte for \0
-        return AlignUp(container_layout->element_size * (capacity + 1) + container_layout->data_offset);
-      } else if (stamp_wtag == STAMPWTAG_llvmo__ObjectFile_O) [[unlikely]] {
-        llvmo::ObjectFile_O* code = (llvmo::ObjectFile_O*)client;
-        return AlignUp(llvmo::ObjectFile_O::sizeofInState(code, code->_State));
-      } else {
-        return AlignUp(container_layout->element_size * capacity + container_layout->data_offset);
-      }
-    } else if (stamp_layout.layout_op == templated_op) {
-      return AlignUp(client->templatedSizeof());
-    } else { // normal object, not a container or template or anything
-      return AlignUp(stamp_layout.size);
+
+  GCStampEnum stamp_wtag = header_value.stamp_wtag();
+  size_t stamp_index = header_value.stamp_();
+  const Stamp_layout& stamp_layout = global_stamp_layout[stamp_index];
+  const Container_layout* container_layout = stamp_layout.container_layout;
+  if (container_layout) {
+    // abs is there because for bignums, we use a negative length to
+    // indicate that the bignum is negative.
+    size_t capacity = std::abs(*(int64_t*)((const char*)client + container_layout->capacity_offset));
+    if (container_layout->bits_per_bitunit) { // sub-byte array
+      return AlignUp(bitunit_sizeof(container_layout->bits_per_bitunit, capacity) + container_layout->data_offset);
+    } else if (stamp_wtag == STAMPWTAG_core__SimpleBaseString_O) [[unlikely]] { // Account for the SimpleBaseString additional byte for \0
+      return AlignUp(container_layout->element_size * (capacity + 1) + container_layout->data_offset);
+    } else if (stamp_wtag == STAMPWTAG_llvmo__ObjectFile_O) [[unlikely]] {
+      llvmo::ObjectFile_O* code = (llvmo::ObjectFile_O*)client;
+      return AlignUp(llvmo::ObjectFile_O::sizeofInState(code, code->_State));
+    } else {
+      return AlignUp(container_layout->element_size * capacity + container_layout->data_offset);
     }
-  } break; // stampP is false, so this is something weird like a forwarding pointer
-  default: {
-    throw_hard_error_bad_client((void*)client);
-  } break;
+  } else if (stamp_layout.layout_op == templated_op) {
+    return AlignUp(client->templatedSizeof());
+  } else { // normal object, not a container or template or anything
+    return AlignUp(stamp_layout.size);
   }
 }
 

--- a/src/gctools/threadlocal.cc
+++ b/src/gctools/threadlocal.cc
@@ -455,6 +455,17 @@ core::T_sp ThreadLocalState::dequeue_interrupt() {
   return interrupt;
 }
 
+// Check if there is anything in the interrupt queue.
+// Used in fast path polling (interrupt.cc handle_queued_interrupts)
+bool ThreadLocalState::pending_interrupts_p() {
+  // Use acquire-release since sending an interrupt synchronizes-with processing
+  // that interrupt.
+  core::Cons_sp head = _PendingInterruptsHead.load(std::memory_order_acquire);
+  if (!static_cast<bool>(head)) return false; // inline interrupt_queue_validp
+  core::T_sp next = head->cdr();
+  return !next.nilp();
+}
+
 void ThreadLocalState::startUpVM() { this->_VM.startup(); }
 
 ThreadLocalState::~ThreadLocalState() {

--- a/src/gctools/threadlocal.cc
+++ b/src/gctools/threadlocal.cc
@@ -220,6 +220,7 @@ ThreadLocalState::ThreadLocalState(bool dummy)
   // this point the world is not stopped. MMTk demands that the set of mutators
   // not change during a stop, and bind_mutator adds a mutator.
   _LowLevel._mmtk_mutator = mmtk_clasp_bind_mutator(this);
+  _LowLevel._mmtk_default_allocator_offset = mmtk_clasp_get_default_allocator_offset();
 #endif
 
 }
@@ -318,6 +319,7 @@ ThreadLocalState::ThreadLocalState()
   gctools::stw_register_thread(this);
 #ifdef USE_MMTK
   _LowLevel._mmtk_mutator = mmtk_clasp_bind_mutator(this);
+  _LowLevel._mmtk_default_allocator_offset = mmtk_clasp_get_default_allocator_offset();
 #endif
 }
 

--- a/src/gctools/threadlocal.cc
+++ b/src/gctools/threadlocal.cc
@@ -445,6 +445,7 @@ core::T_sp ThreadLocalState::dequeue_interrupt() {
   core::Cons_sp cnext;
   do {
     next = head->cdr();
+    if (!static_cast<bool>(head)) return nil<T_O>(); // not set up yet
     if (next.nilp()) return next; // nothing to dequeue
     cnext = next.as_assert<core::Cons_O>();
   } while (!_PendingInterruptsHead.compare_exchange_weak(head, cnext,

--- a/src/koga/config-header.lisp
+++ b/src/koga/config-header.lisp
@@ -66,7 +66,6 @@
                  "DEBUG_GUARD_BACKTRACE" (debug-guard-backtrace configuration)
                  "DEBUG_GUARD_EXHAUSTIVE_VALIDATE" (debug-guard-exhaustive-validate configuration)
                  "DEBUG_RELEASE" (debug-release configuration)
-                 "DEBUG_BITUNIT_CONTAINER" (debug-bitunit-container configuration)
                  "DEBUG_TRACK_UNWINDS" (debug-track-unwinds configuration)
                  "DEBUG_NO_UNWIND" (debug-no-unwind configuration)
                  "DEBUG_STARTUP" (debug-startup configuration)

--- a/src/koga/configure.lisp
+++ b/src/koga/configure.lisp
@@ -279,11 +279,6 @@
                   :initform nil
                   :type boolean
                   :documentation "Turn off optimization for a few C++ functions; undef this to optimize everything")
-   (debug-bitunit-container :accessor debug-bitunit-container
-                            :initarg :debug-bitunit-container
-                            :initform nil
-                            :type boolean
-                            :documentation "Prints debug info for bitunit containers")
    (debug-track-unwinds :accessor debug-track-unwinds
                         :initarg :debug-track-unwinds
                         :initform nil

--- a/src/lisp/kernel/lsp/fli.lisp
+++ b/src/lisp/kernel/lsp/fli.lisp
@@ -366,7 +366,7 @@
 (defun signature-return-type (signature) (first signature))
 (defun signature-argument-types (signature) (rest signature))
 
-(defun codegen-callback (signature var &key (c-name "callback"))
+(defun codegen-callback (signature literals &key (c-name "callback"))
   (let* ((rett-kw (signature-return-type signature))
          (rett (safe-translator-type rett-kw))
          (args-kws (signature-argument-types signature))
@@ -391,7 +391,9 @@
                                    (format nil "translated-~a" c-arg-name)))
                                 c-args c-argument-names args-kws))
                ;; Grab the function.
-               (closure-to-call (cmp:irc-t*-load var))
+               (closure-to-call
+                 (cmp:irc-t*-load
+                  (cmp:irc-const-gep2-64 cmp:%t*[0]% literals 0 0 "callback")))
                ;; And call.
                ;; results-in-registers keeps things in the basic tmv format,
                ;; which is all we need here, as the C function only uses
@@ -415,29 +417,24 @@
   (declare (ignorable function))
   (let* ((module (cmp::create-run-time-module-for-compile))
          (id (cmp::next-jit-compile-counter))
-         (varname (format nil "callback-lisp-function-~d" id))
-         (callback-name (format nil "callback-~d" id)))
+         (callback-name (format nil "callback-~d" id))
+         (litsname (format nil "__clasp_literals_~a" callback-name))
+         (litstype (llvm-sys:array-type-get cmp:%t*% 1))
+         ;; The Lisp function being called is stored in the generated literals.
+         ;; This is important for two reasons:
+         ;; 1. Our parseLinkGraph code expects there to be a variable named
+         ;;    __clasp_literals_whatever and we don't wanna rock the boat.
+         ;; 2. This puts the Lisp function in the ObjectFile's literals, which lets
+         ;;    it be scanned by GC properly.
+         (lits (llvm-sys:make-global-variable module litstype nil
+                                              'llvm-sys:external-linkage
+                                              (llvm-sys:undef-value-get litstype)
+                                              litsname)))
     (cmp::with-module (:module module)
-      (let ((var (llvm-sys:make-global-variable module cmp:%t*% nil
-                                                'llvm-sys:external-linkage
-                                                (llvm-sys:undef-value-get
-                                                 cmp:%t*%)
-                                                varname)))
-        (codegen-callback signature var :c-name callback-name))
-      ;; Some variables required by parseLinkGraph.
-      ;; We don't actually use them - this is a stupid sham.
-      ;; Initializers need to be put in to ensure the symbol actually
-      ;; exist in the lib - without initializers these are just declarations.
-      (llvm-sys:make-global-variable module cmp:%t*[0]% nil
-                                     'llvm-sys:external-linkage
-                                     (llvm-sys:constant-array-get
-                                      cmp:%t*[0]% nil)
-                                     (format nil "__clasp_literals_~a"
-                                             callback-name))
-      ;;(llvm-sys:dump-module module)
-      ;;(cmp:irc-verify-module-safe module)
-      (let ((dylib (llvm-sys:jit-module-to-dylib module callback-name)))
-        (setf (llvm-sys:jit-lookup-t dylib varname) function)
+      (codegen-callback signature lits :c-name callback-name)
+      (let* ((dylib (llvm-sys:jit-module-to-dylib module callback-name))
+             (lits (llvm-sys:jit-lookup dylib litsname)))
+        (setf (core:literals-vref lits 0) function)
         (llvm-sys:jit-lookup dylib callback-name)))))
 
 (defun %ensure-callback (signature function)

--- a/src/llvmo/link_intrinsics.cc
+++ b/src/llvmo/link_intrinsics.cc
@@ -688,7 +688,7 @@ core::T_O* cc_enclose(core::T_O* simpleFunInfo, std::size_t numCells) {
   core::T_sp tsimpleFun((gctools::Tagged)simpleFunInfo);
   core::SimpleFun_sp simpleFun = gc::As<SimpleFun_sp>(tsimpleFun);
   gctools::smart_ptr<core::Closure_O> functoid =
-      gctools::GC<core::Closure_O>::allocate_container<gctools::RuntimeStage>(false, numCells, simpleFun);
+    gctools::GC<core::Closure_O>::allocate_container<gctools::RuntimeStage, gctools::collectable_immobile>(false, numCells, simpleFun);
   return functoid.raw_();
 }
 

--- a/src/mmtk_clasp/src/api.rs
+++ b/src/mmtk_clasp/src/api.rs
@@ -174,11 +174,10 @@ pub extern "C" fn mmtk_clasp_alloc(
     mutator: *mut Mutator<ClaspVM>,
     size: usize,
     align: usize,
-    mut semantics: AllocationSemantics,
+    semantics: AllocationSemantics,
 ) -> Address {
-    if size >= mmtk().get_plan().constraints().max_non_los_default_alloc_bytes {
-        semantics = AllocationSemantics::Los;
-    }
+    debug_assert!(semantics == AllocationSemantics::Los
+                  || size < mmtk().get_plan().constraints().max_non_los_default_alloc_bytes);
     memory_manager::alloc::<ClaspVM>(unsafe { &mut *mutator }, size, align, 0, semantics)
 }
 
@@ -187,11 +186,10 @@ pub extern "C" fn mmtk_clasp_post_alloc(
     mutator: *mut Mutator<ClaspVM>,
     object: ObjectReference,
     bytes: usize,
-    mut semantics: AllocationSemantics,
+    semantics: AllocationSemantics,
 ) {
-    if bytes >= mmtk().get_plan().constraints().max_non_los_default_alloc_bytes {
-        semantics = AllocationSemantics::Los;
-    }
+    debug_assert!(semantics == AllocationSemantics::Los
+                  || bytes < mmtk().get_plan().constraints().max_non_los_default_alloc_bytes);
     memory_manager::post_alloc::<ClaspVM>(unsafe { &mut *mutator }, object, bytes, semantics)
 }
 

--- a/src/mmtk_clasp/src/api.rs
+++ b/src/mmtk_clasp/src/api.rs
@@ -13,12 +13,14 @@ use crate::scanning::QWEAKS;
 use crate::scanning::QWEAKS_RESURRECT;
 use libc::c_char;
 use mmtk::memory_manager;
+use mmtk::plan::Mutator;
 use mmtk::scheduler::GCWorker;
+use mmtk::util::alloc::Allocator;
+use mmtk::util::alloc::ImmixAllocator;
 use mmtk::util::opaque_pointer::*;
 use mmtk::util::{Address, ObjectReference};
 use mmtk::AllocationSemantics;
 use mmtk::MMTKBuilder;
-use mmtk::Mutator;
 use std::ffi::CStr;
 
 #[no_mangle]
@@ -77,6 +79,12 @@ pub extern "C" fn mmtk_clasp_init(builder: *mut MMTKBuilder) {
 }
 
 #[no_mangle]
+pub extern "C" fn mmtk_clasp_max_default_alloc_bytes(
+) -> usize {
+    mmtk().get_plan().constraints().max_non_los_default_alloc_bytes
+}
+
+#[no_mangle]
 pub extern "C" fn mmtk_clasp_initialize_collection(tls: VMThread) {
     memory_manager::initialize_collection(mmtk(), tls);
 }
@@ -116,6 +124,49 @@ pub extern "C" fn mmtk_clasp_destroy_mutator(mutator: *mut Mutator<ClaspVM>) {
     // Create a Box from the raw pointer which immediately goes
     // out of scope. Box going out of scope frees the pointed object.
     let _ = unsafe { Box::from_raw(mutator) };
+}
+
+/// Returns the byte offset from a Mutator pointer to its default (Immix) allocator.
+/// This is constant for a given plan and VM binding — compute it once at mutator
+/// bind time and reuse it for every allocation to skip semantic dispatch.
+#[no_mangle]
+pub extern "C" fn mmtk_clasp_get_default_allocator_offset() -> usize {
+    let selector = memory_manager::get_allocator_mapping(mmtk(), AllocationSemantics::Default);
+    Mutator::<ClaspVM>::get_allocator_base_offset(selector)
+}
+
+/// Fast-path alloc for Default semantics: bypasses AllocationSemantics dispatch by
+/// accessing the ImmixAllocator directly via the pre-computed offset.
+#[no_mangle]
+pub extern "C" fn mmtk_clasp_alloc_immix(
+    mutator: *mut Mutator<ClaspVM>,
+    immix_offset: usize,
+    size: usize,
+    align: usize,
+) -> Address {
+    debug_assert!(size < mmtk().get_plan().constraints().max_non_los_default_alloc_bytes);
+    let allocator = unsafe {
+        (Address::from_ptr(mutator) + immix_offset).as_mut_ref::<ImmixAllocator<ClaspVM>>()
+    };
+    allocator.alloc(size, align, 0)
+}
+
+/// Fast-path post_alloc for Default semantics: skips the LOS redirect check in
+/// mmtk_clasp_post_alloc and calls directly with Default, relying on the caller
+/// having already verified the object is below the LOS threshold.
+#[no_mangle]
+pub extern "C" fn mmtk_clasp_post_alloc_immix(
+    mutator: *mut Mutator<ClaspVM>,
+    object: ObjectReference,
+    bytes: usize,
+) {
+    debug_assert!(bytes < mmtk().get_plan().constraints().max_non_los_default_alloc_bytes);
+    memory_manager::post_alloc::<ClaspVM>(
+        unsafe { &mut *mutator },
+        object,
+        bytes,
+        AllocationSemantics::Default,
+    );
 }
 
 #[no_mangle]


### PR DESCRIPTION
Stuff to get MMTk working slightly better - inlining allocations and optimizing scanning a bit. Most of this doesn't affect the Boehm/other build, except:

- Allocation space is now specifiable as a template (constant) parameter rather than a runtime boolean, for marginal efficiency.
- Scanning can now be done through a separate shorter table of "fast" bitmaps.

...neither of which is really user visible.

One user visible thing is that now GCInfo has to be specified before the class is defined, or at least before the GC template is instantiated with that class. This is necessary for the allocation space specification to work.