### PR TITLE
Smart pointer cleanup

### DIFF
--- a/include/clasp/core/array.h
+++ b/include/clasp/core/array.h
@@ -592,10 +592,7 @@ public:
     // Dynamic dispatch the common self case for speed, and also to avoid
     // any aliasing problems.
     if (source.isA<leaf_type>())
-      // KLUDGE: apparently the generic smart_ptr template does not define
-      // as_unsafe, so source.as_unsafe gets you a base_ptr, which does not
-      // fit the templates. WTF?
-      copy_n(gc::As_unsafe<leaf_smart_ptr_type>(source), dest_start, source_start, n);
+      copy_n(source.as_unsafe<leaf_type>(), dest_start, source_start, n);
     else
       for (size_t i = 0; i < n; ++i)
         // virtual dispatch is required unless we want to hardcode

--- a/include/clasp/core/bytecode_compiler.h
+++ b/include/clasp/core/bytecode_compiler.h
@@ -509,7 +509,7 @@ public:
    */
   CL_DEFMETHOD Lexenv_sp macroexpansion_environment();
   T_sp variableInfo(T_sp varname);
-  T_sp lookupSymbolMacro(T_sp sname);
+  T_sp lookupSymbolMacro(Symbol_sp sname);
   T_sp functionInfo(T_sp fname);
   T_sp lookupMacro(Symbol_sp mname);
   bool notinlinep(T_sp fname);

