### PR TITLE
Always assert type cast

### DIFF
--- a/include/clasp/clbind/constructor.h
+++ b/include/clasp/clbind/constructor.h
@@ -218,18 +218,11 @@ public:
       gctools::GCStamp<typename clbind::WRAPPER_Constructor_O<Sig, Pols, Pointer, T>::TemplatedBase>::StampWtag;
 };
 
-template <typename Sig, typename Pols, typename Pointer, typename T>
-struct gctools::Inherits<typename clbind::WRAPPER_Constructor_O<Sig, Pols, Pointer, T>::TemplatedBase,
-                         clbind::WRAPPER_Constructor_O<Sig, Pols, Pointer, T>> : public std::true_type {};
-
 template <typename Policies, typename T> class gctools::GCStamp<clbind::DerivableDefaultConstructorFunctor<Policies, T>> {
 public:
   static gctools::GCStampEnum const StampWtag =
       gctools::GCStamp<typename clbind::DerivableDefaultConstructorFunctor<Policies, T>::TemplatedBase>::StampWtag;
 };
-template <typename Policies, typename T>
-struct gctools::Inherits<typename clbind::DerivableDefaultConstructorFunctor<Policies, T>::TemplatedBase,
-                         clbind::DerivableDefaultConstructorFunctor<Policies, T>> : public std::true_type {};
 
 namespace clbind {
 template <typename... SIGS> using init = constructor<SIGS...>;

--- a/include/clasp/clbind/function.h
+++ b/include/clasp/clbind/function.h
@@ -152,11 +152,6 @@ public:
       gctools::GCStamp<typename clbind::WRAPPER_VariadicFunction<FunctionPtrType, Policies>::TemplatedBase>::StampWtag;
 };
 
-template <typename FunctionPtrType, typename Policies>
-struct gctools::Inherits<
-    typename clbind::WRAPPER_VariadicFunction<FunctionPtrType, Policies>::TemplatedBase,
-    clbind::WRAPPER_VariadicFunction<FunctionPtrType, Policies>> : public std::true_type {};
-
 namespace clbind {
 
 namespace detail {

--- a/include/clasp/clbind/iteratorMemberFunction.h
+++ b/include/clasp/clbind/iteratorMemberFunction.h
@@ -98,7 +98,3 @@ public:
   static gctools::GCStampEnum const StampWtag =
       gctools::GCStamp<typename clbind::WRAPPER_Iterator<Policies, OT, Begin, End>::TemplatedBase>::StampWtag;
 };
-
-template <typename Policies, typename OT, typename Begin, typename End>
-struct gctools::Inherits<typename clbind::WRAPPER_Iterator<Policies, OT, Begin, End>::TemplatedBase,
-                         clbind::WRAPPER_Iterator<Policies, OT, Begin, End>> : public std::true_type {};

--- a/include/clasp/clbind/property.h
+++ b/include/clasp/clbind/property.h
@@ -65,16 +65,8 @@ public:
 };
 
 template <typename Policies, typename OT, typename VariablePtrType>
-struct gctools::Inherits<typename clbind::WRAPPER_Getter<Policies, OT, VariablePtrType>::TemplatedBase,
-                         clbind::WRAPPER_Getter<Policies, OT, VariablePtrType>> : public std::true_type {};
-
-template <typename Policies, typename OT, typename VariablePtrType>
 class gctools::GCStamp<clbind::WRAPPER_Setter<Policies, OT, VariablePtrType>> {
 public:
   static gctools::GCStampEnum const StampWtag =
       gctools::GCStamp<typename clbind::WRAPPER_Setter<Policies, OT, VariablePtrType>::TemplatedBase>::StampWtag;
 };
-
-template <typename Policies, typename OT, typename VariablePtrType>
-struct gctools::Inherits<typename clbind::WRAPPER_Setter<Policies, OT, VariablePtrType>::TemplatedBase,
-                         clbind::WRAPPER_Setter<Policies, OT, VariablePtrType>> : public std::true_type {};

--- a/include/clasp/core/configure_clasp.h
+++ b/include/clasp/core/configure_clasp.h
@@ -300,10 +300,3 @@ ENTRY_POINT_MAX_ARGS_IN_REGISTER_SAVE_AREA includes the closure
 // On linux and OS X we have mkstemp so use it
 #define HAVE_MKSTEMP
 #define HAVE_MKDTEMP
-
-#if defined(DEBUG_ASSERT_TYPE_CAST) && defined(USE_PRECISE_GC)
-// DO_ASSERT_TYPE_CAST only works with USE_PRECISE_GC
-#define DO_ASSERT_TYPE_CAST 1
-#else
-                        // Do nothing - we can't DO_ASSERT_TYPE_CAST if
-#endif

--- a/include/clasp/core/external_wrappers.h
+++ b/include/clasp/core/external_wrappers.h
@@ -197,10 +197,6 @@ public:
       typename clbind::WRAPPER_IndirectMethod<MethodPtrType, Policies, OT>::TemplatedBase>::StampWtag;
 };
 
-template <typename Policies, typename OT, typename MethodPtrType>
-struct gctools::Inherits<typename clbind::WRAPPER_IndirectMethod<MethodPtrType, Policies, OT>::TemplatedBase,
-                         clbind::WRAPPER_IndirectMethod<MethodPtrType, Policies, OT>> : public std::true_type {};
-
 namespace core {
 
 // ----------------------------------------

--- a/include/clasp/core/wrappers.h
+++ b/include/clasp/core/wrappers.h
@@ -199,9 +199,6 @@ public:
   static gctools::GCStampEnum const StampWtag = gctools::GCStamp<
       typename clbind::WRAPPER_VariadicMethod<FunctionPtrType, Policies>::TemplatedBase>::StampWtag;
 };
