### PR TITLE
bytecode: a capture-free unwind-protect cleanup needs no closure

### DIFF
--- a/src/core/bytecode.cc
+++ b/src/core/bytecode.cc
@@ -217,6 +217,48 @@ static unsigned char* long_dispatch(VirtualMachine&, unsigned char*, MultipleVal
                                     core::T_O**, core::T_O**, size_t, core::T_O**, uint8_t);
 
 SYMBOL_EXPORT_SC_(KeywordPkg, name);
+gctools::return_type bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure, core::T_O** fp,
+                                 core::T_O** sp, size_t lcc_nargs, core::T_O** lcc_args);
+
+// PROTECT, for both operand widths.  `c` indexes the cleanup template in LITERALS and `pc` sits on
+// the operand's last byte.  A template that closes over nothing is the cleanup function itself; only
+// one that captures is wrapped in a closure carrying the captured values.  The bytecode contract
+// (Maclina MACHINE.md, "protect") permits either, and the closure would have carried no environment.
+// Leaves SP and PC where the protected body's CLEANUP instruction left them.
+static inline void vm_protect(VirtualMachine& vm, MultipleValues& multipleValues, T_O** literals, T_O** closed,
+                              Closure_O* closure, core::T_O** fp, core::T_O**& sp, unsigned char*& pc, size_t c,
+                              size_t lcc_nargs, core::T_O** lcc_args) {
+  T_sp fn_sp((gctools::Tagged)literals[c]);
+  BytecodeSimpleFun_sp fn = fn_sp.as_assert<BytecodeSimpleFun_O>();
+  size_t nclosed = fn->environmentSize();
+  DBG_VM("  nclosed = %zu\n", nclosed);
+  vm._stackPointer = sp;
+  T_sp cleanup = fn;
+  if (nclosed > 0) {
+    Closure_sp cl = Closure_O::make_bytecode_closure(fn, nclosed);
+    vm.copyto(sp, nclosed, (T_O**)(cl->_Slots.data()));
+    vm.drop(sp, nclosed);
+    cleanup = cl;
+  }
+  // Now stick it onto the dynamic environment.
+  vm._pc = ++pc;
+  T_mv result = funwind_protect([&]() {
+    return bytecode_vm(vm, literals, closed, closure, fp, sp, lcc_nargs, lcc_args);
+  },
+    [&]() {
+      // Push a valid PC fixnum so bytecode_call (via eval::funcall) sees
+      // a proper frame header at fp[-3]. The CALL opcode normally does this
+      // before apply_raw, but cleanup thunks are called from C++ without one.
+      vm.push(vm._stackPointer, core::Integer_O::create((uintptr_t)pc).raw_());
+      eval::funcall(cleanup);
+      vm.drop(vm._stackPointer, 1);
+    });
+  // copied from vm_code::call - required to avoid the cleanup's values
+  // for... some reason. I'm not totally sure.
+  multipleValues.setN(result.raw_(), result.number_of_values());
+  sp = vm._stackPointer;
+  pc = vm._pc;
+}
 #ifdef DEBUG_VIRTUAL_MACHINE
 __attribute__((optnone))
 #endif
