### PR TITLE
cleavir: a local mv-call's phi must name the block its arguments end in

### DIFF
--- a/src/lisp/kernel/cleavir/translate.lisp
+++ b/src/lisp/kernel/cleavir/translate.lisp
@@ -1065,43 +1065,55 @@ function-or-placeholder - the llvm function or a placeholder for
         (loop for i below nreq
               do (cmp:irc-add-case sw (%size_t i) mismatch))
         ;; Generate optional arg cases, including the exactly-enough case.
+        ;; ★THE PHI'S PREDECESSOR IS THE BLOCK THE VALUES END IN, NOT THE ONE THEY START IN.
+        ;; Building an argument can emit an INVOKE -- an unboxing cast here, CC_MVCGATHERREST2 in the
+        ;; more-than-enough case below -- and an invoke ENDS its block, continuing in a fresh
+        ;; normal-destination block (irc-create-invoke-wft).  Naming the block we began then gives
+        ;; MERGE a phi entry for a block that does not branch to it: "PHI node entries do not match
+        ;; predecessors", and a broken module.  It happens only with a landing pad in scope, i.e. an
+        ;; enclosing unwind-protect or handler-case, which is why COMPILE-FILE'd code -- where such a
+        ;; function is rarer -- did not show it.  So read the insert block AFTER the values are built.
         (loop for i upto nopt
               for b = (cmp:irc-basic-block-create
                        (format nil "lmvc-optional-~d" i))
               do (cmp:irc-add-case sw (%size_t (+ nreq i)) b)
                  (cmp:irc-begin-block b)
-                 (loop for phi in opt-phis
-                       for val in (optionals i)
-                       do (cmp:irc-phi-add-incoming phi val b))
-                 (when (and rest-var (not (bir:unused-p rest-var)))
-                   (cmp:irc-phi-add-incoming
-                    rest-phi
-                    (if varest-p
-                        (maybe-boxed-vaslist
-                         rest-vaboxp (%size_t 0)
-                         (llvm-sys:constant-pointer-null-get cmp:%t**%))
-                        (%nil))
-                    b))
+                 (let* ((vals (optionals i))
+                        (rest-val
+                          (when (and rest-var (not (bir:unused-p rest-var)))
+                            (if varest-p
+                                (maybe-boxed-vaslist
+                                 rest-vaboxp (%size_t 0)
+                                 (llvm-sys:constant-pointer-null-get cmp:%t**%))
+                                (%nil))))
+                        (pred (cmp:irc-get-insert-block)))
+                   (loop for phi in opt-phis
+                         for val in vals
+                         do (cmp:irc-phi-add-incoming phi val pred))
+                   (when rest-val
+                     (cmp:irc-phi-add-incoming rest-phi rest-val pred)))
                  (cmp:irc-br merge))
         ;; If there's a &rest, generate the more-than-enough arguments case.
         (when rest-var
           (cmp:irc-begin-block mte)
-          (loop for phi in opt-phis
-                for val in (optionals nopt)
-                do (cmp:irc-phi-add-incoming phi val mte))
-          (unless (bir:unused-p rest-var)
-            (cmp:irc-phi-add-incoming
-             rest-phi
-             (if varest-p
-                 (maybe-boxed-vaslist
-                  rest-vaboxp
-                  (cmp:irc-sub rnret (%size_t nfixed))
-                  (cmp:irc-typed-gep cmp:%t*% rvalues (list nfixed)))
-                 (%intrinsic-invoke-if-landing-pad-or-call
-                  "cc_mvcGatherRest2"
-                  (list (cmp:irc-typed-gep cmp:%t*% rvalues (list nfixed))
-                        (cmp:irc-sub rnret (%size_t nfixed)))))
-             mte))
+          (let* ((vals (optionals nopt))
+                 (rest-val
+                   (unless (bir:unused-p rest-var)
+                     (if varest-p
+                         (maybe-boxed-vaslist
+                          rest-vaboxp
+                          (cmp:irc-sub rnret (%size_t nfixed))
+                          (cmp:irc-typed-gep cmp:%t*% rvalues (list nfixed)))
+                         (%intrinsic-invoke-if-landing-pad-or-call
+                          "cc_mvcGatherRest2"
+                          (list (cmp:irc-typed-gep cmp:%t*% rvalues (list nfixed))
+                                (cmp:irc-sub rnret (%size_t nfixed)))))))
+                 (pred (cmp:irc-get-insert-block)))
+            (loop for phi in opt-phis
+                  for val in vals
+                  do (cmp:irc-phi-add-incoming phi val pred))
+            (when rest-val
+              (cmp:irc-phi-add-incoming rest-phi rest-val pred)))
           (cmp:irc-br merge))
         ;; Generate the call, in the merge block.
         (cmp:irc-begin-block merge)


### PR DESCRIPTION
`DIRECT-MV-LOCAL-CALL-VAS` gives MERGE one phi per optional parameter, then in each switch case builds that case's argument values and records **the case's own block** as the phi predecessor.

Building a value can emit an `invoke` — the checked unbox a generated type-checker performs, whenever a landing pad is in scope — and `IRC-CREATE-INVOKE-WFT` ends the block and continues in a fresh `normal-dest`. The phi is then told about a block that no longer branches to MERGE:

```
PHI node entries do not match predecessors!
  %phi263 = phi float [ undef, %lmvc-optional-0 ], [ %single-float276, %lmvc-optional-1 ], ...
label %lmvc-optional-3
label %normal-dest295
```

Broken module → the image dies.

- both loops now read the insert block **after** the values are built, and use that
- optional cases and the more-than-enough case alike
- values computed before an invoke still dominate: their block dominates the invoke's normal destination

Repro (no minimal case yet — see below): a CLIM toolkit compiled natively, FiveAM compiling test bodies at run time; died at test 1582/2101 in a `MULTIPLE-VALUE-BIND` of three `single-float`s from a typed function inside an `UNWIND-PROTECT`. With this change the same run completes all 2101.

- full `ninja test`: exit 0, 2070 successes, no new failure
- 34 826 such block splits recorded in one instrumented run; callees are all generated `…-CHECKER` local functions
- **no regression test**: 26 standalone shapes, including that source form, compile cleanly — the trigger needs type information the running image accumulates. Happy to keep hunting if you want the small case before merging.