--- a/include/clasp/core/core.h
+++ b/include/clasp/core/core.h
@@ -808,7 +808,7 @@ List_sp lisp_parse_arguments(const string& packageName, const string& args, int 
 List_sp lisp_lexical_variable_names(List_sp lambda_list, bool& trivial_wrapper);
 List_sp lisp_parse_declares(const string& packageName, const string& declarestring);
 
-void lisp_defineSingleDispatchMethod(T_sp name, Symbol_sp classSymbol,
+void lisp_defineSingleDispatchMethod(Symbol_sp name, Symbol_sp classSymbol,
                                      Function_sp entry, size_t TemplateDispatchOn = 0,
                                      bool useTemplateDispatchOn = false, const string& lambda_list = "",
                                      const string& declares = "", const string& docstring = "", bool autoExport = true,

--- a/include/clasp/core/fli.h
+++ b/include/clasp/core/fli.h
@@ -192,7 +192,7 @@ private:
 DOCGROUP(clasp)
 CL_DEFUN ForeignData_sp PERCENTallocate_foreign_object(core::T_sp kind);
 DOCGROUP(clasp)
-CL_DEFUN ForeignData_sp PERCENTallocate_foreign_data(core::Integer_sp size);
+CL_DEFUN ForeignData_sp PERCENTallocate_foreign_data(size_t size);
 ForeignData_sp allocate_foreign_data(uint64_t size);
 
 DOCGROUP(clasp)

--- a/include/clasp/core/hashTable.h
+++ b/include/clasp/core/hashTable.h
@@ -39,7 +39,7 @@ double maybeFixRehashThreshold(double rt);
 #define DEFAULT_REHASH_THRESHOLD 0.7
 
 T_sp cl__make_hash_table(T_sp test, Fixnum_sp size, Number_sp rehash_size, Real_sp orehash_threshold,
-                         Symbol_sp weakness = nil<T_O>(), T_sp debug = nil<T_O>(), T_sp thread_safe = nil<T_O>(),
+                         Symbol_sp weakness = nil<Symbol_O>(), T_sp debug = nil<T_O>(), T_sp thread_safe = nil<T_O>(),
                          T_sp hashf = nil<T_O>());
 
 size_t next_hash_table_id();

--- a/include/clasp/core/record.h
+++ b/include/clasp/core/record.h
@@ -611,7 +611,7 @@ public:
       // and search from there and reverse the alist once it's done
       List_sp find = core__alist_assoc_eq(this->_alist, name);
       if (!find.consp())
-        value = nil<core::T_O>();
+        value = nil<OT>();
       else {
         Cons_sp apair = gc::As_unsafe<Cons_sp>(find);
         value = gc::As<gc::smart_ptr<OT>>(CONS_CDR(apair));
@@ -623,7 +623,7 @@ public:
       // and search from there and reverse the alist once it's done
       List_sp find = core__alist_assoc_eq(this->_alist, name);
       if (!find.consp())
-        value = nil<core::T_O>();
+        value = nil<OT>();
       else {
         Cons_sp apair = gc::As_unsafe<Cons_sp>(find);
         // When loading the object oCdr(apair) may not be of the

--- a/include/clasp/core/smallMultimap.h
+++ b/include/clasp/core/smallMultimap.h
@@ -51,13 +51,13 @@ class SmallMultimap_O : public General_O {
   map_type map;
 
 public:
-  void insert(T_sp key, T_sp val);
+  void insert(Symbol_sp key, T_sp val);
   CL_LISPIFY_NAME("small_multimap_size");
   CL_DEFMETHOD int size() const { return this->map.size(); };
   void erase(T_sp key);
   void describe();
-  void describeRange(T_sp key);
-  bool contains(T_sp key);
+  void describeRange(Symbol_sp key);
+  bool contains(Symbol_sp key);
   DEFAULT_CTOR_DTOR(SmallMultimap_O);
 };
 }; // namespace core

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -994,27 +994,6 @@ public:
 };     // namespace gctools
 
 namespace gctools {
-
-////////////////////////////////////////////////////////////////////////
-///
-/// Specialize type conversions to simulate Common Lisp semantics and
-/// Common Lisp type hierarchy (is that the term)
-///
-
-template <> inline smart_ptr<core::List_V> smart_ptr<core::T_O>::asOrNull<core::List_V>() const {
-  if (this->consp() || this->nilp())
-    return smart_ptr<core::List_V>((Tagged)this->theObject);
-  return smart_ptr<core::List_V>();
-};
-
-template <> inline smart_ptr<core::List_V> smart_ptr<core::Symbol_O>::asOrNull<core::List_V>() const {
-  if (this->nilp())
-    return smart_ptr<core::List_V>((Tagged)this->theObject);
-  return smart_ptr<core::List_V>();
-};
-}; // namespace gctools
-
-namespace gctools {
 // An idea suggested by Georgiy Tugai.
 // Nilable<Foo_sp> is a variable that has the type (OR NULL FOO)
 // It inherits from Foo_sp

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -528,7 +528,9 @@ public:
   explicit inline smart_ptr(Type* ptr) : base_ptr((Type*)ptr){};
   inline smart_ptr(base_ptr<core::Symbol_O> orig) : base_ptr<core::Symbol_O>((Tagged)orig.raw_()){};
 
-  template <class From> inline smart_ptr(smart_ptr<From> const& rhs) {
+  template <class From> inline smart_ptr(smart_ptr<From> const& rhs)
+    requires InheritsC<Type, From>
+  {
     if (LIKELY(rhs.objectp())) {
       Type* px = TaggedCast<Type*, From*>::castOrNULL(rhs.theObject);
       if (px == 0) {

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -201,10 +201,6 @@ public:
   bool short_floatp() const { return tagged_short_floatp<Type*>(this->theObject); };
   short_float_t unsafe_short_float() const { return untag_short_float<Type*>(this->theObject); };
 #endif
-  Fixnum asFixnum() const {
-    GCTOOLS_ASSERT(this->fixnump());
-    return untag_fixnum<Type*>(this->theObject);
-  };
   bool valistp() const { return tagged_vaslistp(this->theObject); };
   void* unsafe_valist() const { return untag_vaslist(this->theObject); };
   void* safe_valist() const {

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -92,8 +92,7 @@ public:
 
   template <class o_class> inline smart_ptr<o_class> asOrNull() const {
     o_class* cast = TaggedCast<o_class*, Type*>::castOrNULL(this->theObject);
-    smart_ptr<o_class> ret((Tagged)cast);
-    return ret;
+    return smart_ptr<o_class>((Tagged)cast);
   }
 
   template <class o_class> inline smart_ptr<o_class> as() const {
@@ -104,8 +103,7 @@ public:
   }
 
   template <class o_class> inline smart_ptr<o_class> as_unsafe() const {
-    smart_ptr<o_class> ret((Tagged)this->theObject);
-    return ret;
+    return smart_ptr<o_class>((Tagged)this->theObject);
   }
 
   template <class o_class> inline smart_ptr<o_class> as_assert() const {
@@ -114,8 +112,7 @@ public:
       throw_hard_error_failed_assertion("as_assert failed!");
     }
 #endif
-    smart_ptr<o_class> ret((Tagged)this->theObject);
-    return ret;
+    return smart_ptr<o_class>((Tagged)this->theObject);
   }
 
   template <class o_class> inline bool isA() const { return TaggedCast<o_class*, Type*>::isA(this->theObject); }

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -281,49 +281,40 @@ namespace gctools {
 // Declare As converters
 //
 template <typename To_SP> inline bool IsA(return_type const& rhs) {
-  return TaggedCast<typename To_SP::Type*, typename core::T_O*>::isA(reinterpret_cast<core::T_O*>(rhs.ret0[0]));
+  return core::T_sp((Tagged)rhs.ret0[0]).isA<typename To_SP::Type>();
 };
-template <typename To_SP, typename From_SP> inline bool IsA(From_SP const& rhs) {
-  return TaggedCast<typename To_SP::Type*, typename From_SP::Type*>::isA(reinterpret_cast<typename From_SP::Type*>(rhs.raw_()));
+template <typename To_SP, typename From> inline bool IsA(smart_ptr<From> const& rhs) {
+  return rhs.template isA<typename To_SP::Type>();
 }
 
-template <typename To_SP, typename From_SP> inline To_SP As(From_SP const& rhs) {
-  if (IsA<To_SP>(rhs)) {
-    To_SP ret((Tagged)rhs.raw_());
-    return ret;
-  }
-  // If the cast didn't work then signal a type error
+template <typename To_SP, typename From> inline To_SP As(smart_ptr<From> const& rhs) {
+  if (rhs.template isA<typename To_SP::Type>())
+    return To_SP((Tagged)rhs.raw_());
+  // If the cast didn't work then signal a type error.
+  // This is why we can't just use smart_ptr::as directly: here we
+  // signal an errorBadCastStampWtag instead of the more sophisticated
+  // errorCast as() uses, and errorCast requires the type to be
+  // complete. errorBadCastStampWtag does not, and is used in a few
+  // places with incomplete types. This is the only remaining
+  // difference between as() and As() that I can see. KLUDGE, FIXME
   gctools::GCStampEnum expectedStampWtag = gctools::GCStamp<typename To_SP::Type>::StampWtag;
   lisp_errorBadCastStampWtag((size_t)expectedStampWtag, rhs.raw_());
   HARD_UNREACHABLE();
 }
 template <typename To_SP> inline To_SP As(const return_type& rhs) {
   GCTOOLS_ASSERT(rhs.nvals == 1);
-  if (IsA<To_SP>(rhs)) {
-    To_SP ret((Tagged)rhs.ret0[0]);
-    return ret;
-  }
-  class_id expected_typ = reg::registered_class<typename To_SP::Type>::id;
-  lisp_errorBadCastFromT_O(expected_typ, reinterpret_cast<core::T_O*>(rhs.ret0[0]));
-  HARD_UNREACHABLE();
+  return core::T_sp((Tagged)rhs.ret0[0]).as<typename To_SP::Type>();
 }
 
 // Cast the type without any concern if it is appropriate
-template <typename To_SP, typename From_SP> inline To_SP As_unsafe(From_SP const& rhs) {
-  To_SP ret((Tagged)rhs.raw_());
-  return ret;
+template <typename To_SP, typename From> inline To_SP As_unsafe(smart_ptr<From> const& rhs) {
+  return rhs.template as_unsafe<typename To_SP::Type>();
 }
 
 // Cast the type without any concern if it is appropriate
 // If DEBUG_ASSERT then check if the type is appropriate.
-template <typename To_SP, typename From_SP> inline To_SP As_assert(From_SP const& rhs) {
-#ifdef DEBUG_ASSERT
-  if (!gctools::IsA<To_SP>(rhs)) {
-    throw_hard_error_cast_failed(typeid(To_SP).name(), typeid(From_SP).name());
-  }
-#endif
-  To_SP ret((Tagged)rhs.raw_());
-  return ret;
+template <typename To_SP, typename From> inline To_SP As_assert(smart_ptr<From> const& rhs) {
+  return rhs.template as_assert<typename To_SP::Type>();
 }
 
 }; // namespace gctools

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -40,6 +40,11 @@ namespace gctools {
 
 template <typename Super, typename Sub> struct Inherits : std::is_base_of<Super, Sub> {};
 /// Add special Inheritance info here
+// T_O is a superclass of everything- this is needed so that
+// T_sp can be converted from smart_ptr<X> for any X, even if X
+// is an incomplete type (forward-declared).
+template <typename Any> struct Inherits<core::T_O, Any> : public std::true_type {};
+// Magic immediate number types
 template <> struct Inherits<core::Number_O, ::core::SingleFloat_I> : public std::true_type {};
 template <> struct Inherits<core::Real_O, ::core::SingleFloat_I> : public std::true_type {};
 template <> struct Inherits<core::Float_O, ::core::SingleFloat_I> : public std::true_type {};
@@ -200,6 +205,12 @@ public:
     GCTOOLS_ASSERT(this->fixnump());
     return untag_fixnum<Type*>(this->theObject);
   };
+  bool valistp() const { return tagged_vaslistp(this->theObject); };
+  void* unsafe_valist() const { return untag_vaslist(this->theObject); };
+  void* safe_valist() const {
+    GCTOOLS_ASSERT(this->valistp());
+    return this->unsafe_valist();
+  };
 
   /*! Return the raw smart_ptr value interpreted as a T_O* */
   inline core::T_O* raw_() const { return reinterpret_cast<core::T_O*>(this->theObject); }
@@ -322,121 +333,6 @@ template <typename To_SP, typename From_SP> inline To_SP As_assert(From_SP const
 }; // namespace gctools
 
 namespace gctools {
-template <> class smart_ptr<core::T_O> {
-public:
-  typedef core::T_O Type;
-  Type* theObject;
-
-public:
-  // Default constructor, set theObject to NULL
-  smart_ptr() noexcept : theObject((Type*)NULL){};
-  explicit inline smart_ptr(Type* ptr) : theObject(ptr){};
-  /*! Create a smart pointer from an existing tagged pointer */
-  explicit inline smart_ptr(Tagged ptr) : theObject((Type*)ptr){};
-  inline smart_ptr(const return_type& rt) : theObject((Type*)rt.ret0[0]){};
-  template <class From> inline smart_ptr(smart_ptr<From> const& rhs) : theObject((Type*)rhs.theObject){};
-
-  inline return_type as_return_type() const { return return_type(this->theObject, 1); };
-
-  template <class o_class> inline smart_ptr<o_class> asOrNull() const {
-    return smart_ptr<o_class>((Tagged)TaggedCast<o_class*, Type*>::castOrNULL(this->theObject));
-  }
-
-  template <class o_class> inline smart_ptr<o_class> as() const {
-    smart_ptr<o_class> ret = this->asOrNull<o_class>();
-    if (ret)
-      return ret;
-    core::lisp_errorCast<o_class, Type>(this->theObject);
-  }
-
-  template <class o_class> inline smart_ptr<o_class> as_unsafe() const {
-    smart_ptr<o_class> ret((Tagged)this->theObject);
-    return ret;
-  }
-
-  template <class o_class> inline smart_ptr<o_class> as_assert() const {
-#ifdef DEBUG_ASSERT
-    if (!TaggedCast<o_class*, Type*>::isA(this->theObject)) {
-      throw_hard_error_failed_assertion("as_assert failed!");
-    }
-#endif
-    smart_ptr<o_class> ret((Tagged)this->theObject);
-    return ret;
-  }
-
-  template <class o_class> inline bool isA() const {
-    smart_ptr<o_class> ret = this->asOrNull<o_class>();
-    return ((bool)ret);
-  }
-
-public:
-  inline explicit operator bool() const { return this->theObject != NULL; };
-  inline Type* untag_object() const { return ::gctools::untag_object(this->theObject); }
-  /*! Dereferencing operator - remove the other tag */
-  inline Type* operator->() const {
-    GCTOOLS_ASSERT(this->theObject);
-    return this->untag_object();
-  };
-  inline Type& operator*() const {
-    GCTOOLS_ASSERT(this->theObject);
-    return *this->untag_object();
-  };
-  /*! This should almost NEVER be used!!!!!!
-
-          List all uses of rawRef_ here:
-          intrinsics.cc>>cc_loadTimeValueReference
-          record.h>>field specialized on gc::smart_ptr<OT>&
-          SMART_PTR_FIX and smart_ptr fixing in general when SMART_PTR_FIX is replaced
-                  with a direct call to the fixing template function
-        */
-  Type*& rawRef_() { return this->theObject; };
-  inline void setRaw_(Tagged p) { this->theObject = reinterpret_cast<core::T_O*>(p); }
-  void reset_() { this->theObject = NULL; };
-
-public:
-  int number_of_values() const { return this->theObject == NULL ? 0 : 1; };
-  bool unboundp() const { return tagged_unboundp(this->theObject); };
-  bool boundp() const { return !tagged_unboundp(this->theObject); };
-  bool no_keyp() const { return tagged_no_keyp(this->theObject); };
-  bool deletedp() const { return tagged_deletedp(this->theObject); };
-  bool same_as_keyP() const { return tagged_same_as_keyp(this->theObject); };
-  inline bool nilp() const { return tagged_nilp(this->theObject); }
-  inline bool notnilp() const { return (!this->nilp()); };
-  bool isTrue() const { return !this->nilp(); };
-  inline bool fixnump() const { return tagged_fixnump(this->theObject); };
-  bool characterp() const { return tagged_characterp<Type*>(this->theObject); };
-  claspCharacter unsafe_character() const { return untag_character(this->theObject); };
-  inline bool generalp() const { return tagged_generalp(this->theObject); };
-  inline bool consp() const { return tagged_consp(this->theObject); };
-  inline bool objectp() const { return this->generalp() || this->consp(); };
-  inline Fixnum unsafe_fixnum() const { return untag_fixnum(this->theObject); };
-  bool single_floatp() const { return tagged_single_floatp<Type*>(this->theObject); };
-  float unsafe_single_float() const { return untag_single_float<Type*>(this->theObject); };
-#ifdef CLASP_SHORT_FLOAT
-  bool short_floatp() const { return tagged_short_floatp<Type*>(this->theObject); };
-  float unsafe_short_float() const { return untag_short_float<Type*>(this->theObject); };
-#endif
-  bool valistp() const { return tagged_vaslistp(this->theObject); };
-  void* unsafe_valist() const { return untag_vaslist(this->theObject); };
-  void* safe_valist() const {
-    GCTOOLS_ASSERT(this->valistp());
-    return this->unsafe_valist();
-  };
-
-  inline core::T_O* raw_() const { return reinterpret_cast<core::T_O*>(this->theObject); };
-  inline gctools::Tagged tagged_() const { return reinterpret_cast<gctools::Tagged>(this->theObject); }
-  inline core::Cons_O* unsafe_cons() const {
-    GCTOOLS_ASSERT(this->consp());
-    return untag_cons(reinterpret_cast<core::Cons_O*>(this->theObject));
-  };
-  core::General_O* unsafe_general() const {
-    GCTOOLS_ASSERT(this->generalp());
-    return untag_general(reinterpret_cast<core::General_O*>(this->theObject));
-  };
-  template <class U> inline bool operator==(smart_ptr<U> const other) const { return this->theObject == other.theObject; }
-
-  template <class U> inline bool operator!=(smart_ptr<U> const other) const { return this->theObject != other.theObject; }
-};
 /* Smart pointers should be trivial so they can be passed/returned
  * in registers easily. But the default constructor is nontrivial,
  * so we're merely trivially copyable.

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -59,22 +59,22 @@ namespace gctools {
 template <typename O, typename Index>
 concept Indexable = requires(O o, Index i) { o[i]; };
 
-template <class T> class base_ptr {
+template <class T> class smart_ptr {
 public:
   typedef T Type;
   Type* theObject;
 
 public:
   // Default constructor, set theObject to NULL
-  inline base_ptr() noexcept : theObject(NULL){};
+  inline smart_ptr() noexcept : theObject(NULL){};
   /*! Create a smart pointer from an existing tagged pointer */
-  explicit inline base_ptr(Tagged ptr) : theObject(reinterpret_cast<Type*>(ptr)){};
-  explicit inline base_ptr(Type* ptr) : theObject(ptr ? tag_general<Type*>(ptr) : NULL) {
+  explicit inline smart_ptr(Tagged ptr) : theObject(reinterpret_cast<Type*>(ptr)){};
+  explicit inline smart_ptr(Type* ptr) : theObject(ptr ? tag_general<Type*>(ptr) : NULL) {
     GCTOOLS_ASSERT((reinterpret_cast<uintptr_t>(ptr) & ptag_mask) == 0);
   };
-  inline base_ptr(const return_type& rt) : theObject((Type*)rt.ret0[0]){};
+  inline smart_ptr(const return_type& rt) : theObject((Type*)rt.ret0[0]){};
 
-  template <class From> inline base_ptr(base_ptr<From> const& rhs)
+  template <class From> inline smart_ptr(smart_ptr<From> const& rhs)
     requires InheritsC<Type, From>
     : theObject(reinterpret_cast<Type*>(rhs.theObject)) {}
 
@@ -83,38 +83,38 @@ public:
 public:
   void reset_() { this->theObject = NULL; };
 
-  inline void swap(base_ptr<Type>& other) {
+  inline void swap(smart_ptr<Type>& other) {
     Type* temp;
     temp = this->theObject;
     this->theObject = other.theObject;
     other.theObject = temp;
   };
 
-  template <class o_class> inline base_ptr<o_class> asOrNull() const {
+  template <class o_class> inline smart_ptr<o_class> asOrNull() const {
     o_class* cast = TaggedCast<o_class*, Type*>::castOrNULL(this->theObject);
-    base_ptr<o_class> ret((Tagged)cast);
+    smart_ptr<o_class> ret((Tagged)cast);
     return ret;
   }
 
-  template <class o_class> inline base_ptr<o_class> as() const {
-    base_ptr<o_class> ret = this->asOrNull<o_class>();
+  template <class o_class> inline smart_ptr<o_class> as() const {
+    smart_ptr<o_class> ret = this->asOrNull<o_class>();
     if (ret)
       return ret;
     core::lisp_errorCast<o_class, Type>(this->theObject);
   }
 
-  template <class o_class> inline base_ptr<o_class> as_unsafe() const {
-    base_ptr<o_class> ret((Tagged)this->theObject);
+  template <class o_class> inline smart_ptr<o_class> as_unsafe() const {
+    smart_ptr<o_class> ret((Tagged)this->theObject);
     return ret;
   }
 
-  template <class o_class> inline base_ptr<o_class> as_assert() const {
+  template <class o_class> inline smart_ptr<o_class> as_assert() const {
 #ifdef DEBUG_ASSERT
     if (!TaggedCast<o_class*, Type*>::isA(this->theObject)) {
       throw_hard_error_failed_assertion("as_assert failed!");
     }
 #endif
-    base_ptr<o_class> ret((Tagged)this->theObject);
+    smart_ptr<o_class> ret((Tagged)this->theObject);
     return ret;
   }
 
@@ -204,7 +204,7 @@ public:
     return untag_fixnum<Type*>(this->theObject);
   };
 
-  /*! Return the raw base_ptr value interpreted as a T_O* */
+  /*! Return the raw smart_ptr value interpreted as a T_O* */
   inline core::T_O* raw_() const { return reinterpret_cast<core::T_O*>(this->theObject); }
   inline gctools::Tagged tagged_() const { return reinterpret_cast<gctools::Tagged>(this->theObject); }
 
@@ -222,32 +222,14 @@ public:
     GCTOOLS_ASSERT(false); // BF("Implement me"));
   }
 
-  template <class U> inline bool operator==(const base_ptr<U>& other) const {
+  template <class U> inline bool operator==(const smart_ptr<U>& other) const {
     return this->theObject == other.theObject;
   }
 
-  template <class U> inline bool operator!=(const base_ptr<U>& other) const {
+  template <class U> inline bool operator!=(const smart_ptr<U>& other) const {
     return this->theObject != other.theObject;
   }
 };
-}; // namespace gctools
-
-namespace gctools {
-template <typename Type> class smart_ptr : public base_ptr<Type> {
-public:
-  // Default constructor, set theObject to NULL
-  inline smart_ptr() noexcept : base_ptr<Type>((Type*)NULL){};
-  /*! Create a smart pointer from an existing tagged pointer */
-  explicit inline smart_ptr(Tagged ptr) : base_ptr<Type>(ptr){};
-  explicit inline smart_ptr(Type* ptr) : base_ptr<Type>(ptr){};
-  inline smart_ptr(const return_type& rt) : base_ptr<Type>(rt){};
-  inline smart_ptr(base_ptr<Type> orig) : base_ptr<Type>((Tagged)orig.raw_()){};
-
-  template <class From> inline smart_ptr(smart_ptr<From> const& rhs)
-    requires InheritsC<Type, From>
-    : base_ptr<Type>((Tagged)rhs.raw_()) {}
-};
-
 }; // namespace gctools
 
 namespace gctools {
@@ -516,48 +498,6 @@ typedef gctools::smart_ptr<Fixnum_I> Fixnum_sp;
 typedef gctools::smart_ptr<SingleFloat_I> SingleFloat_sp;
 typedef gctools::smart_ptr<Character_I> Character_sp;
 }; // namespace core
-
-namespace gctools {
-template <> class smart_ptr<core::Symbol_O> : public base_ptr<core::Symbol_O> {
-public:
-  // Default constructor, set theObject to NULL
-  smart_ptr() noexcept : base_ptr<core::Symbol_O>(tag_unbound<Tagged>()){};
-
-  /*! Create a smart pointer from an existing tagged pointer */
-  explicit inline smart_ptr(Tagged ptr) : base_ptr((Tagged)ptr){};
-  explicit inline smart_ptr(Type* ptr) : base_ptr((Type*)ptr){};
-  inline smart_ptr(base_ptr<core::Symbol_O> orig) : base_ptr<core::Symbol_O>((Tagged)orig.raw_()){};
-
-  template <class From> inline smart_ptr(smart_ptr<From> const& rhs)
-    requires InheritsC<Type, From>
-  : base_ptr<Type>((Tagged)rhs.raw_()) {}
-
-  // specialized for List_V below.
-  template <class o_class> inline smart_ptr<o_class> asOrNull() const {
-    return this->base_ptr<Type>::asOrNull<o_class>();
-  }
-
-  // We need these because C++ gets stupid with implicit conversions for
-  // templated functions.
-  template <class o_class> inline smart_ptr<o_class> as() const {
-    return this->base_ptr<Type>::as<o_class>();
-  }
-  template <class o_class> inline smart_ptr<o_class> as_unsafe() const {
-    return this->base_ptr<Type>::as_unsafe<o_class>();
-  }
-  template <class o_class> inline smart_ptr<o_class> as_assert() const {
-    return this->base_ptr<Type>::as_assert<o_class>();
-  }
-  template <class U> inline bool operator==(const smart_ptr<U>& other) const {
-    // i don't think there's any simple way to call the base function. bleh.
-    return this->theObject == other.theObject;
-  }
-
-  template <class U> inline bool operator!=(const smart_ptr<U>& other) const {
-    return this->theObject != other.theObject;
-  }
-};
-}; // namespace gctools
 
 namespace cl {
 extern gctools::smart_ptr<core::Symbol_O>& _sym_list;

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -81,9 +81,6 @@ public:
   uintptr_t ptag() const { return reinterpret_cast<uintptr_t>(this->theObject) & ptag_mask; };
 
 public:
-  /*! Get the pointer typcast to an integer quantity for hashing */
-  uintptr_t intptr() const { return ((uintptr_t)(this->theObject)); };
-
   void reset_() { this->theObject = NULL; };
 
   inline void swap(base_ptr<Type>& other) {
@@ -128,14 +125,14 @@ public:
   /*! Dereferencing operator - remove the other tag */
   inline Type* operator->() const {
     GCTOOLS_ASSERT(this->theObject);
-    GCTOOLS_ASSERT(this->generalp());
-    return untag_general(this->theObject);
+    GCTOOLS_ASSERT(this->objectp());
+    return untag_object();
   };
 
   inline Type& operator*() const {
     GCTOOLS_ASSERT(this->theObject);
     GCTOOLS_ASSERT(this->objectp());
-    return *(this->untag_object());
+    return *untag_object();
   };
 
   inline Type* untag_object() const { return ::gctools::untag_object(this->theObject); }
@@ -211,14 +208,12 @@ public:
   inline core::T_O* raw_() const { return reinterpret_cast<core::T_O*>(this->theObject); }
   inline gctools::Tagged tagged_() const { return reinterpret_cast<gctools::Tagged>(this->theObject); }
 
+  /*! These two should almost never be used.
+      Generally we want to not alter an existing pointer. It's messy.
+      List actual uses here:
+       * record.h when editing an object
+   */
   inline void setRaw_(Tagged p) { this->theObject = reinterpret_cast<Type*>(p); }
-
-  /*! This should almost NEVER be used!!!!!!
-          The only reason to ever use this is when theObject will be set to NULL
-          and you are sure that it will not be interpreted as a Fixnum!!!
-
-          List actual uses here:
-        */
   Type*& rawRef_() { return this->theObject; };
 
   /*! Check if this tagged theObject matches the templated type.
@@ -420,8 +415,6 @@ public:
   void reset_() { this->theObject = NULL; };
 
 public:
-  /*! Get the pointer typcast to an integer quantity for hashing */
-  uintptr_t intptr() const { return ((uintptr_t)(this->theObject)); };
   int number_of_values() const { return this->theObject == NULL ? 0 : 1; };
   bool unboundp() const { return tagged_unboundp(this->theObject); };
   bool boundp() const { return !tagged_unboundp(this->theObject); };

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -400,6 +400,9 @@ extern gctools::smart_ptr<core::Symbol_O>& _sym_expected_type;
 
 namespace gctools {
 
+// Explicit specialization is necessary for at least one basic
+// purpose: the constructor needs to do tag_cons rather than
+// tag_general, which the general template does above.
 template <> class smart_ptr<core::Cons_O> {
 public:
   typedef core::Cons_O Type;

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -327,52 +327,6 @@ namespace gctools {
 static_assert(std::is_trivially_copyable_v<core::T_sp>);
 }; // namespace gctools
 
-namespace gctools {
-template <> class smart_ptr<core::Fixnum_I> {
-public:
-  typedef core::Fixnum_I Type;
-  Type* theObject;
-
-public:
-  // Default constructor, set theObject to NULL
-  smart_ptr() noexcept : theObject(NULL){};
-
-  smart_ptr(Type* fn) : theObject(fn){};
-  template <typename From> inline smart_ptr(smart_ptr<From> const& rhs) {
-    if (rhs.fixnump()) {
-      this->theObject = reinterpret_cast<Type*>(rhs.raw_());
-      return;
-    }
-    class_id from_typ = reg::registered_class<From>::id;
-    lisp_errorBadCastToFixnum(from_typ, rhs.raw_());
-  }
-  /*! Constructor that takes Tagged assumes that the pointer is tagged.
-          Any ptr passed to this constructor must have the CONS tag.
-        */
-  explicit inline smart_ptr(Tagged ptr) : theObject(reinterpret_cast<Type*>(ptr)) {
-    GCTOOLS_ASSERT(tagged_fixnump<Type*>(reinterpret_cast<Type*>(ptr)));
-  };
-
-public:
-  inline explicit operator bool() const { return this->theObject != NULL; };
-  inline operator smart_ptr<core::T_O>() const { return smart_ptr<core::T_O>((Tagged)this->theObject); };
-
-public:
-  inline return_type as_return_type() const { return return_type(this->theObject, 1); };
-  inline bool unboundp() const { return tagged_unboundp(this->theObject); };
-  inline bool boundp() const { return !tagged_unboundp(this->theObject); };
-  inline bool nilp() const { return tagged_nilp(this->theObject); }
-  inline bool notnilp() const { return (!this->nilp()); };
-  inline bool fixnump() const { return tagged_fixnump(this->theObject); };
-  inline bool generalp() const { return tagged_generalp(this->theObject); };
-  inline bool consp() const { return tagged_consp(this->theObject); };
-  inline bool objectp() const { return this->generalp() || this->consp(); };
-  inline Fixnum unsafe_fixnum() const { return untag_fixnum(this->theObject); };
-  inline core::T_O* raw_() const { return reinterpret_cast<core::T_O*>(this->theObject); };
-  inline gctools::Tagged tagged_() const { return reinterpret_cast<gctools::Tagged>(this->theObject); }
-};
-}; // namespace gctools
-
 namespace core {
 typedef gctools::smart_ptr<Fixnum_I> Fixnum_sp;
 typedef gctools::smart_ptr<SingleFloat_I> SingleFloat_sp;

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -530,17 +530,7 @@ public:
 
   template <class From> inline smart_ptr(smart_ptr<From> const& rhs)
     requires InheritsC<Type, From>
-  {
-    if (LIKELY(rhs.objectp())) {
-      Type* px = TaggedCast<Type*, From*>::castOrNULL(rhs.theObject);
-      if (px == 0) {
-        throw_hard_error_cast_failed(typeid(Type*).name(), typeid(From*).name());
-      }
-      this->theObject = px;
-    } else {
-      this->theObject = reinterpret_cast<Type*>(rhs.theObject);
-    }
-  }
+  : base_ptr<Type>((Tagged)rhs.raw_()) {}
 
   // specialized for List_V below.
   template <class o_class> inline smart_ptr<o_class> asOrNull() const {

--- a/include/clasp/gctools/smart_pointers.h
+++ b/include/clasp/gctools/smart_pointers.h
@@ -1128,11 +1128,6 @@ public:
 
 namespace gc = gctools;
 
-namespace gctools {
-// List_sp <-- T_sp
-template <> inline core::List_sp As(core::T_sp const& rhs) { return core::List_sp(rhs); }
-}; // namespace gctools
-
 namespace core {
 string _rep_(T_sp obj);
 };

--- a/include/clasp/gctools/tagged_cast.h
+++ b/include/clasp/gctools/tagged_cast.h
@@ -31,12 +31,15 @@ template <typename TOPTR, typename FROMPTR> struct TaggedCast {
 }; // namespace gctools
 
 namespace core {
-class Fixnum_I {};
+// Marker classes used for defining smart "pointers" that are really
+// immediates, e.g. Character_sp = smart_ptr<Character_I>.
+// Constructors are deleted to prevent actual instantiation.
+class Fixnum_I { Fixnum_I() = delete; };
 #ifdef CLASP_SHORT_FLOAT
-class ShortFloat_I {};
+class ShortFloat_I { ShortFloat_I() = delete; };
 #endif
-class SingleFloat_I {};
-class Character_I {};
+class SingleFloat_I { SingleFloat_I() = delete; };
+class Character_I { Character_I() = delete; };
 class Integer_O;
 class Rational_O;
 class Real_O;

--- a/src/core/allClSymbols.cc
+++ b/src/core/allClSymbols.cc
@@ -67,7 +67,7 @@ CL_DEFUN T_sp core__calculate_missing_common_lisp_symbols() {
 void initializeAllClSymbols(Package_sp commonLispPkg) {
 #define AddClSymbol(name)                                                                                                          \
   {                                                                                                                                \
-    Symbol_sp sym = commonLispPkg->intern(SimpleBaseString_O::make(name));                                                         \
+    Symbol_sp sym = commonLispPkg->intern(SimpleBaseString_O::make(name)).as_assert<Symbol_O>();                                               \
     commonLispPkg->_export2(sym);                                                                                                  \
   }
   AddClSymbol("&ALLOW-OTHER-KEYS");

--- a/src/core/bytecode_compiler.cc
+++ b/src/core/bytecode_compiler.cc
@@ -404,7 +404,7 @@ VarInfoV var_info_v(Symbol_sp sym, Lexenv_sp env) {
   }
 }
 
-T_sp Lexenv_O::lookupSymbolMacro(T_sp sname) {
+T_sp Lexenv_O::lookupSymbolMacro(Symbol_sp sname) {
   VarInfoV info = var_info_v(sname, this->asSmartPtr());
   if (std::holds_alternative<SymbolMacroVarInfoV>(info))
     return std::get<SymbolMacroVarInfoV>(info).expander();
@@ -2035,7 +2035,7 @@ void compile_with_lambda_list(T_sp lambda_list, List_sp body, Lexenv_sp env, con
     for (auto& it : reqs) {
       // We account for special declarations in outer environments/globally
       // by checking the original environment - not our new one - for info.
-      T_sp var = it._ArgTarget;
+      Symbol_sp var = it._ArgTarget.as<core::Symbol_O>();
       auto lvinfo = gc::As_assert<LexicalVarInfo_sp>(new_env->variableInfo(var));
       if (special_binding_p(var, specials, env)) {
         sreqs << var;
@@ -2060,8 +2060,8 @@ void compile_with_lambda_list(T_sp lambda_list, List_sp body, Lexenv_sp env, con
     // be initialized with the unbound marker.
     context.assemble2(vm_code::bind_optional_args, min_count, optional_count);
     for (auto& it : optionals) {
-      T_sp optional_var = it._ArgTarget;
-      T_sp supplied_var = it._Sensor._ArgTarget;
+      Symbol_sp optional_var = it._ArgTarget.as<core::Symbol_O>();
+      Symbol_sp supplied_var = it._Sensor._ArgTarget.as<core::Symbol_O>();
       bool optional_special_p = special_binding_p(optional_var, specials, env);
       bool supplied_special_p = supplied_var.notnilp() && special_binding_p(supplied_var, specials, env);
       gen1default(it._Default, supplied_var.notnilp(), new_env, context);
@@ -2081,7 +2081,7 @@ void compile_with_lambda_list(T_sp lambda_list, List_sp body, Lexenv_sp env, con
   }
   // &rest
   if (restarg._ArgTarget.notnilp()) {
-    Symbol_sp rest = restarg._ArgTarget;
+    Symbol_sp rest = restarg._ArgTarget.as<core::Symbol_O>();
     bool varestp = restarg.VaRest;
     if (varestp) {
       context.assemble1(vm_code::vaslistify_rest_args, max_count);
@@ -2116,8 +2116,8 @@ void compile_with_lambda_list(T_sp lambda_list, List_sp body, Lexenv_sp env, con
     context.emit_parse_key_args(max_count, keys.size(), first_key_index, aokp.notnilp());
     // Default and bind
     for (auto& it : keys) {
-      T_sp key_var = it._ArgTarget;
-      T_sp supplied_var = it._Sensor._ArgTarget;
+      Symbol_sp key_var = it._ArgTarget.as<core::Symbol_O>();
+      Symbol_sp supplied_var = it._Sensor._ArgTarget.as<core::Symbol_O>();
       bool key_special_p = special_binding_p(key_var, specials, env);
       bool supplied_special_p = supplied_var.notnilp() && special_binding_p(supplied_var, specials, env);
       gen1default(it._Default, supplied_var.notnilp(), new_env, context);

--- a/src/core/fli.cc
+++ b/src/core/fli.cc
@@ -435,11 +435,10 @@ void ForeignData_O::PERCENTfree_foreign_object(void) { this->free_(); }
 
 // ---------------------------------------------------------------------------
 // ---------------------------------------------------------------------------
-ForeignData_sp PERCENTallocate_foreign_data(core::Integer_sp size) {
-  size_t _size = unbox_fixnum(size);
+ForeignData_sp PERCENTallocate_foreign_data(size_t size) {
   auto self = gctools::GC<ForeignData_O>::allocate();
   // foreign-alloc memory is permanent until explicit %foreign-free (CFFI/malloc contract); no GC finalizer.
-  self->allocate(kw::_sym_clasp_foreign_data_kind_data, core::None, _size);
+  self->allocate(kw::_sym_clasp_foreign_data_kind_data, core::None, size);
   return self;
 }
 
@@ -746,24 +745,16 @@ core::Integer_sp PERCENToffset_address_as_integer(core::T_sp address_or_foreign_
 
   // If offset is not NIL then get v
   if (offset.notnilp()) {
-    if (offset.fixnump()) {
-      n_offset = unbox_fixnum(offset);
-    } else {
-      n_offset = core::clasp_to_uintptr_t(offset);
-    }
+    n_offset = core::clasp_to_uintptr_t(offset);
   }
 
   if (address_or_foreign_data_ptr.fixnump()) {
-    n_address = unbox_fixnum(address_or_foreign_data_ptr);
+    n_address = address_or_foreign_data_ptr.unsafe_fixnum();
   } else {
     ForeignData_sp sp_fd = address_or_foreign_data_ptr.asOrNull<ForeignData_O>();
     if (sp_fd && PERCENTpointerp(address_or_foreign_data_ptr)) {
       core::Integer_sp sp_address = sp_fd->PERCENTforeign_data_address();
-      if (sp_address.fixnump()) {
-        n_address = unbox_fixnum(sp_address);
-      } else {
-        n_address = core::clasp_to_uintptr_t(sp_address);
-      }
+      n_address = core::clasp_to_uintptr_t(sp_address);
     } else {
       SIMPLE_ERROR("Invalid parameter type for address!");
     }

--- a/src/core/fli.cc
+++ b/src/core/fli.cc
@@ -406,8 +406,8 @@ core::Integer_sp ForeignData_O::PERCENTforeign_data_address(void) {
 ForeignData_sp PERCENTallocate_foreign_object(core::T_sp kind) {
   size_t n_size = 0;
 
-  if (core::cl__symbolp(kind)) {
-    n_size = foreign_type_size(kind);
+  if (kind.isA<core::Symbol_O>()) {
+    n_size = foreign_type_size(kind.as_unsafe<core::Symbol_O>());
   } else {
     // Get the size out of kind's v of form (:array n)
     core::Cons_sp ckind = gc::As<core::Cons_sp>(kind);

--- a/src/core/foundation.cc
+++ b/src/core/foundation.cc
@@ -401,7 +401,7 @@ CL_DEFUN Symbol_sp core__magic_intern(const string& name, const string& package)
   std::string pkg;
   colon_split(pkg_sym, pkg, sym);
   Package_sp p = gc::As<Package_sp>(_lisp->findPackage(pkg));
-  return p->intern(SimpleBaseString_O::make(sym));
+  return p->intern(SimpleBaseString_O::make(sym)).as_assert<Symbol_O>();
 }
 
 CL_LAMBDA("name");
@@ -913,7 +913,7 @@ static Function_sp bytecompile_wrapper(Function_sp entry, List_sp vars, Symbol_s
   return comp::bytecompile(form, nil<T_O>());
 }
 
-void lisp_defineSingleDispatchMethod(T_sp name, Symbol_sp classSymbol,
+void lisp_defineSingleDispatchMethod(Symbol_sp name, Symbol_sp classSymbol,
                                      Function_sp method_body, size_t TemplateDispatchOn, bool useTemplateDispatchOn,
                                      const string& raw_arguments, const string& declares, const string& docstring, bool autoExport,
                                      int number_of_required_arguments, const std::set<int> pureOutIndices) {

--- a/src/core/lisp.cc
+++ b/src/core/lisp.cc
@@ -1948,8 +1948,8 @@ CL_DEFUN void cl__error(T_sp datum, List_sp initializers) {
    * it to zero instead. This does mean that if nested error handlers
    * repeatedly reset it to some non-fixnum, unchecked infinite error depth
    * could occur. FIXME. */
-  if (gc::IsA<Fixnum_sp>(objErrorDepth))
-    nestedErrorDepth = unbox_fixnum(objErrorDepth);
+  if (objErrorDepth.fixnump())
+    nestedErrorDepth = objErrorDepth.unsafe_fixnum();
   else
     nestedErrorDepth = 0;
   if (nestedErrorDepth > 10) {

--- a/src/core/lispReader.cc
+++ b/src/core/lispReader.cc
@@ -208,7 +208,7 @@ void unread_ch(T_sp sin, Character_sp c) { stream_unread_char(sin, clasp_as_clas
 /*! See SACLA reader.lisp::collect-escaped-lexemes */
 List_sp collect_escaped_lexemes(Character_sp c, T_sp sin) {
   T_sp readTable = _lisp->getCurrentReadTable();
-  Symbol_sp syntax_type = core__syntax_type(readTable, c);
+  Symbol_sp syntax_type = core__syntax_type(readTable, c).as<Symbol_O>();
   if (syntax_type == kw::_sym_invalid) {
     SIMPLE_ERROR("invalid-character-error: {}", _rep_(c));
   } else if (syntax_type == kw::_sym_multiple_escape) {
@@ -229,7 +229,7 @@ List_sp collect_lexemes(/*Character_sp*/ T_sp tc, T_sp sin) {
   if (tc.notnilp()) {
     Character_sp c = gc::As<Character_sp>(tc);
     T_sp readTable = _lisp->getCurrentReadTable();
-    Symbol_sp syntax_type = core__syntax_type(readTable, c);
+    Symbol_sp syntax_type = core__syntax_type(readTable, c).as<Symbol_O>();
     if (syntax_type == kw::_sym_invalid) {
       SIMPLE_ERROR("invalid-character-error: {}", _rep_(c));
     } else if (syntax_type == kw::_sym_whitespace) {
@@ -352,7 +352,7 @@ void make_str_preserve_case(StrNs_sp sout, List_sp cur_char) {
       into a stringstream */
 void make_str(StrNs_sp sout, List_sp cur_char) {
   T_sp readtable = _lisp->getCurrentReadTable();
-  Symbol_sp case_ = cl__readtable_case(readtable);
+  Symbol_sp case_ = cl__readtable_case(readtable).as<Symbol_O>();
   if (case_ == kw::_sym_invert) {
     UnEscapedCase strcase = check_case(cur_char, undefined);
     switch (strcase) {
@@ -515,7 +515,7 @@ void token_downcase(Token& token, size_t start, size_t end) {
 
 void apply_readtable_case(Token& token, size_t start, size_t end) {
   T_sp readtable = _lisp->getCurrentReadTable();
-  Symbol_sp case_ = cl__readtable_case(readtable);
+  Symbol_sp case_ = cl__readtable_case(readtable).as<Symbol_O>();
   if (case_ == kw::_sym_invert) {
     UnEscapedCase strcase = token_check_case(token, start, end);
     switch (strcase) {
@@ -733,7 +733,7 @@ T_sp interpret_token_or_throw_reader_error(T_sp sin, Token& token, bool only_dot
     if (cl::_sym_STARread_suppressSTAR->symbolValue().isTrue())
       return nil<T_O>();
     SimpleString_sp sym_name = SimpleBaseString_O::make("");
-    Symbol_sp sym = _lisp->getCurrentPackage()->intern(sym_name);
+    Symbol_sp sym = _lisp->getCurrentPackage()->intern(sym_name).as_assert<Symbol_O>();
     return sym;
   }
     SIMPLE_ERROR("There was no token!!!!");
@@ -751,7 +751,7 @@ T_sp interpret_token_or_throw_reader_error(T_sp sin, Token& token, bool only_dot
       if (cl::_sym_STARread_suppressSTAR->symbolValue().isTrue())
         return nil<T_O>();
       SimpleString_sp sym_name = symbolTokenStr(sin, token, name_marker - token.data(), token.size(), only_dots_ok);
-      Symbol_sp sym = _lisp->getCurrentPackage()->intern(sym_name);
+      Symbol_sp sym = _lisp->getCurrentPackage()->intern(sym_name).as_assert<Symbol_O>();
       LOG_READ(BF("sym_name = |%s| sym->symbolNameAsString() = |%s|") % _rep_(sym_name) % sym->symbolNameAsString());
       return sym;
     }
@@ -790,7 +790,7 @@ T_sp interpret_token_or_throw_reader_error(T_sp sin, Token& token, bool only_dot
                      sin);
       }
     } else {
-      sym = pkg->intern(symbol_name_str);
+      sym = pkg->intern(symbol_name_str).as_assert<Symbol_O>();
     }
     ASSERT(sym);
     return sym;
@@ -1074,7 +1074,7 @@ step1:
   }
   xxx = gc::As<Character_sp>(tx);
   LOG_READ(BF("Read character x[%d/%s]") % (int)clasp_as_claspCharacter(xxx) % (char)clasp_as_claspCharacter(xxx));
-  Symbol_sp xxx_syntax_type = core__syntax_type(readTable, xxx);
+  Symbol_sp xxx_syntax_type = core__syntax_type(readTable, xxx).as_assert<Symbol_O>();
   //    step2:
   if (xxx_syntax_type == kw::_sym_invalid) {
     LOG_READ(BF("step2 - invalid-character[%c]") % clasp_as_claspCharacter(xxx));
@@ -1154,7 +1154,7 @@ step8:
     }
     Character_sp y(gc::As_unsafe<Character_sp>(ty));
     LOG_READ(BF("Step8: Read y[%s/%c]") % clasp_as_claspCharacter(y) % (char)clasp_as_claspCharacter(y));
-    Symbol_sp y8_syntax_type = core__syntax_type(readTable, y);
+    Symbol_sp y8_syntax_type = core__syntax_type(readTable, y).as<Symbol_O>();
     LOG_READ(BF("y8_syntax_type=%s") % _rep_(y8_syntax_type));
     if ((y8_syntax_type == kw::_sym_constituent) || (y8_syntax_type == kw::_sym_non_terminating_macro)) {
       // Y = readTable->convert_case(y);
@@ -1198,7 +1198,7 @@ step9:
   LOG_READ(BF("step9"));
   {
     y = gc::As<Character_sp>(cl__read_char(sin, _lisp->_true(), nil<T_O>(), _lisp->_true()));
-    Symbol_sp y9_syntax_type = core__syntax_type(readTable, y);
+    Symbol_sp y9_syntax_type = core__syntax_type(readTable, y).as<Symbol_O>();
     LOG_READ(BF("Step9: Read y[%s] y9_syntax_type[%s]") % clasp_as_claspCharacter(y) % _rep_(y9_syntax_type));
     if ((y9_syntax_type == kw::_sym_constituent) || (y9_syntax_type == kw::_sym_non_terminating_macro) ||
         (y9_syntax_type == kw::_sym_terminating_macro) || (y9_syntax_type == kw::_sym_whitespace)) {

--- a/src/core/loadltv.cc
+++ b/src/core/loadltv.cc
@@ -643,7 +643,7 @@ struct loadltv {
     uint8_t testcode = read_u8();
     uint16_t count = read_u16();
     // Resolve test
-    T_sp test = nil<T_O>();
+    Symbol_sp test = nil<Symbol_O>();
     switch (testcode) {
     case 0b00:
       test = cl::_sym_eq;
@@ -661,7 +661,7 @@ struct loadltv {
       SIMPLE_ERROR("Unknown hash table test code {:02x}", testcode);
     }
     set_ltv(cl__make_hash_table(test, clasp_make_fixnum(count), clasp_make_single_float(2.0), clasp_make_single_float(0.7),
-                                nil<T_O>(), nil<T_O>(), nil<T_O>(), nil<T_O>()),
+                                nil<Symbol_O>(), nil<T_O>(), nil<T_O>(), nil<T_O>()),
             index);
   }
 

--- a/src/core/readtable.cc
+++ b/src/core/readtable.cc
@@ -553,7 +553,7 @@ CL_DEFUN T_mv core__sharp_asterisk(T_sp sin, Character_sp ch, T_sp num) {
     if (tch.nilp())
       break;
     ch = gc::As<Character_sp>(tch);
-    Symbol_sp syntaxType = core__syntax_type(rtbl, ch);
+    Symbol_sp syntaxType = core__syntax_type(rtbl, ch).as<core::Symbol_O>();
     if (syntaxType == kw::_sym_terminating_macro || syntaxType == kw::_sym_whitespace) {
       unread_ch(sin, ch);
       break;
@@ -961,7 +961,7 @@ string Readtable_O::__repr__() const {
 
 Symbol_sp Readtable_O::syntax_type_(Character_sp ch) const {
 
-  Symbol_sp result = this->SyntaxTypes_->gethash(ch, kw::_sym_constituent);
+  Symbol_sp result = this->SyntaxTypes_->gethash(ch, kw::_sym_constituent).as<Symbol_O>();
   LOG("character[{}] syntax_type: {}", _rep_(ch), _rep_(result));
   return result;
 }

--- a/src/core/singleDispatchGenericFunction.cc
+++ b/src/core/singleDispatchGenericFunction.cc
@@ -90,7 +90,7 @@ CL_DEFUN SingleDispatchGenericFunction_sp core__ensure_single_dispatch_generic_f
       cell->rplacd(expected);
     } while (!_lisp->_Roots._SingleDispatchGenericFunctions.compare_exchange_weak(expected, cell));
     if (gfname.consp() && CONS_CAR(gfname) == cl::_sym_setf) {
-      Symbol_sp setf_gfname = CONS_CAR(CONS_CDR(gfname));
+      Symbol_sp setf_gfname = CONS_CAR(CONS_CDR(gfname)).as<core::Symbol_O>();
       if (setf_gfname->fboundp_setf()) {
         SIMPLE_ERROR("The name {} has something bound to its setf function slot but no generic function with that name was found",
                      _rep_(gfname));

--- a/src/core/smallMultimap.cc
+++ b/src/core/smallMultimap.cc
@@ -59,7 +59,7 @@ CL_DEFMETHOD void SmallMultimap_O::describe() {
 }
 
 CL_LISPIFY_NAME("small_multimap_describe_range");
-CL_DEFMETHOD void SmallMultimap_O::describeRange(T_sp key) {
+CL_DEFMETHOD void SmallMultimap_O::describeRange(Symbol_sp key) {
   pair<map_type::iterator, map_type::iterator> range = this->map.equal_range(key);
   for (auto it = range.first; it != range.second; ++it) {
     clasp_write_string(fmt::format("{}:{}  key: {}   value: {}\n", __FILE__, __LINE__, _rep_(it->first), _rep_(it->second)));
@@ -67,12 +67,12 @@ CL_DEFMETHOD void SmallMultimap_O::describeRange(T_sp key) {
 }
 
 CL_LISPIFY_NAME("small_multimap_insert");
-CL_DEFMETHOD void SmallMultimap_O::insert(T_sp key, T_sp val) {
+CL_DEFMETHOD void SmallMultimap_O::insert(Symbol_sp key, T_sp val) {
   pair<map_type::iterator, bool> found = this->map.insert(std::make_pair(key, val));
   (void)found;
 }
 
 CL_LISPIFY_NAME("small_multimap_contains");
-CL_DEFMETHOD bool SmallMultimap_O::contains(T_sp key) { return this->map.contains(key); }
+CL_DEFMETHOD bool SmallMultimap_O::contains(Symbol_sp key) { return this->map.contains(key); }
 
 }; // namespace core

--- a/src/core/sourceFileInfo.cc
+++ b/src/core/sourceFileInfo.cc
@@ -129,7 +129,7 @@ CL_LAMBDA(source-pos-info);
 CL_DECLARE();
 CL_DOCSTRING(R"dx(sourcePosInfoLineno)dx");
 DOCGROUP(clasp);
-CL_DEFUN Fixnum_sp core__source_pos_info_lineno(T_sp info) {
+CL_DEFUN Integer_sp core__source_pos_info_lineno(T_sp info) {
   if (info.nilp())
     return make_fixnum(0);
   if (gc::IsA<SourcePosInfo_sp>(info)) {

--- a/src/core/string.cc
+++ b/src/core/string.cc
@@ -1303,13 +1303,12 @@ bool Str8Ns_O::equalp(T_sp other) const {
 
 // Creators - depreciate these once the new array stuff is working better
 Str8Ns_sp Str8Ns_O::create(const string& nm) {
-  auto ss = SimpleBaseString_O::make(nm.size(), '\0', true, nm.size(), (const claspChar*)nm.c_str());
-  return Str8Ns_O::make(nm.size(), '\0', false, nil<T_O>(), ss, false, 0);
+  return Str8Ns_O::make(nm);
 }
 
 Str8Ns_sp Str8Ns_O::create(const char* nm, size_t len) {
   SimpleBaseString_sp ss = SimpleBaseString_O::make(len, '\0', true, len, (const claspChar*)nm);
-  return Str8Ns_O::make(len, '\0', false, nil<T_O>(), ss, false, 0);
+  return Str8Ns_O::make(len, '\0', false, nil<T_O>(), ss, false, clasp_make_fixnum(0));
 }
 
 Str8Ns_sp Str8Ns_O::create(const char* nm) {
@@ -1317,12 +1316,12 @@ Str8Ns_sp Str8Ns_O::create(const char* nm) {
   return Str8Ns_O::create(nm, len);
 }
 
-Str8Ns_sp Str8Ns_O::create(size_t len) { return Str8Ns_O::make(len, '\0', true, nil<T_O>(), nil<T_O>(), false, 0); }
+Str8Ns_sp Str8Ns_O::create(size_t len) { return Str8Ns_O::make(len, '\0', true, nil<T_O>(), nil<T_O>(), false, clasp_make_fixnum(0)); }
 
 Str8Ns_sp Str8Ns_O::create(Str8Ns_sp other) {
   size_t len = other->length();
   SimpleBaseString_sp ss = SimpleBaseString_O::make(len, '\0', true, len, &(*other)[0]);
-  return Str8Ns_O::make(len, '\0', false, nil<T_O>(), ss, false, 0);
+  return Str8Ns_O::make(len, '\0', false, nil<T_O>(), ss, false, clasp_make_fixnum(0));
 }
 
 SimpleString_sp Str8Ns_O::asMinimalSimpleString() const {

--- a/src/core/symbolToEnumConverter.cc
+++ b/src/core/symbolToEnumConverter.cc
@@ -85,7 +85,7 @@ CL_DEFMETHOD int SymbolToEnumConverter_O::enumIndexForSymbol(T_sp obj) {
   MultipleValues& mv = core::lisp_multipleValues();
   if (mv.second(match_mv.number_of_values()).nilp())
     TYPE_ERROR(obj, Cons_O::create(cl::_sym_member, this->enumSymbolsAsList()));
-  return unbox_fixnum(match_mv);
+  return match_mv.unsafe_fixnum();
 }
 
 Symbol_sp SymbolToEnumConverter_O::symbolForEnumIndex(int index) {

--- a/src/core/unixfsys.cc
+++ b/src/core/unixfsys.cc
@@ -530,7 +530,7 @@ static Symbol_sp smart_file_kind(String_sp sfilename, bool follow_links) {
       // If its a broken link return _sym_file
       Symbol_sp kind_no_follow_links = file_kind((char*)(sfilename->get_path_string().c_str()), false);
       if (kind_no_follow_links.nilp())
-        return nil<T_O>();
+        return nil<Symbol_O>();
       return kw::_sym_broken_link;
     }
   } else {

--- a/src/core/write_symbol.cc
+++ b/src/core/write_symbol.cc
@@ -106,7 +106,7 @@ static bool all_dots(String_sp s) {
 
 static bool needs_to_be_escaped(String_sp s, T_sp readtable) {
   ASSERT(cl__stringp(s));
-  Symbol_sp action = cl__readtable_case(readtable);
+  Symbol_sp action = cl__readtable_case(readtable).as_assert<Symbol_O>();
   if (potential_number_p(s, clasp_print_base()))
     return 1;
   /* The value of *PRINT-ESCAPE* is T. We need to check whether the
@@ -118,7 +118,7 @@ static bool needs_to_be_escaped(String_sp s, T_sp readtable) {
   for (cl_index i = 0, iEnd(s->length()); i < iEnd; i++) {
     claspCharacter c = clasp_as_claspCharacter(cl__char(s, i));
     Character_sp cc = clasp_make_character(c);
-    Symbol_sp syntax = core__syntax_type(readtable, cc);
+    Symbol_sp syntax = core__syntax_type(readtable, cc).as_assert<Symbol_O>();
     if (syntax != kw::_sym_constituent || clasp_invalid_base_char_p(c) || (c) == ':')
       return 1;
     if ((action == kw::_sym_downcase) && upper_case_p(c))
@@ -197,7 +197,7 @@ void clasp_write_symbol(Symbol_sp x, T_sp stream) {
   if (!print_readably && !clasp_print_escape()) {
     //            printf("%s:%d quick print of symbol print_readably=%d print_escape=%d\n",__FILE__,__LINE__, print_readably,
     //            clasp_print_escape());
-    write_symbol_string(name, cl__readtable_case(readtable), print_case, stream, 0);
+    write_symbol_string(name, cl__readtable_case(readtable).as_assert<Symbol_O>(), print_case, stream, 0);
     return;
   }
   /* From here on, print-escape is true which means that it should
@@ -216,19 +216,19 @@ void clasp_write_symbol(Symbol_sp x, T_sp stream) {
     MultipleValues& mvn = core::lisp_multipleValues();
     if (!print_package) {
       T_mv symbol_mv = cl__find_symbol(name, _lisp->getCurrentPackage());
-      Symbol_sp sym = symbol_mv;
-      Symbol_sp intern_flag = gc::As<Symbol_sp>(mvn.valueGet(1, symbol_mv.number_of_values()));
+      Symbol_sp sym = symbol_mv.as_assert<Symbol_O>();
+      Symbol_sp intern_flag = mvn.valueGet(1, symbol_mv.number_of_values()).as_assert<Symbol_O>();
       if ((sym != x) || intern_flag.nilp())
         print_package = true;
     }
     if (print_package) {
-      SimpleString_sp name = gc::As<Package_sp>(package)->name();
-      write_symbol_string(name, cl__readtable_case(readtable), print_case, stream,
+      SimpleString_sp name = package.as_assert<Package_O>()->name();
+      write_symbol_string(name, cl__readtable_case(readtable).as_assert<Symbol_O>(), print_case, stream,
                           needs_to_be_escaped(gc::As<Array_sp>(name), readtable));
       if (!x.nilp()) {
-        Symbol_mv sym2_mv = cl__find_symbol(x->symbolName(), package);
-        Symbol_sp sym2 = sym2_mv;
-        Symbol_sp intern_flag2 = gc::As<Symbol_sp>(mvn.valueGet(1, sym2_mv.number_of_values()));
+        T_mv sym2_mv = cl__find_symbol(x->symbolName(), package);
+        Symbol_sp sym2 = sym2_mv.as<Symbol_O>();
+        Symbol_sp intern_flag2 = mvn.valueGet(1, sym2_mv.number_of_values()).as<Symbol_O>();
         if (sym2 != x) {
           clasp_write_string("<UNPRINTABLE-SYMBOL@", stream);
           stringstream ss;
@@ -256,7 +256,7 @@ void clasp_write_symbol(Symbol_sp x, T_sp stream) {
       }
     }
   }
-  write_symbol_string(name, cl__readtable_case(readtable), print_case, stream,
+  write_symbol_string(name, cl__readtable_case(readtable).as_assert<Symbol_O>(), print_case, stream,
                       needs_to_be_escaped(name, readtable) || all_dots(name));
 }
 

--- a/src/llvmo/llvmoExpose.cc
+++ b/src/llvmo/llvmoExpose.cc
@@ -1409,7 +1409,7 @@ void convert_sequence_types_to_vector(core::T_sp elements, vector<llvm::Type*>& 
   // nil is a little stupid here but this is called from many
   // different functions and I don't want to bother adding an
   // argument just for this unlikely error message.
-  ERROR_WRONG_TYPE_NTH_ARG(nil<core::T_O>(), 0, elements, ::cl::_sym_sequence);
+  ERROR_WRONG_TYPE_NTH_ARG(nil<core::Symbol_O>(), 0, elements, ::cl::_sym_sequence);
 }
 } // namespace llvmo
 


### PR DESCRIPTION
Mostly making things more strict so dangerous or runtime-affecting implicit casts are blocked. Also cleanup, deleting code, etc.