@@ -1006,35 +1048,7 @@ bytecode_vm(VirtualMachine& vm, T_O** literals, T_O** closed, Closure_O* closure
     case vm_code::protect: {
       uint8_t c = *(++pc);
       DBG_VM("protect %" PRIu8 "\n", c);
-      // Build a closure - this works mostly like make_closure.
-      T_sp fn_sp((gctools::Tagged)literals[c]);
-      BytecodeSimpleFun_sp fn = fn_sp.as_assert<BytecodeSimpleFun_O>();
-      size_t nclosed = fn->environmentSize();
-      DBG_VM("  nclosed = %zu\n", nclosed);
-      // Technically we could avoid consing a closure when nclosed = 0
-      // but I don't know that it's worth the trouble.
-      vm._stackPointer = sp;
-      Closure_sp cleanup = Closure_O::make_bytecode_closure(fn, nclosed);
-      vm.copyto(sp, nclosed, (T_O**)(cleanup->_Slots.data()));
-      vm.drop(sp, nclosed);
-      // Now stick it onto the dynamic environment.
-      vm._pc = ++pc;
-      T_mv result = funwind_protect([&]() {
-        return bytecode_vm(vm, literals, closed, closure, fp, sp, lcc_nargs, lcc_args);
-      },
-        [&]() {
-          // Push a valid PC fixnum so bytecode_call (via eval::funcall) sees
-          // a proper frame header at fp[-3]. The CALL opcode normally does this
-          // before apply_raw, but cleanup thunks are called from C++ without one.
-          vm.push(vm._stackPointer, core::Integer_O::create((uintptr_t)pc).raw_());
-          eval::funcall(cleanup);
-          vm.drop(vm._stackPointer, 1);
-        });
-      // copied from vm_code::call - required to avoid the cleanup's values
-      // for... some reason. I'm not totally sure.
-      multipleValues.setN(result.raw_(), result.number_of_values());
-      sp = vm._stackPointer;
-      pc = vm._pc;
+      vm_protect(vm, multipleValues, literals, closed, closure, fp, sp, pc, c, lcc_nargs, lcc_args);
       break;
     }
     case vm_code::cleanup: {
@@ -1515,26 +1529,7 @@ static unsigned char* long_dispatch(VirtualMachine& vm, unsigned char* pc, Multi
     uint8_t low = *(++pc);
     uint16_t c = low + (*(++pc) << 8);
     DBG_VM1("long protect %" PRIu16 "\n", c);
-    T_sp fn_sp((gctools::Tagged)literals[c]);
-    BytecodeSimpleFun_sp fn = fn_sp.as_assert<BytecodeSimpleFun_O>();
-    size_t nclosed = fn->environmentSize();
-    DBG_VM("  nclosed = %zu\n", nclosed);
-    vm._stackPointer = sp;
-    Closure_sp cleanup = Closure_O::make_bytecode_closure(fn, nclosed);
-    vm.copyto(sp, nclosed, (T_O**)(cleanup->_Slots.data()));
-    vm.drop(sp, nclosed);
-    vm._pc = ++pc;
-    T_mv result = funwind_protect([&]() {
-      return bytecode_vm(vm, literals, closed, closure, fp, sp, lcc_nargs, lcc_args);
-    },
-      [&]() {
-        vm.push(vm._stackPointer, core::Integer_O::create((uintptr_t)pc).raw_());
-        eval::funcall(cleanup);
-        vm.drop(vm._stackPointer, 1);
-      });
-    multipleValues.setN(result.raw_(), result.number_of_values());
-    sp = vm._stackPointer;
-    pc = vm._pc;
+    vm_protect(vm, multipleValues, literals, closed, closure, fp, sp, pc, c, lcc_nargs, lcc_args);
     break;
   }
   case vm_code::encell: {

--- a/src/lisp/regression-tests/allocation-helpers.lisp
+++ b/src/lisp/regression-tests/allocation-helpers.lisp
@@ -1,0 +1,29 @@
+(in-package #:clasp-tests)
+
+;;;; The helpers the two allocation suites share: allocation.lisp (the bytecode tier) and
+;;;; allocation-native.lisp (the native tier) measure the same shapes through the same sinks, so the
+;;;; sinks live once, here, and each suite LOADs this file at its top.  Loading it twice is harmless.
+
+(defvar *alloc-sink* nil)
+(defvar *alloc-lock* (mp:make-lock :name "allocation-test"))
+
+(define-condition %alloc-full (error) ())
+
+(declaim (notinline %alloc-touch %alloc-two %alloc-three %alloc-global-handler %alloc-call))
+(defun %alloc-touch (x) (setq *alloc-sink* x) nil)
+(defun %alloc-two (i) (values i (1+ i)))
+(defun %alloc-three (i) (values i (1+ i) (+ i 2)))
+(defun %alloc-global-handler (c) (declare (ignore c)) nil)
+(defun %alloc-call (f) (funcall f))
+
+;;; A two-class hierarchy for the CALL-NEXT-METHOD rows: a method that mentions CALL-NEXT-METHOD
+;;; takes the contf convention, and the convention's cost is what the rows read.
+(defclass %alloc-base () ())
+(defclass %alloc-sub (%alloc-base) ())
+(defgeneric %alloc-gf1 (x))
+(defmethod %alloc-gf1 ((x %alloc-base)) x)
+(defmethod %alloc-gf1 ((x %alloc-sub)) (call-next-method))
+(defgeneric %alloc-gf2 (x y))
+(defmethod %alloc-gf2 ((x %alloc-base) y) (declare (ignore y)) x)
+(defmethod %alloc-gf2 ((x %alloc-sub) y) (declare (ignore y)) (call-next-method))
+(defvar *alloc-sub* (make-instance '%alloc-sub))

--- a/src/lisp/regression-tests/allocation-native.lisp
+++ b/src/lisp/regression-tests/allocation-native.lisp
@@ -1,0 +1,180 @@
+(in-package #:clasp-tests)
+
+;;;; Byte-exact allocation tests for the control-flow constructs of the NATIVE tier.
+;;;;
+;;;; Every measured function is built by CL:COMPILE under CMP:*COMPILE-NATIVE*, and NATIVE-COMPILE
+;;;; refuses a result whose entry is not a SIMPLE-CORE-FUN, so a reading here is a native reading
+;;;; whatever tier the image defaults to.  This is the (COMPILE NIL ...) pipeline; it agrees with
+;;;; COMPILE-FILE's on every shape below except a surplus MULTIPLE-VALUE-BIND value, which is
+;;;; asserted as this pipeline's fact and claims nothing about a compiled file.
+;;;;
+;;;; A row whose construct is a LAW (an escaping closure costs 32 + 8 per captured variable) asserts
+;;;; the law, so a change that moves it is seen.  A row whose construct is a TARGET asserts 0 and is
+;;;; listed in set-unexpected-failures.lisp under the change that removes its bytes, with today's
+;;;; reading in its :description.  The figure is exact by construction: the driver divides the total
+;;;; by the call count, so a partial result shows up as a ratio, never as a rounded 0.
+
+(load "sys:src;lisp;regression-tests;allocation-helpers.lisp")
+
+(defun native-compile (lambda-expression)
+  "LAMBDA-EXPRESSION compiled by CL:COMPILE under CMP:*COMPILE-NATIVE*.  Signals unless the
+result's entry is a SIMPLE-CORE-FUN, so this file never measures a bytecode function by accident."
+  (let ((f (let ((cmp:*compile-native* t)) (compile nil lambda-expression))))
+    (unless (string= (symbol-name (type-of f)) "SIMPLE-CORE-FUN")
+      (error "~s compiled to a ~a, not native code" lambda-expression (type-of f)))
+    f))
+
+;;; The driver is native too, so its own loop cannot be charged to the construct.
+(defparameter *native-driver*
+  (native-compile
+   '(lambda (f n)
+     (funcall f 0)                       ; warm up once, outside the window
+     (let ((before (gctools:bytes-allocated)))
+       (dotimes (i n) (funcall f i))
+       (- (gctools:bytes-allocated) before)))))
+
+(defun native-bytes-per-call (lambda-expression &optional (n 10000))
+  "Bytes allocated per call of the natively compiled LAMBDA-EXPRESSION over N calls, exact."
+  (let ((cmp:*autocompile-hook* nil))
+    (/ (funcall *native-driver* (native-compile lambda-expression) n) n)))
+
+;;; ---- controls: the instrument moves, and the free shapes are free -----------------------
+
+(test alloc-native.driver-alone
+      (native-bytes-per-call '(lambda (i) (%alloc-touch i)))
+      (0)
+      :description "the native driver and a call into a notinline sink allocate nothing")
+
+(test alloc-native.control-cons
+      (native-bytes-per-call '(lambda (i) (%alloc-touch (cons i i))))
+      (24)
+      :description "one cons per call: the counter is live and byte-exact")
+
+(test alloc-native.catch-throw
+      (native-bytes-per-call '(lambda (i) (catch 'alloc-tag (%alloc-touch i) (throw 'alloc-tag nil))))
+      (0)
+      :description "the catch dynenv is stack-initialised; a throw allocates nothing")
+
+(test alloc-native.block-return
+      (native-bytes-per-call '(lambda (i) (block b (%alloc-touch i) (return-from b nil))))
+      (0)
+      :description "a block nothing closes over is a simple unwind; a local return-from is a jump")
+
+(test alloc-native.special-bind
+      (native-bytes-per-call '(lambda (i) (let ((*alloc-sink* i)) (%alloc-touch *alloc-sink*))))
+      (0)
+      :description "a special binding is a stack dynenv")
+
+(test alloc-native.values-trampoline
+      (native-bytes-per-call '(lambda (i) (multiple-value-call #'values (%alloc-three i))))
+      (0)
+      :description "passing three values through VALUES allocates nothing")
+
+(test alloc-native.mvb.capturing
+      (native-bytes-per-call '(lambda (i) (let ((y i)) (multiple-value-bind (a b) (%alloc-two i) (%alloc-touch (+ a b y))))))
+      (0)
+      :description "a MULTIPLE-VALUE-BIND whose body captures an outer variable: Cleavir inlines the bind lambda")
+
+;;; ---- the laws: what an escaping closure costs natively -------------------------------------
+
+(test alloc-native.closure-0
+      (native-bytes-per-call '(lambda (i) (%alloc-call (lambda () (%alloc-touch 0)))))
+      (0)
+      :description "a capture-free lambda is a literal function object, whatever it is passed to")
+
+(test alloc-native.closure-1
+      (native-bytes-per-call '(lambda (i) (let ((y i)) (%alloc-call (lambda () (%alloc-touch y))))))
+      (40)
+      :description "an escaping closure over one variable: 32 + 8 (the law)")
+
+(test alloc-native.closure-3
+      (native-bytes-per-call '(lambda (i) (let ((y i) (z (1+ i)) (w (+ i 2))) (%alloc-call (lambda () (%alloc-touch (+ y z w)))))))
+      (56)
+      :description "an escaping closure over three variables: 32 + 24 (the law)")
+
+(test alloc-native.assigned-capture
+      (native-bytes-per-call '(lambda (i) (let ((y i)) (%alloc-call (lambda () (%alloc-touch y))) (setq y 0) (%alloc-touch y))))
+      (64)
+      :description "an escaping closure over a variable with two writers: 40 + a 24-byte cell (the law)")
+
+(test alloc-native.escaping-block-closure
+      (native-bytes-per-call '(lambda (i) (block b (%alloc-call (lambda () (return-from b nil))) (%alloc-touch i))))
+      (72)
+      :description "a lambda that RETURN-FROMs an outer block: a 40-byte closure plus a 32-byte heap BlockDynEnv (the law)")
+
+(test alloc-native.mvb.surplus-value-in-this-pipeline
+      (native-bytes-per-call '(lambda (i) (multiple-value-bind (a b) (%alloc-three i) (%alloc-touch (+ a b)))))
+      (24)
+      :description "a surplus value costs one cons in the (COMPILE NIL ...) pipeline, whose bind lambda is called through its general entry; COMPILE-FILE local-calls it and reads 0 -- a pipeline fact, not a leg fact")
+
+;;; ---- the targets: the constructs the closure-law arc takes to 0 ---------------------------
+
+(test alloc-native.unwind-protect.nocapture
+      (native-bytes-per-call '(lambda (i) (unwind-protect (%alloc-touch i) (%alloc-touch 0))))
+      (0)
+      :description "a cleanup that captures nothing is a literal; the dynenv is on the stack")
+
+(test alloc-native.unwind-protect.capture-1
+      (native-bytes-per-call '(lambda (i) (let ((y i)) (unwind-protect (%alloc-touch i) (%alloc-touch y)))))
+      (0)
+      :description "reads 40 today: the cleanup thunk is a heap closure over one variable (slice 4)")
+
+(test alloc-native.unwind-protect.capture-3
+      (native-bytes-per-call '(lambda (i) (let ((y i) (z (1+ i)) (w (+ i 2))) (unwind-protect (%alloc-touch i) (%alloc-touch (+ y z w))))))
+      (0)
+      :description "reads 56 today: 32 + 8 per captured variable (slice 4)")
+
+(test alloc-native.unwind-protect.assigned-capture
+      (native-bytes-per-call '(lambda (i) (let ((y i)) (unwind-protect (setq y (1+ y)) (%alloc-touch y)))))
+      (0)
+      :description "reads 64 today: the closure plus a cell for the captured, assigned variable (slice 4)")
+
+(test alloc-native.with-lock-held
+      (native-bytes-per-call '(lambda (i) (mp:with-lock (*alloc-lock*) (%alloc-touch i))))
+      (0)
+      :description "reads 40 today: WITH-LOCK's cleanup captures the lock it must release (slice 4)")
+
+(test alloc-native.dx-flet
+      (native-bytes-per-call '(lambda (i) (flet ((f () (%alloc-touch i))) (declare (dynamic-extent #'f)) (%alloc-call #'f))))
+      (0)
+      :description "reads 40 today: the DYNAMIC-EXTENT declaration reaches no BIR slot and the stack arm of ENCLOSE is disabled (slice 7)")
+
+(test alloc-native.handler-bind
+      (native-bytes-per-call '(lambda (i) (handler-bind ((%alloc-full #'%alloc-global-handler)) (%alloc-touch i))))
+      (0)
+      :description "reads 72 today: three conses push the cluster onto *HANDLER-CLUSTERS* (slice 6)")
+
+(test alloc-native.handler-bind.two
+      (native-bytes-per-call '(lambda (i) (handler-bind ((%alloc-full #'%alloc-global-handler) (error #'%alloc-global-handler)) (%alloc-touch i))))
+      (0)
+      :description "reads 120 today: 72 for the first binding and 48 for each further one (slice 6)")
+
+(test alloc-native.catch-handler-bind
+      (native-bytes-per-call '(lambda (i) (catch 'alloc-tag (handler-bind ((%alloc-full #'%alloc-global-handler)) (%alloc-touch i)))))
+      (0)
+      :description "reads 72 today: the cheapest guarded region natively is the cluster alone (slice 6)")
+
+(test alloc-native.handler-case.novar
+      (native-bytes-per-call '(lambda (i) (handler-case (%alloc-touch i) (%alloc-full () (%alloc-touch 0)))))
+      (0)
+      :description "reads 144 today: the cluster 72, an escaping closure that GOes 40, a heap TagbodyDynEnv 32 (slice 5 to 72, slice 6 to 0)")
+
+(test alloc-native.handler-case.var
+      (native-bytes-per-call '(lambda (i) (handler-case (%alloc-touch i) (%alloc-full (c) (%alloc-touch c)))))
+      (0)
+      :description "reads 176 today: 144 plus a cell and a slot for the SETQ'd clause variable (slice 5 to 72, slice 6 to 0)")
+
+(test alloc-native.ignore-errors
+      (native-bytes-per-call '(lambda (i) (ignore-errors (%alloc-touch i))))
+      (0)
+      :description "reads 176 today: IGNORE-ERRORS is HANDLER-CASE with a clause variable (slice 5 to 72, slice 6 to 0)")
+
+(test alloc-native.cnm-1arg
+      (native-bytes-per-call '(lambda (i) (%alloc-touch (%alloc-gf1 *alloc-sub*))))
+      (0)
+      :description "reads 24 today: a method that mentions CALL-NEXT-METHOD pays the contf &REST gather, 24 per required argument, on every call (slice 5)")
+
+(test alloc-native.cnm-2args
+      (native-bytes-per-call '(lambda (i) (%alloc-touch (%alloc-gf2 *alloc-sub* i))))
+      (0)
+      :description "reads 48 today: 24 per required argument (slice 5)")

--- a/src/lisp/regression-tests/allocation.lisp
+++ b/src/lisp/regression-tests/allocation.lisp
@@ -12,14 +12,8 @@
 ;;;; today in the test's :description.  The figure is exact by construction: the driver divides
 ;;;; the total by the call count, so a partial result shows up as a ratio, never as a rounded 0.
 
-(defvar *alloc-sink* nil)
-(defvar *alloc-lock* (mp:make-lock :name "allocation-test"))
-
-(declaim (notinline %alloc-touch %alloc-two %alloc-three %alloc-global-handler))
-(defun %alloc-touch (x) (setq *alloc-sink* x) nil)
-(defun %alloc-two (i) (values i (1+ i)))
-(defun %alloc-three (i) (values i (1+ i) (+ i 2)))
-(defun %alloc-global-handler (c) (declare (ignore c)) nil)
+;;; The sinks and the CLOS fixture are shared with allocation-native.lisp, which measures the same shapes.
+(load "sys:src;lisp;regression-tests;allocation-helpers.lisp")
 
 ;;; The driver is bytecode too, so its own loop cannot be charged to the construct.
 (defparameter *alloc-driver*

--- a/src/lisp/regression-tests/allocation.lisp
+++ b/src/lisp/regression-tests/allocation.lisp
@@ -1,0 +1,146 @@
+(in-package #:clasp-tests)
+
+;;;; Byte-exact allocation tests for the control-flow constructs of the BYTECODE tier.
+;;;;
+;;;; Every measured function is built with CMP:BYTECOMPILE, so the tier under test is bytecode
+;;;; whatever CMP:*COMPILE-FILE-NATIVE* says for this file.  GCTOOLS:BYTES-ALLOCATED is per-thread
+;;;; and counts every Clasp allocation with its header, so one cons reads exactly 24 and the
+;;;; control below proves the instrument is live in this process.
+;;;;
+;;;; Each test asserts 0 bytes per entry.  A construct that still allocates is listed in
+;;;; set-unexpected-failures.lisp under the change that will remove it, with the figure it reads
+;;;; today in the test's :description.  The figure is exact by construction: the driver divides
+;;;; the total by the call count, so a partial result shows up as a ratio, never as a rounded 0.
+
+(defvar *alloc-sink* nil)
+(defvar *alloc-lock* (mp:make-lock :name "allocation-test"))
+
+(declaim (notinline %alloc-touch %alloc-two %alloc-three %alloc-global-handler))
+(defun %alloc-touch (x) (setq *alloc-sink* x) nil)
+(defun %alloc-two (i) (values i (1+ i)))
+(defun %alloc-three (i) (values i (1+ i) (+ i 2)))
+(defun %alloc-global-handler (c) (declare (ignore c)) nil)
+
+;;; The driver is bytecode too, so its own loop cannot be charged to the construct.
+(defparameter *alloc-driver*
+  (cmp:bytecompile
+   '(lambda (f n)
+     (funcall f 0)                       ; warm up once, outside the window
+     (let ((before (gctools:bytes-allocated)))
+       (dotimes (i n) (funcall f i))
+       (- (gctools:bytes-allocated) before)))))
+
+(defun bytes-per-call (lambda-expression &optional (n 10000))
+  "Bytes allocated per call of the bytecompiled LAMBDA-EXPRESSION over N calls, exact.
+The autocompile hook is bound off for the window: the shared helpers above cross
+BYTECODE_COMPILE_THRESHOLD part-way through this file, and a live hook would run on this
+thread inside the window and cons for every later call."
+  (let ((cmp:*autocompile-hook* nil))
+    (/ (funcall *alloc-driver* (cmp:bytecompile lambda-expression) n) n)))
+
+;;; ---- controls: the instrument moves, and the free shapes are free -----------------------
+
+(test alloc.control-cons
+      (bytes-per-call '(lambda (i) (%alloc-touch (cons i i))))
+      (24)
+      :description "one cons per call: the counter is live and byte-exact")
+
+(test alloc.catch-throw
+      (bytes-per-call '(lambda (i) (catch 'alloc-tag (%alloc-touch i) (throw 'alloc-tag nil))))
+      (0)
+      :description "a catch dynenv is stack-allocated and a throw allocates nothing")
+
+(test alloc.block-return
+      (bytes-per-call '(lambda (i) (block b (%alloc-touch i) (return-from b nil))))
+      (0)
+      :description "a block that is not closed over is a saved stack pointer; a local return-from is a jump")
+
+(test alloc.special-bind
+      (bytes-per-call '(lambda (i) (let ((*alloc-sink* i)) (%alloc-touch *alloc-sink*))))
+      (0)
+      :description "a special binding is a stack-allocated dynenv")
+
+(test alloc.mvb.capture-free
+      (bytes-per-call '(lambda (i) (multiple-value-bind (a b) (%alloc-two i) (%alloc-touch (+ a b)))))
+      (0)
+      :description "the bind's lambda references only its own parameters, so it is a constant; its &rest list is NIL because %ALLOC-TWO returns exactly two values")
+
+(test alloc.mvb.surplus-value
+      (bytes-per-call '(lambda (i) (multiple-value-bind (a b) (%alloc-three i) (%alloc-touch (+ a b)))))
+      (0)
+      :description "24 today: the bind's lambda has an ignored &rest, and listify_rest_args conses the third value anyway")
+
+;;; ---- unwind-protect: the protect opcode builds the cleanup closure ----------------------
+
+(test alloc.unwind-protect.nocapture
+      (bytes-per-call '(lambda (i) (unwind-protect (%alloc-touch i) (%alloc-touch 0))))
+      (0)
+      :description "32 on the unmodified VM: a cleanup closure with no captured variable")
+
+(test alloc.unwind-protect.capture-1
+      (bytes-per-call '(lambda (i) (let ((y i)) (unwind-protect (%alloc-touch i) (%alloc-touch y)))))
+      (0)
+      :description "40 = 32 + 8 x 1 captured variable")
+
+(test alloc.unwind-protect.capture-3
+      (bytes-per-call '(lambda (i)
+                        (let ((a i) (b i) (c i))
+                          (unwind-protect (%alloc-touch i)
+                            (%alloc-touch a) (%alloc-touch b) (%alloc-touch c)))))
+      (0)
+      :description "56 = 32 + 8 x 3 captured variables")
+
+(test alloc.unwind-protect.assigned-capture
+      (bytes-per-call '(lambda (i) (let ((y i)) (unwind-protect (setq y (1+ y)) (%alloc-touch y)))))
+      (0)
+      :description "64 = 40 + a 24 B cell: Y is captured by the cleanup and assigned in the body")
+
+(test alloc.with-lock-held
+      (bytes-per-call '(lambda (i) (mp:with-lock (*alloc-lock*) (%alloc-touch i))))
+      (0)
+      :description "40: one unwind-protect whose cleanup captures the lock")
+
+;;; ---- multiple values --------------------------------------------------------------------
+
+(test alloc.values-trampoline
+      (bytes-per-call '(lambda (i) (multiple-value-call #'values (%alloc-three i))))
+      (0)
+      :description "mv_call: a full call to VALUES over three values in the MV register, all three returned")
+
+(test alloc.mvb.capturing
+      (bytes-per-call '(lambda (i)
+                        (let ((z i))
+                          (multiple-value-bind (a b) (%alloc-two i) (%alloc-touch (+ a b z))))))
+      (0)
+      :description "40 = 32 + 8: the bind expands to a lambda that captures Z")
+
+;;; ---- the condition system ---------------------------------------------------------------
+
+(test alloc.handler-bind
+      (bytes-per-call '(lambda (i)
+                        (handler-bind ((error (lambda (c) (declare (ignore c)) (%alloc-touch 0))))
+                          (%alloc-touch i))))
+      (0)
+      :description "72: three conses for the cluster; the handler lambda captures nothing")
+
+(test alloc.handler-bind.global-handler
+      (bytes-per-call '(lambda (i) (handler-bind ((error #'%alloc-global-handler)) (%alloc-touch i))))
+      (0)
+      :description "72 today: the same three conses as alloc.handler-bind; only the type-test lambda is a literal")
+
+(test alloc.handler-case.novar
+      (bytes-per-call '(lambda (i) (handler-case (%alloc-touch i) (error () (%alloc-touch 0)))))
+      (0)
+      :description "144 = 72 cluster + 32 entry dynenv + 40 handler closure")
+
+(test alloc.handler-case.var
+      (bytes-per-call '(lambda (i) (handler-case (%alloc-touch i) (error (c) (%alloc-touch c)))))
+      (0)
+      :description "176 = 144 + a 24 B cell and an 8 B slot for the clause variable")
+
+;;; ---- a closed-over tagbody: the entry opcode's heap dynenv ------------------------------
+
+(test alloc.closed-over-tagbody
+      (bytes-per-call '(lambda (i) (tagbody (funcall (lambda () (go end))) (%alloc-touch i) end)))
+      (0)
+      :description "a lambda closing over a tagbody: the heap dynenv plus a one-slot closure")

--- a/src/lisp/regression-tests/loop.lisp
+++ b/src/lisp/regression-tests/loop.lisp
@@ -116,3 +116,36 @@
  (loop for x in (make-hash-table)
         do (format t "x = ~a~%" x))
  :type type-error)
+
+;;; FOR-AS-EQUALS-THEN's temp was bound to NIL under the user's strict type; only native code checks it
+(defun loop-typed-equals-native (form arg)
+  (let ((cmp:*compile-native* t))
+    (funcall (compile nil form) arg)))
+
+(test loop-typed-equals-cons-native
+      (loop-typed-equals-native
+       '(lambda (l) (loop for e in l for p of-type cons = (list e) collect p))
+       '(1 2))
+      (((1) (2))))
+
+(test loop-typed-equals-then-native
+      (loop-typed-equals-native
+       '(lambda (l) (loop for e in l for p of-type cons = (list e) then (list e e) collect p))
+       '(1 2))
+      (((1) (2 2))))
+
+(test loop-typed-equals-array-native
+      (loop-typed-equals-native
+       '(lambda (l)
+         (loop for e in l
+               for p of-type (simple-array fixnum (*))
+                 = (make-array 1 :element-type 'fixnum :initial-element e)
+               collect (aref p 0)))
+       '(1 2))
+      ((1 2)))
+
+(test loop-typed-equals-deducible-stays-strict
+      (loop-typed-equals-native
+       '(lambda (l) (loop for e in l for p of-type fixnum = (* 2 e) collect p))
+       '(1 2))
+      ((2 4)))

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -24,6 +24,7 @@
     "tests01"
     "gc"
     "allocation"
+    "allocation-native"
     "strings01"
     "cons01"
     "sequences01"

--- a/src/lisp/regression-tests/run-all.lisp
+++ b/src/lisp/regression-tests/run-all.lisp
@@ -23,6 +23,7 @@
     "array0"
     "tests01"
     "gc"
+    "allocation"
     "strings01"
     "cons01"
     "sequences01"

--- a/src/lisp/regression-tests/set-unexpected-failures.lisp
+++ b/src/lisp/regression-tests/set-unexpected-failures.lisp
@@ -11,4 +11,19 @@
         ;; these don't work well on boehm. In particular
         ;; key-or-value tables are effectively strong.
         #+use-boehm weak-key-and-value-weakness
+        ;; allocation.lisp: the bytecode tier's control-flow constructs still heap-allocate.
+        ;; A name is removed from this list by the change that removes its bytes; until then a
+        ;; test that starts reading 0 shows up as an Unexpected Success (the run still exits 0).
+        ;; unwind-protect: the protect opcode builds the cleanup closure
+        alloc.unwind-protect.nocapture
+        alloc.unwind-protect.capture-1 alloc.unwind-protect.capture-3
+        alloc.unwind-protect.assigned-capture alloc.with-lock-held
+        ;; multiple-value-bind: a macro over multiple-value-call of a lambda
+        alloc.mvb.capturing alloc.mvb.surplus-value
+        ;; handler-bind / handler-case: the cluster conses, the entry dynenv, the handler closure
+        alloc.handler-bind alloc.handler-bind.global-handler
+        alloc.handler-case.novar alloc.handler-case.var
+        ;; a closed-over tagbody: the entry opcode's heap dynenv
+        alloc.closed-over-tagbody
+        ;; on boehm key-or-value tables are effectively strong.
         #+use-boehm weak-key-or-value-weakness))

--- a/src/lisp/regression-tests/set-unexpected-failures.lisp
+++ b/src/lisp/regression-tests/set-unexpected-failures.lisp
@@ -14,8 +14,7 @@
         ;; allocation.lisp: the bytecode tier's control-flow constructs still heap-allocate.
         ;; A name is removed from this list by the change that removes its bytes; until then a
         ;; test that starts reading 0 shows up as an Unexpected Success (the run still exits 0).
-        ;; unwind-protect: the protect opcode builds the cleanup closure
-        alloc.unwind-protect.nocapture
+        ;; unwind-protect: the protect opcode builds the cleanup closure (a capture-free one no longer)
         alloc.unwind-protect.capture-1 alloc.unwind-protect.capture-3
         alloc.unwind-protect.assigned-capture alloc.with-lock-held
         ;; multiple-value-bind: a macro over multiple-value-call of a lambda

--- a/src/lisp/regression-tests/set-unexpected-failures.lisp
+++ b/src/lisp/regression-tests/set-unexpected-failures.lisp
@@ -25,5 +25,17 @@
         alloc.handler-case.novar alloc.handler-case.var
         ;; a closed-over tagbody: the entry opcode's heap dynenv
         alloc.closed-over-tagbody
+        ;; allocation-native.lisp: the NATIVE tier's targets, each under the slice of the closure-law
+        ;; plan (neoseidr docs/plans/2026-09-06-clasp-closure-law/04-slices.md) that removes its bytes.
+        ;; slice 4 -- an unwind-protect cleanup becomes a stack closure
+        alloc-native.unwind-protect.capture-1 alloc-native.unwind-protect.capture-3
+        alloc-native.unwind-protect.assigned-capture alloc-native.with-lock-held
+        ;; slice 5 -- the contf &rest gather becomes a vaslist
+        alloc-native.cnm-1arg alloc-native.cnm-2args
+        ;; slice 5 takes handler-case to the cluster's 72; slice 6 takes the cluster to 0
+        alloc-native.handler-bind alloc-native.handler-bind.two alloc-native.catch-handler-bind
+        alloc-native.handler-case.novar alloc-native.handler-case.var alloc-native.ignore-errors
+        ;; slice 7 -- a declared DYNAMIC-EXTENT local function becomes a stack closure
+        alloc-native.dx-flet
         ;; on boehm key-or-value tables are effectively strong.
         #+use-boehm weak-key-or-value-weakness))


### PR DESCRIPTION
The `protect` opcode built a closure for the cleanup unconditionally: `32 + 8×captures`, on every entry to every `unwind-protect`.

- a template that closes over nothing **is** the cleanup function; only a capturing one needs the wrapper
- the bytecode contract (Maclina `MACHINE.md`, "protect") permits either, and the closure carried no environment
- both `protect` arms, short and long operand, now go through one `vm_protect`

`alloc.unwind-protect.nocapture`: **32 → 0**, leaves the expected failures. Other rows unchanged. Full `ninja test` exit 0.

Downstream: every `with-float-traps-masked` region in a CLIM toolkit's frame lost 40 B, and one zero-cons bar went green.

Stacked on #1854 (the suites this flips a row in).


---

**Stack.** GitHub cannot base a cross-fork PR on a branch that lives only in the fork, so this diff also carries its predecessors.

- review **only** `4c4ac03f0`
- inherited, already under review: #1854 (f4292c1b3, cac57cdfb, 5a487f20f)
- merge order: 1854 → 1855 → 1856 → 1857; #1853 is independent