-template <typename FunctionPtrType, typename Policies>
-struct gctools::Inherits<typename clbind::WRAPPER_VariadicMethod<FunctionPtrType, Policies>::TemplatedBase,
-                         clbind::WRAPPER_VariadicMethod<FunctionPtrType, Policies>> : public std::true_type {};
 
 namespace core {
 

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -50,7 +50,10 @@
 
 namespace gctools {
 
-#if (defined(DO_ASSERT_TYPE_CAST) && !defined(SCRAPING))
+#ifdef SCRAPING
+// with scraping we don't have the above, so problems could happen (?)
+template <typename T1, typename T2> struct Inherits : std::true_type {};
+#else
 template <typename Super, typename Sub> struct Inherits : std::is_base_of<Super, Sub> {};
 /// Add special Inheritance info here
 template <> struct Inherits<core::Number_O, ::core::SingleFloat_I> : public std::true_type {};
@@ -60,10 +63,7 @@ template <> struct Inherits<core::Number_O, ::core::Fixnum_I> : public std::true
 template <> struct Inherits<core::Real_O, ::core::Fixnum_I> : public std::true_type {};
 template <> struct Inherits<core::Rational_O, ::core::Fixnum_I> : public std::true_type {};
 template <> struct Inherits<core::Integer_O, ::core::Fixnum_I> : public std::true_type {};
-
 /// Stop special Inheritance
-#else
-template <typename T1, typename T2> struct Inherits : std::true_type {};
 #endif
 
 template <typename Super, typename Sub>

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -36,24 +36,8 @@
 #include <type_traits> // is_base_of
 #include <ranges>
 
-#ifndef SCRAPING
-#ifdef USE_PRECISE_GC
-#define DECLARE_FORWARDS
-#include CLASP_GC_CC
-#undef DECLARE_FORWARDS
-#else
-#define DECLARE_FORWARDS
-#include INIT_CLASSES_INC_H
-#undef DECLARE_FORWARDS
-#endif
-#endif
-
 namespace gctools {
 
-#ifdef SCRAPING
-// with scraping we don't have the above, so problems could happen (?)
-template <typename T1, typename T2> struct Inherits : std::true_type {};
-#else
 template <typename Super, typename Sub> struct Inherits : std::is_base_of<Super, Sub> {};
 /// Add special Inheritance info here
 template <> struct Inherits<core::Number_O, ::core::SingleFloat_I> : public std::true_type {};
@@ -64,7 +48,6 @@ template <> struct Inherits<core::Real_O, ::core::Fixnum_I> : public std::true_t
 template <> struct Inherits<core::Rational_O, ::core::Fixnum_I> : public std::true_type {};
 template <> struct Inherits<core::Integer_O, ::core::Fixnum_I> : public std::true_type {};
 /// Stop special Inheritance
-#endif
 
 template <typename Super, typename Sub>
 concept InheritsC = Inherits<Super, Sub>::value;

--- a/src/gctools/gcFunctions.cc
+++ b/src/gctools/gcFunctions.cc
@@ -818,16 +818,6 @@ bool debugging_configuration(bool setFeatures, bool buildReport, stringstream& s
   if (buildReport)
     ss << (fmt::format("DEBUG_VERIFY_TRANSFORMATIONS = {}\n", (debug_verify_transformations ? "**DEFINED**" : "undefined")));
 
-  bool debug_assert_type_cast = false;
-#ifdef DO_ASSERT_TYPE_CAST
-  debug_assert_type_cast = true;
-  debugging = true;
-  if (setFeatures)
-    features = core::Cons_O::create(_lisp->internKeyword("DEBUG-ASSERT-TYPE-CAST"), features);
-#endif
-  if (buildReport)
-    ss << (fmt::format("DO_ASSERT_TYPE_CAST = {}\n", (debug_assert_type_cast ? "**DEFINED**" : "undefined")));
-
   bool debug_llvm_optimization_level_0 = false;
 #ifdef DEBUG_LLVM_OPTIMIZATION_LEVEL_0
   debug_llvm_optimization_level_0 = true;

--- a/src/koga/config-header.lisp
+++ b/src/koga/config-header.lisp
@@ -57,7 +57,6 @@
                  "DEBUG_DTREE_INTERPRETER" (debug-dtree-interpreter configuration)
                  "DEBUG_DTRACE_LOCK_PROBE" (debug-dtrace-lock-probe configuration)
                  "DEBUG_STACKMAPS" (debug-stackmaps configuration)
-                 "DEBUG_ASSERT_TYPE_CAST" (debug-assert-type-cast configuration)
                  "DEBUG_ASSERT" (debug-assert configuration)
                  "SOURCE_DEBUG" (source-debug configuration)
                  "DEBUG_JIT_LOG_SYMBOLS" (debug-jit-log-symbols configuration)

--- a/src/koga/configure.lisp
+++ b/src/koga/configure.lisp
@@ -239,11 +239,6 @@
                  :initform nil
                  :type boolean
                  :documentation "Turn on DEBUG_ASSERT")
-   (debug-assert-type-cast :accessor debug-assert-type-cast
-                           :initarg :debug-assert-type-cast
-                           :initform nil
-                           :type boolean
-                           :documentation "Turn on type checking when passing arguments")
    (source-debug :accessor source-debug
                  :initarg :source-debug
                  :initform nil


### PR DESCRIPTION
Remove `debug-assert-type-cast` build option and instead just always assert type casts. See first commit for more detailed rationale, but in short, it no longer has runtime overhead and is less error prone.